### PR TITLE
feature/fix popovers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -96,7 +96,7 @@
     },
     "packages/payload-plugin-comments": {
       "name": "@focus-reactive/payload-plugin-comments",
-      "version": "1.1.0",
+      "version": "1.4.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "class-variance-authority": "^0.7.1",
@@ -140,7 +140,10 @@
     },
     "packages/payload-plugin-presets": {
       "name": "@focus-reactive/payload-plugin-presets",
-      "version": "0.2.0",
+      "version": "0.3.1",
+      "dependencies": {
+        "@radix-ui/react-popover": "^1.1.15",
+      },
       "devDependencies": {
         "@payloadcms/ui": "3.79.0",
         "@swc/cli": "^0.4.0",
@@ -657,6 +660,50 @@
 
     "@preact/signals-core": ["@preact/signals-core@1.14.0", "", {}, "sha512-AowtCcCU/33lFlh1zRFf/u+12rfrhtNakj7UpaGEsmMwUKpKWMVvcktOGcwBBNiB4lWrZWc01LhiyyzVklJyaQ=="],
 
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
+
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
+
+    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
+
+    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
+
+    "@radix-ui/react-popover": ["@radix-ui/react-popover@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA=="],
+
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.8", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-rect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw=="],
+
+    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
+
+    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
+
     "@react-email/render": ["@react-email/render@1.1.2", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3", "react-promise-suspense": "^0.3.4" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw=="],
 
     "@repo/eslint-config": ["@repo/eslint-config@workspace:packages/eslint-config"],
@@ -955,6 +1002,8 @@
 
     "argv-formatter": ["argv-formatter@1.0.0", "", {}, "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw=="],
 
+    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
     "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "array-buffer-byte-length": ["array-buffer-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "is-array-buffer": "^3.0.5" } }, "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw=="],
@@ -1187,6 +1236,8 @@
 
     "detect-newline": ["detect-newline@3.1.0", "", {}, "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="],
 
+    "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
     "dev": ["dev@workspace:apps/dev"],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
@@ -1396,6 +1447,8 @@
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
@@ -2033,7 +2086,13 @@
 
     "react-promise-suspense": ["react-promise-suspense@0.3.4", "", { "dependencies": { "fast-deep-equal": "^2.0.1" } }, "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ=="],
 
+    "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
+
+    "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
     "react-select": ["react-select@5.9.0", "", { "dependencies": { "@babel/runtime": "^7.12.0", "@emotion/cache": "^11.4.0", "@emotion/react": "^11.8.1", "@floating-ui/dom": "^1.0.1", "@types/react-transition-group": "^4.4.0", "memoize-one": "^6.0.0", "prop-types": "^15.6.0", "react-transition-group": "^4.3.0", "use-isomorphic-layout-effect": "^1.2.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-nwRKGanVHGjdccsnzhFte/PULziueZxGD8LL2WojON78Mvnq7LdAMEtu2frrwld1fr3geixg3iiMBIc/LLAZpw=="],
+
+    "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
 
@@ -2371,9 +2430,13 @@
 
     "url-join": ["url-join@5.0.0", "", {}, "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="],
 
+    "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
+
     "use-context-selector": ["use-context-selector@2.0.0", "", { "peerDependencies": { "react": ">=18.0.0", "scheduler": ">=0.19.0" } }, "sha512-owfuSmUNd3eNp3J9CdDl0kMgfidV+MkDvHPpvthN5ThqM+ibMccNE0k+Iq7TWC6JPFvGZqanqiGCuQx6DyV24g=="],
 
     "use-isomorphic-layout-effect": ["use-isomorphic-layout-effect@1.2.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA=="],
+
+    "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
 
     "utf8-byte-length": ["utf8-byte-length@1.0.5", "", {}, "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="],
 

--- a/packages/payload-plugin-presets/package.json
+++ b/packages/payload-plugin-presets/package.json
@@ -67,5 +67,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.5.0"
+  },
+  "dependencies": {
+    "@radix-ui/react-popover": "^1.1.15"
   }
 }

--- a/packages/payload-plugin-presets/src/components/PresetAdminComponent.scss
+++ b/packages/payload-plugin-presets/src/components/PresetAdminComponent.scss
@@ -30,8 +30,8 @@
 
   &__popup-image {
     display: block;
-    max-width: 300px;
-    max-height: 300px;
+    max-width: 200px;
+    max-height: 200px;
     width: auto;
     height: auto;
     border-radius: 4px;

--- a/packages/payload-plugin-presets/src/components/PresetAdminComponentPreview.tsx
+++ b/packages/payload-plugin-presets/src/components/PresetAdminComponentPreview.tsx
@@ -29,6 +29,10 @@ export const PresetAdminComponentPreview: React.FC = () => {
       return;
     }
 
+    if (media?.id === mediaId) {
+      return;
+    }
+
     setIsLoading(true);
     fetch(`/api/${mediaCollection}/${mediaId}`)
       .then((res) => res.json())

--- a/packages/payload-plugin-presets/src/components/PresetAdminComponentPreview.tsx
+++ b/packages/payload-plugin-presets/src/components/PresetAdminComponentPreview.tsx
@@ -1,53 +1,53 @@
-'use client'
+"use client";
 
-import { useState, useEffect } from 'react'
-import Image from 'next/image'
-import { useField, useTranslation } from '@payloadcms/ui'
-import { EmptyPlaceholder, type MediaData } from './shared/index.js'
-import { usePresetsConfig } from './usePresetsConfig.js'
+import { useState, useEffect } from "react";
+import Image from "next/image";
+import { useField, useTranslation } from "@payloadcms/ui";
+import { EmptyPlaceholder, type MediaData } from "./shared/index.js";
+import { usePresetsConfig } from "./usePresetsConfig.js";
 
-import './PresetAdminComponent.scss'
+import "./PresetAdminComponent.scss";
 
 export const PresetAdminComponentPreview: React.FC = () => {
-  const { mediaCollection } = usePresetsConfig()
-  const { t } = useTranslation()
-  const { value } = useField<number | MediaData | null>({ path: 'preview' })
-  const [media, setMedia] = useState<MediaData | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const { mediaCollection } = usePresetsConfig();
+  const { t } = useTranslation();
+  const { value } = useField<number | MediaData | null>({ path: "preview" });
+  const [media, setMedia] = useState<MediaData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
-  const mediaId = typeof value === 'number' ? value : value?.id
+  const mediaId = typeof value === "number" ? value : value?.id;
 
   useEffect(() => {
     if (!mediaId) {
-      setIsLoading(false)
-      return
+      setIsLoading(false);
+      return;
     }
 
-    if (typeof value === 'object' && value !== null) {
-      setMedia(value as MediaData)
-      setIsLoading(false)
-      return
+    if (typeof value === "object" && value !== null) {
+      setMedia(value as MediaData);
+      setIsLoading(false);
+      return;
     }
 
-    setIsLoading(true)
+    setIsLoading(true);
     fetch(`/api/${mediaCollection}/${mediaId}`)
       .then((res) => res.json())
       .then((data) => {
-        setMedia(data)
-        setIsLoading(false)
+        setMedia(data);
+        setIsLoading(false);
       })
       .catch(() => {
-        setMedia(null)
-        setIsLoading(false)
-      })
-  }, [mediaId, value, mediaCollection])
+        setMedia(null);
+        setIsLoading(false);
+      });
+  }, [mediaId, value, mediaCollection]);
 
   if (isLoading) {
     return (
       <div className="preset-admin-preview">
         <div className="preset-admin-preview__skeleton" />
       </div>
-    )
+    );
   }
 
   return (
@@ -55,15 +55,17 @@ export const PresetAdminComponentPreview: React.FC = () => {
       {!media?.url ? (
         <EmptyPlaceholder
           style={{
-            objectFit: 'contain',
-            maxHeight: 'var(--preset-admin-preview-max-height)',
-            maxWidth: 'var(--preset-admin-preview-max-width)',
-            width: '100%',
+            objectFit: "contain",
+            maxHeight: "var(--preset-admin-preview-max-height)",
+            maxWidth: "var(--preset-admin-preview-max-width)",
+            width: "100%",
           }}
         />
       ) : (
         <Image
-          alt={media.alt || t('presetsPlugin:blocksDrawer:presetPreview' as never)}
+          alt={
+            media.alt || t("presetsPlugin:blocksDrawer:presetPreview" as never)
+          }
           src={media?.url}
           className="preset-admin-preview__image"
           width={400}
@@ -72,5 +74,5 @@ export const PresetAdminComponentPreview: React.FC = () => {
         />
       )}
     </div>
-  )
-}
+  );
+};

--- a/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.scss
+++ b/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.scss
@@ -120,3 +120,16 @@
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
   z-index: var(--z-popup, 100);
 }
+
+@media (max-width: 500px) {
+  .blocks-drawer__popover-content[data-side="bottom"],
+  .blocks-drawer__popover-content[data-side="top"] {
+    width: calc(100vw - 2 * var(--gutter-h));
+    max-width: none;
+    left: var(--gutter-h) !important;
+  }
+
+  .blocks-drawer__presets-popup {
+    max-width: 100% !important;
+  }
+}

--- a/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.scss
+++ b/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.scss
@@ -107,3 +107,48 @@
 .blocks-drawer__loading-grid {
   width: 100%;
 }
+
+.blocks-drawer__popover-content {
+  padding: calc(var(--base) * 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--base) * 0.25);
+  max-width: 400px;
+  background: var(--theme-bg);
+  border: 1px solid var(--theme-elevation-150);
+  border-radius: var(--style-radius-m);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  z-index: var(--z-modal, 1000);
+
+  .thumbnail-card {
+    padding: calc(var(--base) * 0.5);
+    flex-direction: row;
+    align-items: center;
+    gap: calc(var(--base) * 0.5);
+    position: relative;
+
+    &:hover {
+      .remove-preset {
+        opacity: 1;
+      }
+    }
+  }
+
+  .thumbnail-card__thumbnail {
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+
+    img {
+      width: 40px;
+      height: 40px;
+      object-fit: cover;
+      border-radius: var(--style-radius-s);
+    }
+  }
+
+  .thumbnail-card__label {
+    text-align: left;
+    padding: 0;
+  }
+}

--- a/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.scss
+++ b/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.scss
@@ -115,40 +115,8 @@
   gap: calc(var(--base) * 0.25);
   max-width: 400px;
   background: var(--theme-bg);
-  border: 1px solid var(--theme-elevation-150);
+  border: 1px solid var(--theme-elevation-200);
   border-radius: var(--style-radius-m);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-  z-index: var(--z-modal, 1000);
-
-  .thumbnail-card {
-    padding: calc(var(--base) * 0.5);
-    flex-direction: row;
-    align-items: center;
-    gap: calc(var(--base) * 0.5);
-    position: relative;
-
-    &:hover {
-      .remove-preset {
-        opacity: 1;
-      }
-    }
-  }
-
-  .thumbnail-card__thumbnail {
-    width: 40px;
-    height: 40px;
-    flex-shrink: 0;
-
-    img {
-      width: 40px;
-      height: 40px;
-      object-fit: cover;
-      border-radius: var(--style-radius-s);
-    }
-  }
-
-  .thumbnail-card__label {
-    text-align: left;
-    padding: 0;
-  }
+  z-index: var(--z-popup, 100);
 }

--- a/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.tsx
+++ b/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.tsx
@@ -7,6 +7,8 @@ import {
   useTranslation,
   ShimmerEffect,
   ChevronIcon,
+  ConfirmationModal,
+  useModal,
 } from "@payloadcms/ui";
 import type { ClientBlock } from "payload";
 import { usePresetsConfig } from "../usePresetsConfig.js";
@@ -28,6 +30,7 @@ export const BlockSelectorWithPresets: React.FC<
 
   const [searchTerm, setSearchTerm] = useState("");
   const [activeBlockSlug, setActiveBlockSlug] = useState<string | null>(null);
+  const isMobile = useIsMobile();
   const [isLoadingPresets, setIsLoadingPresets] = useState(false);
   const [presetsCache, setPresetsCache] = useState<Preset[]>([]);
 
@@ -179,6 +182,7 @@ export const BlockSelectorWithPresets: React.FC<
                       label={label}
                       hasPresets={hasPresets}
                       isActive={isActive}
+                      isMobile={isMobile}
                       presets={blockPresets}
                       onBlockClick={() =>
                         hasPresets
@@ -201,11 +205,24 @@ export const BlockSelectorWithPresets: React.FC<
 };
 
 // Reusable BlockCard component
+function useIsMobile(breakpoint = 500): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpoint}px)`);
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [breakpoint]);
+  return isMobile;
+}
+
 type BlockCardProps = {
   block: ClientBlock;
   label: string;
   hasPresets: boolean;
   isActive: boolean;
+  isMobile: boolean;
   presets: Preset[];
   onBlockClick: () => void;
   onPresetSelect: (blockType: string, preset: Preset | null) => void;
@@ -218,12 +235,25 @@ const BlockCard: React.FC<BlockCardProps> = ({
   label,
   hasPresets,
   isActive,
+  isMobile,
   presets,
   onBlockClick,
   onPresetSelect,
   onClose,
   onDelete,
 }) => {
+  const [deletingPreset, setDeletingPreset] = useState<Preset | null>(null);
+  const { openModal } = useModal();
+  const { slug: presetsCollectionSlug } = usePresetsConfig();
+  const { t } = useTranslation();
+
+  const modalSlug = `delete-preset-${block.slug}`;
+
+  const handleDeleteRequest = (preset: Preset) => {
+    setDeletingPreset(preset);
+    openModal(modalSlug);
+  };
+
   if (!hasPresets) {
     return (
       <button
@@ -239,51 +269,78 @@ const BlockCard: React.FC<BlockCardProps> = ({
   }
 
   return (
-    <Popover.Root
-      open={isActive}
-      onOpenChange={(open) => {
-        if (!open) onClose();
-      }}
-    >
-      <Popover.Trigger asChild>
-        <button
-          className={`thumbnail-card thumbnail-card--has-on-click thumbnail-card--align-label-center ${isActive ? "thumbnail-card--active" : ""}`}
-          title={label}
-          type="button"
-          onClick={onBlockClick}
-        >
-          <BlockThumbnail imageURL={block.imageURL} label={label} />
-          <div className="thumbnail-card__label">
-            {label}{" "}
-            {presets.length > 0 ? `(${presets.length})` : ""}
-            <ChevronIcon
-              className={`thumbnail-card__chevron ${isActive ? "thumbnail-card__chevron--open" : ""}`}
+    <>
+      <Popover.Root
+        open={isActive}
+        onOpenChange={(open) => {
+          if (!open) onClose();
+        }}
+      >
+        <Popover.Trigger asChild>
+          <button
+            className={`thumbnail-card thumbnail-card--has-on-click thumbnail-card--align-label-center ${isActive ? "thumbnail-card--active" : ""}`}
+            title={label}
+            type="button"
+            onClick={onBlockClick}
+          >
+            <BlockThumbnail imageURL={block.imageURL} label={label} />
+            <div className="thumbnail-card__label">
+              {label}{" "}
+              {presets.length > 0 ? `(${presets.length})` : ""}
+              <ChevronIcon
+                className={`thumbnail-card__chevron ${isActive ? "thumbnail-card__chevron--open" : ""}`}
+              />
+            </div>
+          </button>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            className="blocks-drawer__popover-content"
+            side={isMobile ? "bottom" : "right"}
+            align="start"
+            sideOffset={8}
+            avoidCollisions
+            collisionPadding={8}
+            onOpenAutoFocus={(e) => e.preventDefault()}
+          >
+            <PresetsList
+              blockSlug={block.slug}
+              label={label}
+              presets={presets}
+              onDeleteRequest={handleDeleteRequest}
+              onSelect={(preset) => {
+                onPresetSelect(block.slug, preset);
+              }}
             />
-          </div>
-        </button>
-      </Popover.Trigger>
-      <Popover.Portal>
-        <Popover.Content
-          className="blocks-drawer__popover-content"
-          side="right"
-          sideOffset={8}
-          avoidCollisions
-          collisionPadding={8}
-          onOpenAutoFocus={(e) => e.preventDefault()}
-        >
-          <PresetsList
-            blockSlug={block.slug}
-            label={label}
-            presets={presets}
-            onDeleteButtonClick={onClose}
-            onDelete={onDelete}
-            onSelect={(preset) => {
-              onPresetSelect(block.slug, preset);
-            }}
-          />
-        </Popover.Content>
-      </Popover.Portal>
-    </Popover.Root>
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
+
+      {deletingPreset && (
+        <ConfirmationModal
+          className="confirmation-modal"
+          modalSlug={modalSlug}
+          heading={t("presetsPlugin:deletePreset:heading" as never)}
+          body={t("presetsPlugin:deletePreset:body" as never, {
+            name: deletingPreset.name,
+          })}
+          confirmingLabel={t("presetsPlugin:deletePreset:confirming" as never)}
+          confirmLabel={t("presetsPlugin:deletePreset:confirm" as never)}
+          cancelLabel={t("presetsPlugin:deletePreset:cancel" as never)}
+          onConfirm={async () => {
+            const res = await fetch(
+              `/api/${presetsCollectionSlug}/${deletingPreset.id}`,
+              { method: "DELETE" },
+            );
+            if (res.ok) {
+              onDelete(deletingPreset.id);
+              setDeletingPreset(null);
+              onClose();
+            }
+          }}
+        />
+      )}
+    </>
   );
 };
 
@@ -310,8 +367,7 @@ type PresetsListProps = {
   label: string;
   presets: Preset[];
   onSelect: (preset: Preset | null) => void;
-  onDeleteButtonClick: () => void;
-  onDelete: (presetId: string | number) => void;
+  onDeleteRequest: (preset: Preset) => void;
 };
 
 const PresetsList: React.FC<PresetsListProps> = ({
@@ -319,8 +375,7 @@ const PresetsList: React.FC<PresetsListProps> = ({
   label,
   presets,
   onSelect,
-  onDeleteButtonClick,
-  onDelete,
+  onDeleteRequest,
 }) => {
   const filteredPresets = presets.filter((preset) => preset.type === blockSlug);
   const { mediaCollection } = usePresetsConfig();
@@ -344,8 +399,7 @@ const PresetsList: React.FC<PresetsListProps> = ({
             preset={preset}
             mediaCollection={mediaCollection}
             onSelect={onSelect}
-            onDeleteButtonClick={onDeleteButtonClick}
-            onDelete={onDelete}
+            onDeleteRequest={onDeleteRequest}
           />
         ))}
 

--- a/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.tsx
+++ b/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.tsx
@@ -255,9 +255,7 @@ const BlockCard: React.FC<BlockCardProps> = ({
           <BlockThumbnail imageURL={block.imageURL} label={label} />
           <div className="thumbnail-card__label">
             {label}{" "}
-            {presets.length > 0
-              ? `(${presets.filter((preset) => preset.type === block.slug).length})`
-              : ""}
+            {presets.length > 0 ? `(${presets.length})` : ""}
             <ChevronIcon
               className={`thumbnail-card__chevron ${isActive ? "thumbnail-card__chevron--open" : ""}`}
             />

--- a/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.tsx
+++ b/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.tsx
@@ -281,7 +281,6 @@ const BlockCard: React.FC<BlockCardProps> = ({
             onDelete={onDelete}
             onSelect={(preset) => {
               onPresetSelect(block.slug, preset);
-              onClose();
             }}
           />
         </Popover.Content>

--- a/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.tsx
+++ b/packages/payload-plugin-presets/src/components/blocksDrawer/BlockSelectorWithPresets.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import Image from "next/image";
+import * as Popover from "@radix-ui/react-popover";
 import {
   useTranslation,
-  Popup,
   ShimmerEffect,
   ChevronIcon,
 } from "@payloadcms/ui";
@@ -224,27 +224,6 @@ const BlockCard: React.FC<BlockCardProps> = ({
   onClose,
   onDelete,
 }) => {
-  const ref = useRef<HTMLButtonElement | null>(null);
-  const popupContentRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!isActive) return;
-
-    const handleClickOutside = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      const isInsideButton = ref.current?.contains(target);
-      const isInsidePopup = popupContentRef.current?.contains(target);
-
-      if (!isInsideButton && !isInsidePopup) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isActive, onClose]);
-
   if (!hasPresets) {
     return (
       <button
@@ -260,31 +239,14 @@ const BlockCard: React.FC<BlockCardProps> = ({
   }
 
   return (
-    <Popup
-      buttonType="custom"
-      forceOpen={isActive}
-      horizontalAlign="right"
-      render={({ close }) => (
-        <div ref={popupContentRef}>
-          <PresetsList
-            blockSlug={block.slug}
-            label={label}
-            presets={presets}
-            onDeleteButtonClick={onClose}
-            onDelete={onDelete}
-            onSelect={(preset) => {
-              onPresetSelect(block.slug, preset);
-              close();
-            }}
-          />
-        </div>
-      )}
-      showOnHover={false}
-      size="large"
-      verticalAlign="top"
-      button={
+    <Popover.Root
+      open={isActive}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <Popover.Trigger asChild>
         <button
-          ref={ref}
           className={`thumbnail-card thumbnail-card--has-on-click thumbnail-card--align-label-center ${isActive ? "thumbnail-card--active" : ""}`}
           title={label}
           type="button"
@@ -301,8 +263,30 @@ const BlockCard: React.FC<BlockCardProps> = ({
             />
           </div>
         </button>
-      }
-    />
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          className="blocks-drawer__popover-content"
+          side="right"
+          sideOffset={8}
+          avoidCollisions
+          collisionPadding={8}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <PresetsList
+            blockSlug={block.slug}
+            label={label}
+            presets={presets}
+            onDeleteButtonClick={onClose}
+            onDelete={onDelete}
+            onSelect={(preset) => {
+              onPresetSelect(block.slug, preset);
+              onClose();
+            }}
+          />
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
   );
 };
 

--- a/packages/payload-plugin-presets/src/components/blocksDrawer/BlocksFieldWithPresets.tsx
+++ b/packages/payload-plugin-presets/src/components/blocksDrawer/BlocksFieldWithPresets.tsx
@@ -138,7 +138,7 @@ export const BlocksFieldWithPresets: React.FC<BlocksFieldWithPresetsProps> = (
             >
               <span className="btn__content">
                 <span className="btn__label">
-                  {t("presetsPlugin:blocksDrawer:addBlockWithPreset" as never)}
+                  {t("presetsPlugin:blocksDrawer:addBlockTitle" as never)}
                 </span>
                 <span className="btn__icon">
                   <svg

--- a/packages/payload-plugin-presets/src/components/blocksDrawer/PresetItem/index.tsx
+++ b/packages/payload-plugin-presets/src/components/blocksDrawer/PresetItem/index.tsx
@@ -1,27 +1,22 @@
 "use client";
 
 import { MediaData, Preset } from "../../shared";
-import { useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import { useTranslation, ConfirmationModal, useModal } from "@payloadcms/ui";
+import { useEffect, useState } from "react";
+import { useTranslation } from "@payloadcms/ui";
 import { usePresetsConfig } from "../../usePresetsConfig.js";
 import Image from "next/image";
 import { TrashIcon } from "@payloadcms/ui/icons/Trash";
+import * as Popover from "@radix-ui/react-popover";
 
 import "./styles.scss";
 import { PresetAdminComponentCell } from "../../PresetAdminComponentCell";
-
-const POPUP_WIDTH = 316;
-const POPUP_HEIGHT = 300;
-const HOVER_GAP = 8;
 
 interface Props {
   preset: Preset | null;
   mediaCollection: string;
   label?: string;
   onSelect: (preset: Preset | null) => void;
-  onDeleteButtonClick?: () => void;
-  onDelete?: (presetId: string | number) => void;
+  onDeleteRequest?: (preset: Preset) => void;
 }
 
 export function PresetItem({
@@ -29,73 +24,23 @@ export function PresetItem({
   mediaCollection,
   label,
   onSelect,
-  onDeleteButtonClick,
-  onDelete,
+  onDeleteRequest,
 }: Props) {
   const { preview } = preset ?? {};
-
-  const modalSlug = `delete-preset-${preset?.id}`;
-  const { openModal } = useModal();
-  const { slug: presetsCollectionSlug } = usePresetsConfig();
 
   const { t } = useTranslation();
 
   const [media, setMedia] = useState<MediaData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isOpen, setIsOpen] = useState(false);
-  const [portalStyle, setPortalStyle] = useState<React.CSSProperties>({});
-  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const mediaId = typeof preview === "number" ? preview : preview?.id;
   const mediaUrl = media?.url;
 
-  const handleMouseEnter = () => {
-    if (!buttonRef.current) return;
-    const rect = buttonRef.current.getBoundingClientRect();
-
-    const fitsRight = rect.right + HOVER_GAP + POPUP_WIDTH <= window.innerWidth;
-    const fitsLeft = rect.left - HOVER_GAP - POPUP_WIDTH >= 0;
-    const fitsTop = rect.top - HOVER_GAP - POPUP_HEIGHT >= 0;
-
-    let style: React.CSSProperties;
-
-    if (fitsRight) {
-      style = {
-        top: rect.top,
-        left: rect.right + HOVER_GAP,
-      };
-    } else if (fitsLeft) {
-      style = {
-        top: rect.top,
-        right: window.innerWidth - rect.left + HOVER_GAP,
-      };
-    } else if (fitsTop) {
-      style = {
-        bottom: window.innerHeight - rect.top + HOVER_GAP,
-        left: rect.left,
-      };
-    } else {
-      style = {
-        top: rect.bottom + HOVER_GAP,
-        left: rect.left,
-      };
-    }
-
-    setPortalStyle({
-      position: "fixed",
-      zIndex: 9999,
-      ...style,
-    });
-    setIsOpen(true);
-  };
-
   const handleRemoveButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-
     setIsOpen(false);
-    onDeleteButtonClick?.();
-
-    openModal(modalSlug);
+    if (preset) onDeleteRequest?.(preset);
   };
 
   useEffect(() => {
@@ -123,48 +68,53 @@ export function PresetItem({
       });
   }, [mediaId, preview, mediaCollection]);
 
+  const hasPreview = !isLoading && !!media && !!mediaUrl;
+
   return (
-    <>
-      <button
-        ref={buttonRef}
-        type="button"
-        className="popover__thumbnail-card thumbnail-card thumbnail-card--has-on-click thumbnail-card--align-label-center"
-        onClick={() => onSelect(preset)}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={() => setIsOpen(false)}
-      >
-        <div className="thumbnail-card__thumbnail">
-          <PresetAdminComponentCell media={media} isLoading={isLoading} />
-        </div>
-
-        <div
-          className="thumbnail-card__label"
-          style={{ ...(!preset ? { fontWeight: "normal" } : null) }}
+    <Popover.Root open={isOpen && hasPreview}>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          className="popover__thumbnail-card thumbnail-card thumbnail-card--has-on-click thumbnail-card--align-label-center"
+          onClick={() => onSelect(preset)}
+          onMouseEnter={() => setIsOpen(true)}
+          onMouseLeave={() => setIsOpen(false)}
         >
-          {preset
-            ? preset.name
-            : `${t("presetsPlugin:blocksDrawer:empty" as never)} ${label}`}
-        </div>
+          <div className="thumbnail-card__thumbnail">
+            <PresetAdminComponentCell media={media} isLoading={isLoading} />
+          </div>
 
-        {preset?.name && (
-          <button
-            className="remove-preset"
-            type="button"
-            onClick={handleRemoveButtonClick}
-          >
-            <TrashIcon className="remove-preset__icon" />
-          </button>
-        )}
-      </button>
-
-      {isOpen &&
-        !isLoading &&
-        media &&
-        mediaUrl &&
-        createPortal(
           <div
-            className="preset-preview-cell__popup"
-            style={portalStyle}
+            className="thumbnail-card__label"
+            style={{ ...(!preset ? { fontWeight: "normal" } : null) }}
+          >
+            {preset
+              ? preset.name
+              : `${t("presetsPlugin:blocksDrawer:empty" as never)} ${label}`}
+          </div>
+
+          {preset?.name && (
+            <button
+              className="remove-preset"
+              type="button"
+              onClick={handleRemoveButtonClick}
+            >
+              <TrashIcon className="remove-preset__icon" />
+            </button>
+          )}
+        </button>
+      </Popover.Trigger>
+
+      {hasPreview && (
+        <Popover.Portal>
+          <Popover.Content
+            className="preset-item__popover-content"
+            side="right"
+            sideOffset={8}
+            align="start"
+            avoidCollisions
+            collisionPadding={8}
+            onOpenAutoFocus={(e) => e.preventDefault()}
             onMouseEnter={() => setIsOpen(true)}
             onMouseLeave={() => setIsOpen(false)}
           >
@@ -178,32 +128,9 @@ export function PresetItem({
               className="preset-preview-cell__popup-image"
               unoptimized
             />
-          </div>,
-          document.body,
-        )}
-
-      {preset?.id && (
-        <ConfirmationModal
-          className="confirmation-modal"
-          modalSlug={modalSlug}
-          heading={t("presetsPlugin:deletePreset:heading" as never)}
-          body={t("presetsPlugin:deletePreset:body" as never, {
-            name: preset.name,
-          })}
-          confirmingLabel={t("presetsPlugin:deletePreset:confirming" as never)}
-          confirmLabel={t("presetsPlugin:deletePreset:confirm" as never)}
-          cancelLabel={t("presetsPlugin:deletePreset:cancel" as never)}
-          onConfirm={async () => {
-            const res = await fetch(
-              `/api/${presetsCollectionSlug}/${preset.id}`,
-              { method: "DELETE" },
-            );
-            if (res.ok) {
-              onDelete?.(preset.id);
-            }
-          }}
-        />
+          </Popover.Content>
+        </Popover.Portal>
       )}
-    </>
+    </Popover.Root>
   );
 }

--- a/packages/payload-plugin-presets/src/components/blocksDrawer/PresetItem/styles.scss
+++ b/packages/payload-plugin-presets/src/components/blocksDrawer/PresetItem/styles.scss
@@ -1,3 +1,12 @@
+.preset-item__popover-content {
+  background: var(--theme-elevation-0);
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  padding: 8px;
+  z-index: var(--z-popup, 100);
+}
+
 .remove-preset {
   position: absolute;
   top: 4px;
@@ -24,5 +33,15 @@
   &:hover {
     background-color: var(--theme-error-150);
     color: var(--theme-error-600);
+  }
+}
+
+@media (hover: none) {
+  .remove-preset {
+    opacity: 1;
+  }
+
+  .preset-item__popover-content {
+    display: none;
   }
 }

--- a/packages/payload-plugin-presets/src/components/presetActions/SaveAsPresetButton.tsx
+++ b/packages/payload-plugin-presets/src/components/presetActions/SaveAsPresetButton.tsx
@@ -55,7 +55,9 @@ export function SaveAsPresetButton() {
   const presetType = presetTypeFromPath ?? blockData?.blockType;
 
   const anchorRef = useRef<HTMLDivElement>(null);
-  const [popupList, setPopupList] = useState<Element | null>(null);
+  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(
+    null,
+  );
 
   useEffect(() => {
     if (!presetType) return;
@@ -73,7 +75,19 @@ export function SaveAsPresetButton() {
           ".popup__content .popup-button-list",
         );
 
-        if (list) setPopupList(list);
+        if (list) {
+          const existing = list.querySelector(
+            "[data-save-as-preset-container]",
+          ) as HTMLDivElement | null;
+          if (existing) {
+            setPortalContainer(existing);
+          } else {
+            const container = document.createElement("div");
+            container.setAttribute("data-save-as-preset-container", "true");
+            list.insertBefore(container, list.firstChild);
+            setPortalContainer(container);
+          }
+        }
       }, 0);
     };
 
@@ -97,17 +111,17 @@ export function SaveAsPresetButton() {
       <div ref={anchorRef} style={{ display: "none" }} />
 
       {presetType &&
-        popupList &&
+        portalContainer &&
         createPortal(
-          <div data-save-as-preset="true">
+          <div>
             <PopupList.Button
               className="popup-button-list__button array-actions__action"
               onClick={openDrawer}
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width="18"
-                height="18"
+                width="17"
+                height="17"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -124,7 +138,7 @@ export function SaveAsPresetButton() {
               {t("presetsPlugin:presetActions:saveButton" as never)}
             </PopupList.Button>
           </div>,
-          popupList,
+          portalContainer,
         )}
 
       <DocumentDrawer

--- a/packages/payload-plugin-presets/src/components/presetActions/SaveAsPresetButton.tsx
+++ b/packages/payload-plugin-presets/src/components/presetActions/SaveAsPresetButton.tsx
@@ -55,9 +55,7 @@ export function SaveAsPresetButton() {
   const presetType = presetTypeFromPath ?? blockData?.blockType;
 
   const anchorRef = useRef<HTMLDivElement>(null);
-  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(
-    null,
-  );
+  const [popupList, setPopupList] = useState<Element | null>(null);
 
   useEffect(() => {
     if (!presetType) return;
@@ -75,19 +73,7 @@ export function SaveAsPresetButton() {
           ".popup__content .popup-button-list",
         );
 
-        if (list) {
-          const existing = list.querySelector(
-            "[data-save-as-preset-container]",
-          ) as HTMLDivElement | null;
-          if (existing) {
-            setPortalContainer(existing);
-          } else {
-            const container = document.createElement("div");
-            container.setAttribute("data-save-as-preset-container", "true");
-            list.insertBefore(container, list.firstChild);
-            setPortalContainer(container);
-          }
-        }
+        if (list) setPopupList(list);
       }, 0);
     };
 
@@ -111,17 +97,17 @@ export function SaveAsPresetButton() {
       <div ref={anchorRef} style={{ display: "none" }} />
 
       {presetType &&
-        portalContainer &&
+        popupList &&
         createPortal(
-          <div>
+          <div data-save-as-preset="true">
             <PopupList.Button
               className="popup-button-list__button array-actions__action"
               onClick={openDrawer}
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width="17"
-                height="17"
+                width="18"
+                height="18"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
@@ -138,7 +124,7 @@ export function SaveAsPresetButton() {
               {t("presetsPlugin:presetActions:saveButton" as never)}
             </PopupList.Button>
           </div>,
-          portalContainer,
+          popupList,
         )}
 
       <DocumentDrawer

--- a/packages/payload-plugin-presets/src/plugin.ts
+++ b/packages/payload-plugin-presets/src/plugin.ts
@@ -275,7 +275,6 @@ const pluginTranslations = {
       },
       blocksDrawer: {
         noPresetsAvailable: "No presets available",
-        addBlockWithPreset: "Add block with preset",
         addBlockTitle: "Add block",
         empty: "Empty",
         preview: "Preview",
@@ -317,7 +316,6 @@ const pluginTranslations = {
       },
       blocksDrawer: {
         noPresetsAvailable: "No hay presets disponibles",
-        addBlockWithPreset: "Añadir bloque con preset",
         addBlockTitle: "Añadir bloque",
         empty: "Vacío",
         preview: "Vista previa",


### PR DESCRIPTION
- **fix(payload-plugin-presets): replace add block title**
- **chore(payload-plugin-presets): add @radix-ui/react-popover dependency**
- **fix(payload-plugin-presets): move save as preset button to the top of the menu list**
- **feat(payload-plugin-presets): replace Payload Popup with Radix Popover in BlockCard**
- **fix(payload-plugin-presets): remove redundant onClose call and revert unrelated SaveAsPreset changes**
- **style(payload-plugin-presets): add Radix Popover content styles for BlockCard preset list**
- **fix(payload-plugin-presets): correct z-index to --z-popup and remove redundant thumbnail-card styles in popover content**
- **fix(payload-plugin-presets): simplify redundant preset count filter in BlockCard**
- **fix(payload-plugin-presets): adapt popups**
- **fix(payload-plugin-presets): check for right media while fetching preview**
