### PR TITLE
  fix(translator): work around Payload's broken JSON-where on SQLite for job lookup

### DIFF
--- a/packages/payload-plugin-translator/README.md
+++ b/packages/payload-plugin-translator/README.md
@@ -32,14 +32,14 @@ yarn add @focus-reactive/payload-plugin-translator
 ## Quick Start
 
 ```typescript
-import { buildConfig } from 'payload'
+import { buildConfig } from "payload";
 import {
   translatorPlugin,
   createOpenAIProvider,
   createPayloadJobsRunner,
-} from '@focus-reactive/payload-plugin-translator'
-import { Posts } from './collections/Posts'
-import { Pages } from './collections/Pages'
+} from "@focus-reactive/payload-plugin-translator";
+import { Posts } from "./collections/Posts";
+import { Pages } from "./collections/Pages";
 
 export default buildConfig({
   collections: [Posts, Pages],
@@ -53,10 +53,10 @@ export default buildConfig({
     }),
   ],
   localization: {
-    locales: ['en', 'de', 'fr'],
-    defaultLocale: 'en',
+    locales: ["en", "de", "fr"],
+    defaultLocale: "en",
   },
-})
+});
 ```
 
 ## Configuration
@@ -64,7 +64,6 @@ export default buildConfig({
 ### TranslatorPluginConfig
 
 Configuration for `translatorPlugin()`.
-
 
 | Property              | Type                  | Required | Default        | Description                                                                                                         |
 | --------------------- | --------------------- | -------- | -------------- | ------------------------------------------------------------------------------------------------------------------- |
@@ -74,38 +73,37 @@ Configuration for `translatorPlugin()`.
 | `access`              | `AccessGuard`         | No       | `undefined`    | Access control function for translation endpoints                                                                   |
 | `basePath`            | `string`              | No       | `'/translate'` | Base path for all API endpoints                                                                                     |
 
-
 ```typescript
 translatorPlugin({
   collections: [Posts, Pages],
-  translationProvider: createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY }),
+  translationProvider: createOpenAIProvider({
+    apiKey: process.env.OPENAI_API_KEY,
+  }),
   runner: createPayloadJobsRunner(),
-  access: async ({ req }) => req.user?.role === 'admin',
-  basePath: '/translate',
-})
+  access: async ({ req }) => req.user?.role === "admin",
+  basePath: "/translate",
+});
 ```
 
 ### OpenAIProviderConfig
 
 Configuration for `createOpenAIProvider()`.
 
-
-| Property       | Type                     | Required | Default         | Description                                |
-| -------------- | ------------------------ | -------- | --------------- | ------------------------------------------ |
-| `apiKey`       | `string`                 | Yes      | —               | OpenAI API key                             |
-| `model`        | `string | ChatModel`     | No       | `'gpt-4o'`      | OpenAI model to use for translation        |
-| `systemPrompt` | `SystemPromptBuilder`    | No       | Built-in prompt | Custom function to build the system prompt |
-| `dryRun`       | `boolean | DryRunConfig` | No       | `false`         | Simulate translations without API calls    |
-
+| Property       | Type                      | Required | Default         | Description                                |
+| -------------- | ------------------------- | -------- | --------------- | ------------------------------------------ |
+| `apiKey`       | `string`                  | Yes      | —               | OpenAI API key                             |
+| `model`        | `string \| ChatModel`     | No       | `'gpt-4o'`      | OpenAI model to use for translation        |
+| `systemPrompt` | `SystemPromptBuilder`     | No       | Built-in prompt | Custom function to build the system prompt |
+| `dryRun`       | `boolean \| DryRunConfig` | No       | `false`         | Simulate translations without API calls    |
 
 ```typescript
 createOpenAIProvider({
   apiKey: process.env.OPENAI_API_KEY,
-  model: 'gpt-4o-mini',
+  model: "gpt-4o-mini",
   systemPrompt: ({ sourceLang, targetLang, defaultPrompt }) =>
     `${defaultPrompt}\nUse formal language. Keep brand names unchanged.`,
   dryRun: false,
-})
+});
 ```
 
 #### SystemPromptBuilder
@@ -113,13 +111,13 @@ createOpenAIProvider({
 Function signature for custom system prompt:
 
 ```typescript
-type SystemPromptBuilder = (context: SystemPromptContext) => string
+type SystemPromptBuilder = (context: SystemPromptContext) => string;
 
 type SystemPromptContext = {
-  sourceLang: string
-  targetLang: string
-  defaultPrompt: string
-}
+  sourceLang: string;
+  targetLang: string;
+  defaultPrompt: string;
+};
 ```
 
 #### DryRunConfig
@@ -127,63 +125,60 @@ type SystemPromptContext = {
 When `dryRun` is an object, it allows custom transformation with optional delay:
 
 ```typescript
-type DryRunTransformer = (text: string) => string | Promise<string>
+type DryRunTransformer = (text: string) => string | Promise<string>;
 
 type DryRunConfig = {
-  transform: DryRunTransformer // Custom transformer function
-  timeout?: number // Delay in ms (simulates API latency)
-}
+  transform: DryRunTransformer; // Custom transformer function
+  timeout?: number; // Delay in ms (simulates API latency)
+};
 ```
 
 ### PayloadJobsRunnerOptions
 
 Configuration for `createPayloadJobsRunner()`.
 
-
-| Property    | Type                      | Required | Default                            | Description                                             |
-| ----------- | ------------------------- | -------- | ---------------------------------- | ------------------------------------------------------- |
-| `taskName`  | `string`                  | No       | `'translate_document'`             | Task name in Payload jobs collection                    |
-| `queueName` | `string`                  | No       | `'translations'`                   | Queue name for grouping jobs                            |
-| `autoRun`   | `false | { cron, limit }` | No       | `{ cron: '* * * * *', limit: 50 }` | Auto-run config, or `false` to disable (for serverless) |
-
+| Property    | Type                       | Required | Default                            | Description                                             |
+| ----------- | -------------------------- | -------- | ---------------------------------- | ------------------------------------------------------- |
+| `taskName`  | `string`                   | No       | `'translate_document'`             | Task name in Payload jobs collection                    |
+| `queueName` | `string`                   | No       | `'translations'`                   | Queue name for grouping jobs                            |
+| `autoRun`   | `false \| { cron, limit }` | No       | `{ cron: '* * * * *', limit: 50 }` | Auto-run config, or `false` to disable (for serverless) |
 
 ```typescript
 createPayloadJobsRunner({
-  taskName: 'translate_document',
-  queueName: 'translations',
+  taskName: "translate_document",
+  queueName: "translations",
   autoRun: {
-    cron: '* * * * *',
+    cron: "* * * * *",
     limit: 50,
   },
-})
+});
 ```
 
 ### FieldTranslationConfig
 
 Configuration for `withFieldTranslation()` helper or `field.custom.translateKit`.
 
-
 | Property  | Type      | Required | Default | Description                         |
 | --------- | --------- | -------- | ------- | ----------------------------------- |
 | `exclude` | `boolean` | No       | `false` | Exclude this field from translation |
 
-
 ```typescript
-import { withFieldTranslation } from '@focus-reactive/payload-plugin-translator'
+import { withFieldTranslation } from "@focus-reactive/payload-plugin-translator";
 
-withFieldTranslation({ name: 'sku', type: 'text', localized: true }, { exclude: true })
+withFieldTranslation(
+  { name: "sku", type: "text", localized: true },
+  { exclude: true },
+);
 ```
 
 ## Translation Strategies
 
 When translating, you can choose how to handle existing translations:
 
-
 | Strategy          | Description                                                              |
 | ----------------- | ------------------------------------------------------------------------ |
 | `'overwrite'`     | (Default) Replaces all existing translated content with new translations |
 | `'skip_existing'` | Only translates fields that are empty in the target locale               |
-
 
 ## Important Notes
 
@@ -239,7 +234,7 @@ export default buildConfig({
   jobs: {
     deleteJobOnComplete: false,
   },
-})
+});
 ```
 
 ## Task Runners
@@ -249,16 +244,16 @@ export default buildConfig({
 Uses Payload's built-in job queue for background processing:
 
 ```typescript
-import { createPayloadJobsRunner } from '@focus-reactive/payload-plugin-translator'
+import { createPayloadJobsRunner } from "@focus-reactive/payload-plugin-translator";
 
 const runner = createPayloadJobsRunner({
-  taskName: 'translate_document',
-  queueName: 'translations',
+  taskName: "translate_document",
+  queueName: "translations",
   autoRun: {
-    cron: '* * * * *',
+    cron: "* * * * *",
     limit: 50,
   },
-})
+});
 ```
 
 ### SyncRunner
@@ -266,9 +261,9 @@ const runner = createPayloadJobsRunner({
 Executes translations synchronously (useful for development or small datasets):
 
 ```typescript
-import { createSyncRunner } from '@focus-reactive/payload-plugin-translator'
+import { createSyncRunner } from "@focus-reactive/payload-plugin-translator";
 
-const runner = createSyncRunner()
+const runner = createSyncRunner();
 ```
 
 ## Translation Providers
@@ -278,13 +273,13 @@ const runner = createSyncRunner()
 Built-in provider using OpenAI's API:
 
 ```typescript
-import { createOpenAIProvider } from '@focus-reactive/payload-plugin-translator'
+import { createOpenAIProvider } from "@focus-reactive/payload-plugin-translator";
 
 const provider = createOpenAIProvider({
   apiKey: process.env.OPENAI_API_KEY,
-  model: 'gpt-4o-mini',
+  model: "gpt-4o-mini",
   systemPrompt: ({ defaultPrompt }) => `${defaultPrompt}\nUse formal language.`,
-})
+});
 ```
 
 ### Custom Provider
@@ -293,11 +288,9 @@ Create your own translation provider by implementing the `TranslationProvider` i
 
 #### TranslationProvider Interface
 
-
-| Method      | Signature                                                                                                | Description                                       |
-| ----------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| `translate` | `(content: TranslationInput, sourceLng: string, targetLng: string) => Promise<TranslationOutput | null>` | Translates content from source to target language |
-
+| Method      | Signature                                                                                                 | Description                                       |
+| ----------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `translate` | `(content: TranslationInput, sourceLng: string, targetLng: string) => Promise<TranslationOutput \| null>` | Translates content from source to target language |
 
 **Important:** The numeric indices in `TranslationInput` must be preserved exactly in `TranslationOutput`. Each index maps to a specific field in the document structure, so the provider must return the same keys with translated values.
 
@@ -305,13 +298,13 @@ Create your own translation provider by implementing the `TranslationProvider` i
 
 ```typescript
 // Numeric index representing position in document structure
-type TranslationIndex = number
+type TranslationIndex = number;
 
 // Input: Map of numeric indices to text strings
-type TranslationInput = Record<TranslationIndex, string>
+type TranslationInput = Record<TranslationIndex, string>;
 
 // Output: Same indices with translated values
-type TranslationOutput = Record<TranslationIndex, string>
+type TranslationOutput = Record<TranslationIndex, string>;
 ```
 
 #### Example Implementation
@@ -321,40 +314,44 @@ import type {
   TranslationProvider,
   TranslationInput,
   TranslationOutput,
-} from '@focus-reactive/payload-plugin-translator'
+} from "@focus-reactive/payload-plugin-translator";
 
 class DeepLProvider implements TranslationProvider {
   constructor(private apiKey: string) {}
 
-  async translate(content: TranslationInput, sourceLng: string, targetLng: string): Promise<TranslationOutput | null> {
+  async translate(
+    content: TranslationInput,
+    sourceLng: string,
+    targetLng: string,
+  ): Promise<TranslationOutput | null> {
     try {
       // content example: { "0": "Hello", "1": "World" }
-      const texts = Object.values(content)
+      const texts = Object.values(content);
 
-      const response = await fetch('https://api.deepl.com/v2/translate', {
-        method: 'POST',
+      const response = await fetch("https://api.deepl.com/v2/translate", {
+        method: "POST",
         headers: {
           Authorization: `DeepL-Auth-Key ${this.apiKey}`,
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({
           text: texts,
           source_lang: sourceLng.toUpperCase(),
           target_lang: targetLng.toUpperCase(),
         }),
-      })
+      });
 
-      const data = await response.json()
+      const data = await response.json();
 
       // Reconstruct the result with same keys
-      const result: TranslationOutput = {}
+      const result: TranslationOutput = {};
       Object.keys(content).forEach((key, index) => {
-        result[key] = data.translations[index].text
-      })
+        result[key] = data.translations[index].text;
+      });
 
-      return result
+      return result;
     } catch {
-      return null
+      return null;
     }
   }
 }
@@ -364,7 +361,7 @@ translatorPlugin({
   collections: [Posts],
   translationProvider: new DeepLProvider(process.env.DEEPL_API_KEY),
   runner: createPayloadJobsRunner(),
-})
+});
 ```
 
 ## UI Components
@@ -404,16 +401,8 @@ import type {
 
   // Field config
   FieldTranslationConfig,
-} from '@focus-reactive/payload-plugin-translator'
+} from "@focus-reactive/payload-plugin-translator";
 ```
-
-## Known Issues
-
-### SQLite: Nested JSON queries not supported
-
-SQLite adapter doesn't support nested JSON field queries like `{ 'input.collection.value': { equals: '5' } }`.
-
-**Affected databases:** SQLite only
 
 ## Roadmap
 
@@ -423,4 +412,3 @@ Planned features for future releases:
 - **Global translation dashboard** — Translate all collections at once from a single interface, with progress tracking across the entire CMS
 - **Vercel Cron Jobs runner** — Built-in runner for seamless Vercel/serverless deployments without manual API route configuration
 - Auto-translate on source change — Automatically trigger translation when the default locale content is updated
-

--- a/packages/payload-plugin-translator/src/server/features/cancel/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/cancel/handler.test.ts
@@ -1,18 +1,18 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { Payload, PayloadRequest } from 'payload'
-import { CancelHandler } from './handler'
-import type { TaskRunner, TaskRunnerProvider } from '../../modules/task-runner'
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Payload, PayloadRequest } from "payload";
+import { CancelHandler } from "./handler";
+import type { TaskRunner, TaskRunnerProvider } from "../../modules/task-runner";
 
-describe('CancelHandler', () => {
-  let handler: CancelHandler
-  let mockTaskRunner: TaskRunner
-  let mockTaskRunnerFactory: TaskRunnerProvider
+describe("CancelHandler", () => {
+  let handler: CancelHandler;
+  let mockTaskRunner: TaskRunner;
+  let mockTaskRunnerFactory: TaskRunnerProvider;
 
   const createMockRequest = (body: unknown): PayloadRequest =>
     ({
       payload: {} as Payload,
       json: vi.fn().mockResolvedValue(body),
-    }) as unknown as PayloadRequest
+    }) as unknown as PayloadRequest;
 
   beforeEach(() => {
     mockTaskRunner = {
@@ -20,70 +20,95 @@ describe('CancelHandler', () => {
       cancel: vi.fn().mockResolvedValue(undefined),
       run: vi.fn(),
       findByCollection: vi.fn(),
-    }
+    };
 
     mockTaskRunnerFactory = {
       create: vi.fn().mockReturnValue(mockTaskRunner),
       configure: vi.fn(),
-    }
+    };
 
-    handler = new CancelHandler(mockTaskRunnerFactory)
-  })
+    handler = new CancelHandler(mockTaskRunnerFactory);
+  });
 
-  describe('validation', () => {
-    it('returns validation error for missing ids', async () => {
-      const req = createMockRequest({})
+  describe("validation", () => {
+    it("returns validation error for missing ids", async () => {
+      const req = createMockRequest({});
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-      const body = await response.json()
-      expect(body.message).toBe('Validation error')
-    })
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.message).toBe("Validation error");
+    });
 
-    it('returns validation error for non-array ids', async () => {
-      const req = createMockRequest({ ids: 'not-an-array' })
+    it("returns validation error for non-array ids", async () => {
+      const req = createMockRequest({ ids: "not-an-array" });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-    })
+      expect(response.status).toBe(400);
+    });
 
-    it('returns validation error for empty ids array', async () => {
-      const req = createMockRequest({ ids: [] })
+    it("returns validation error for empty ids array", async () => {
+      const req = createMockRequest({ ids: [] });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-    })
-  })
+      expect(response.status).toBe(400);
+    });
+  });
 
-  describe('success responses', () => {
-    it('cancels tasks and returns 204', async () => {
-      const req = createMockRequest({ ids: ['task-1', 'task-2'] })
+  describe("success responses", () => {
+    it("cancels tasks and returns 204", async () => {
+      const req = createMockRequest({ ids: ["task-1", "task-2"] });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(204)
-      expect(response.body).toBeNull()
-    })
+      expect(response.status).toBe(204);
+      expect(response.body).toBeNull();
+    });
 
-    it('calls runner.cancel with provided ids', async () => {
-      const req = createMockRequest({ ids: ['task-1', 'task-2', 'task-3'] })
+    it("calls runner.cancel with provided ids", async () => {
+      const req = createMockRequest({ ids: ["task-1", "task-2", "task-3"] });
 
-      await handler.handle(req)
+      await handler.handle(req);
 
-      expect(mockTaskRunner.cancel).toHaveBeenCalledWith(['task-1', 'task-2', 'task-3'])
-    })
+      expect(mockTaskRunner.cancel).toHaveBeenCalledWith([
+        "task-1",
+        "task-2",
+        "task-3",
+      ]);
+    });
 
-    it('creates task runner with request payload', async () => {
-      const mockPayload = { collections: {} } as Payload
-      const req = createMockRequest({ ids: ['task-1'] })
-      ;(req as any).payload = mockPayload
+    it("coerces numeric ids to strings (autoincrement DB ids)", async () => {
+      // Admin client sends `{ ids: [1, 2] }` when the underlying DB uses
+      // integer autoincrement (SQLite default). Schema must accept and
+      // coerce, not reject with 400.
+      const req = createMockRequest({ ids: [1, 2] });
 
-      await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(mockTaskRunnerFactory.create).toHaveBeenCalledWith(mockPayload)
-    })
-  })
-})
+      expect(response.status).toBe(204);
+      expect(mockTaskRunner.cancel).toHaveBeenCalledWith(["1", "2"]);
+    });
+
+    it("accepts a mix of numeric and string ids", async () => {
+      const req = createMockRequest({ ids: [1, "uuid-abc"] });
+
+      const response = await handler.handle(req);
+
+      expect(response.status).toBe(204);
+      expect(mockTaskRunner.cancel).toHaveBeenCalledWith(["1", "uuid-abc"]);
+    });
+
+    it("creates task runner with request payload", async () => {
+      const mockPayload = { collections: {} } as Payload;
+      const req = createMockRequest({ ids: ["task-1"] });
+      (req as any).payload = mockPayload;
+
+      await handler.handle(req);
+
+      expect(mockTaskRunnerFactory.create).toHaveBeenCalledWith(mockPayload);
+    });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/features/cancel/model.ts
+++ b/packages/payload-plugin-translator/src/server/features/cancel/model.ts
@@ -1,8 +1,10 @@
-import { z } from 'zod'
+import { z } from "zod";
+
+import { JobIdSchema } from "../../shared";
 
 /**
- * Input validation schema for batch cancel
+ * Input validation schema for batch cancel.
  */
 export const CancelInputSchema = z.object({
-  ids: z.array(z.string().nonempty()).min(1),
-})
+  ids: z.array(JobIdSchema).min(1),
+});

--- a/packages/payload-plugin-translator/src/server/features/get-document-status/model.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-document-status/model.ts
@@ -1,58 +1,63 @@
-import { z } from 'zod'
-import type { CollectionSlug } from 'payload'
+import { z } from "zod";
+import type { CollectionSlug } from "payload";
 
-import type { Task, TaskStatus } from '../../modules/task-runner'
+import { JobIdSchema } from "../../shared";
+import type { Task, TaskStatus } from "../../modules/task-runner";
 
 /**
- * Input validation schema
+ * Input validation schema.
+ *
+ * `collection_id` accepts any of the shapes Payload allows as a document ID
+ * (integer autoincrement, UUID, MongoDB ObjectId, etc.). See JobIdSchema for
+ * the rationale.
  */
 export const GetDocumentStatusInputSchema = z.object({
-  collection_id: z.coerce
-    .string()
-    .refine((val: string) => val.length > 0 && val !== 'undefined', { message: 'Required' }),
+  collection_id: JobIdSchema,
   collection_slug: z.string().nonempty(),
-})
+});
 
-export type GetDocumentStatusInput = z.infer<typeof GetDocumentStatusInputSchema>
+export type GetDocumentStatusInput = z.infer<
+  typeof GetDocumentStatusInputSchema
+>;
 
 /**
  * Translation task status (re-export for backwards compatibility)
  */
-export type TranslationTaskStatus = TaskStatus
+export type TranslationTaskStatus = TaskStatus;
 
 /**
  * Input format for API response (backwards compatible with Payload Jobs format)
  */
 export type JobInputOutput = {
   collection: {
-    relationTo: CollectionSlug
-    value: string | number
-  }
-  source_lng: string
-  target_lng: string
-  strategy?: string
-}
+    relationTo: CollectionSlug;
+    value: string | number;
+  };
+  source_lng: string;
+  target_lng: string;
+  strategy?: string;
+};
 
 /**
  * Normalized job output (snake_case for client compatibility)
  */
 export type JobStatusOutput = {
-  id: string
-  status: TaskStatus
-  created_at: string
-  updated_at: string
-  completed_at?: string
-  input: JobInputOutput
-  error?: { message: string }
-  cancelled: boolean
-}
+  id: string;
+  status: TaskStatus;
+  created_at: string;
+  updated_at: string;
+  completed_at?: string;
+  input: JobInputOutput;
+  error?: { message: string };
+  cancelled: boolean;
+};
 
 /**
  * Handler configuration
  */
 export type GetDocumentStatusConfig = {
-  availableCollections: Set<CollectionSlug>
-}
+  availableCollections: Set<CollectionSlug>;
+};
 
 /**
  * Transforms a Task to API output format (snake_case for client compatibility)
@@ -75,5 +80,5 @@ export function taskToJobStatusOutput(task: Task): JobStatusOutput {
     },
     error: task.error,
     cancelled: task.cancelled,
-  }
+  };
 }

--- a/packages/payload-plugin-translator/src/server/features/run-translation/model.ts
+++ b/packages/payload-plugin-translator/src/server/features/run-translation/model.ts
@@ -1,8 +1,14 @@
-import { z } from 'zod'
+import { z } from "zod";
+
+import { JobIdSchema } from "../../shared";
 
 /**
- * Input validation schema
+ * Input validation schema.
+ *
+ * `id` comes from the URL route param (always a string at the HTTP edge),
+ * but we reuse the canonical JobIdSchema so the contract stays consistent
+ * with batch cancel.
  */
 export const RunInputSchema = z.object({
-  id: z.string().nonempty(),
-})
+  id: JobIdSchema,
+});

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.test.ts
@@ -1,21 +1,21 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { Payload, CollectionSlug } from 'payload'
-import { PayloadJobsTaskRunner } from './PayloadJobsTaskRunner'
-import type { PayloadJobsRunnerConfig, PayloadJob } from './types'
-import type { TaskInput } from '../types'
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Payload, CollectionSlug } from "payload";
+import { PayloadJobsTaskRunner } from "./PayloadJobsTaskRunner";
+import type { PayloadJobsRunnerConfig, PayloadJob } from "./types";
+import type { TaskInput } from "../types";
 
-describe('PayloadJobsTaskRunner', () => {
+describe("PayloadJobsTaskRunner", () => {
   let mockPayload: {
-    find: ReturnType<typeof vi.fn>
-    delete: ReturnType<typeof vi.fn>
+    find: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
     jobs: {
-      queue: ReturnType<typeof vi.fn>
-      cancel: ReturnType<typeof vi.fn>
-      runByID: ReturnType<typeof vi.fn>
-    }
-  }
-  let config: PayloadJobsRunnerConfig
-  let runner: PayloadJobsTaskRunner
+      queue: ReturnType<typeof vi.fn>;
+      cancel: ReturnType<typeof vi.fn>;
+      runByID: ReturnType<typeof vi.fn>;
+    };
+  };
+  let config: PayloadJobsRunnerConfig;
+  let runner: PayloadJobsTaskRunner;
 
   beforeEach(() => {
     mockPayload = {
@@ -26,216 +26,342 @@ describe('PayloadJobsTaskRunner', () => {
         cancel: vi.fn().mockResolvedValue(undefined),
         runByID: vi.fn().mockResolvedValue(undefined),
       },
-    }
+    };
     config = {
-      taskName: 'translate_document',
-      queueName: 'translations',
-      jobsCollection: 'payload-jobs',
+      taskName: "translate_document",
+      queueName: "translations",
+      jobsCollection: "payload-jobs",
       autoRun: {
-        cron: '* * * * *',
+        cron: "* * * * *",
         limit: 50,
       },
-    }
-    runner = new PayloadJobsTaskRunner(mockPayload as unknown as Payload, config)
-  })
+    };
+    runner = new PayloadJobsTaskRunner(
+      mockPayload as unknown as Payload,
+      config,
+    );
+  });
 
   const createInput = (overrides: Partial<TaskInput> = {}): TaskInput => ({
-    collectionSlug: 'posts' as CollectionSlug,
-    collectionId: 'doc-123',
-    sourceLng: 'en',
-    targetLng: 'de',
-    strategy: 'overwrite',
+    collectionSlug: "posts" as CollectionSlug,
+    collectionId: "doc-123",
+    sourceLng: "en",
+    targetLng: "de",
+    strategy: "overwrite",
     publishOnTranslation: false,
     ...overrides,
-  })
+  });
 
   const createJob = (overrides: Partial<PayloadJob> = {}): PayloadJob => ({
-    id: 'job-123',
-    createdAt: '2024-01-01T00:00:00Z',
-    updatedAt: '2024-01-01T00:00:00Z',
+    id: "job-123",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
     input: {
-      collection: { relationTo: 'posts' as CollectionSlug, value: 'doc-123' },
-      source_lng: 'en',
-      target_lng: 'de',
-      strategy: 'overwrite',
+      collection: { relationTo: "posts" as CollectionSlug, value: "doc-123" },
+      source_lng: "en",
+      target_lng: "de",
+      strategy: "overwrite",
     },
     ...overrides,
-  })
+  });
 
-  describe('enqueue', () => {
-    it('queues tasks with correct input', async () => {
-      const input = createInput()
-      await runner.enqueue([input])
+  describe("enqueue", () => {
+    it("queues tasks with correct input", async () => {
+      const input = createInput();
+      await runner.enqueue([input]);
 
       expect(mockPayload.jobs.queue).toHaveBeenCalledWith({
-        task: 'translate_document',
-        queue: 'translations',
+        task: "translate_document",
+        queue: "translations",
         input: {
-          collection: { relationTo: 'posts', value: 'doc-123' },
-          source_lng: 'en',
-          target_lng: 'de',
-          strategy: 'overwrite',
+          collection: { relationTo: "posts", value: "doc-123" },
+          source_lng: "en",
+          target_lng: "de",
+          strategy: "overwrite",
           publish_on_translation: false,
         },
-      })
-    })
+      });
+    });
 
-    it('queues multiple tasks', async () => {
-      const inputs = [createInput({ collectionId: 'doc-1' }), createInput({ collectionId: 'doc-2' })]
-      await runner.enqueue(inputs)
+    it("queues multiple tasks", async () => {
+      const inputs = [
+        createInput({ collectionId: "doc-1" }),
+        createInput({ collectionId: "doc-2" }),
+      ];
+      await runner.enqueue(inputs);
 
-      expect(mockPayload.jobs.queue).toHaveBeenCalledTimes(2)
-    })
+      expect(mockPayload.jobs.queue).toHaveBeenCalledTimes(2);
+    });
 
-    it('cancels existing jobs before queuing new ones', async () => {
-      const existingJob = createJob({ id: 'existing-job' })
-      mockPayload.find.mockResolvedValueOnce({ docs: [existingJob] })
+    it("cancels existing jobs before queuing new ones", async () => {
+      const existingJob = createJob({ id: "existing-job" });
+      mockPayload.find.mockResolvedValueOnce({ docs: [existingJob] });
 
-      const input = createInput()
-      await runner.enqueue([input])
+      const input = createInput();
+      await runner.enqueue([input]);
 
       expect(mockPayload.jobs.cancel).toHaveBeenCalledWith({
-        where: { id: { in: ['existing-job'] } },
-        queue: 'translations',
-      })
+        where: { id: { in: ["existing-job"] } },
+        queue: "translations",
+      });
       expect(mockPayload.delete).toHaveBeenCalledWith({
-        collection: 'payload-jobs',
-        where: { id: { in: ['existing-job'] } },
-      })
-    })
+        collection: "payload-jobs",
+        where: { id: { in: ["existing-job"] } },
+      });
+    });
 
-    it('does not cancel when no existing jobs', async () => {
-      mockPayload.find.mockResolvedValue({ docs: [] })
+    it("does not cancel when no existing jobs", async () => {
+      mockPayload.find.mockResolvedValue({ docs: [] });
 
-      const input = createInput()
-      await runner.enqueue([input])
+      const input = createInput();
+      await runner.enqueue([input]);
 
-      expect(mockPayload.jobs.cancel).not.toHaveBeenCalled()
-      expect(mockPayload.delete).not.toHaveBeenCalled()
-    })
+      expect(mockPayload.jobs.cancel).not.toHaveBeenCalled();
+      expect(mockPayload.delete).not.toHaveBeenCalled();
+    });
 
-    it('groups tasks by collection', async () => {
+    it("groups tasks by collection", async () => {
       const inputs = [
-        createInput({ collectionSlug: 'posts' as CollectionSlug, collectionId: 'post-1' }),
-        createInput({ collectionSlug: 'posts' as CollectionSlug, collectionId: 'post-2' }),
-        createInput({ collectionSlug: 'pages' as CollectionSlug, collectionId: 'page-1' }),
-      ]
+        createInput({
+          collectionSlug: "posts" as CollectionSlug,
+          collectionId: "post-1",
+        }),
+        createInput({
+          collectionSlug: "posts" as CollectionSlug,
+          collectionId: "post-2",
+        }),
+        createInput({
+          collectionSlug: "pages" as CollectionSlug,
+          collectionId: "page-1",
+        }),
+      ];
 
-      await runner.enqueue(inputs)
+      await runner.enqueue(inputs);
 
       // Should check for existing jobs per collection
-      expect(mockPayload.find).toHaveBeenCalledTimes(2)
-    })
-  })
+      expect(mockPayload.find).toHaveBeenCalledTimes(2);
+    });
 
-  describe('cancel', () => {
-    it('cancels jobs by ids', async () => {
-      await runner.cancel(['job-1', 'job-2'])
+    it("preserves the collectionId type when storing job input", async () => {
+      // Payload's Jobs `input` schema declares `collection` as a relationship
+      // field which validates the value's type against the target collection's
+      // ID type (number for autoincrement, string for uuid). The runner must
+      // not coerce the type on write or jobs would silently fail validation
+      // and stay stuck in processing. Findability across mixed types is
+      // handled by in-memory filtering in `findByCollection`.
+      await runner.enqueue([createInput({ collectionId: 5 })]);
+      expect(mockPayload.jobs.queue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            collection: { relationTo: "posts", value: 5 },
+          }),
+        }),
+      );
+      mockPayload.jobs.queue.mockClear();
+
+      await runner.enqueue([createInput({ collectionId: "uuid-abc" })]);
+      expect(mockPayload.jobs.queue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: expect.objectContaining({
+            collection: { relationTo: "posts", value: "uuid-abc" },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("cancel", () => {
+    it("cancels jobs by ids", async () => {
+      await runner.cancel(["job-1", "job-2"]);
 
       expect(mockPayload.jobs.cancel).toHaveBeenCalledWith({
-        where: { id: { in: ['job-1', 'job-2'] } },
-        queue: 'translations',
-      })
+        where: { id: { in: ["job-1", "job-2"] } },
+        queue: "translations",
+      });
       expect(mockPayload.delete).toHaveBeenCalledWith({
-        collection: 'payload-jobs',
-        where: { id: { in: ['job-1', 'job-2'] } },
-      })
-    })
+        collection: "payload-jobs",
+        where: { id: { in: ["job-1", "job-2"] } },
+      });
+    });
 
-    it('does nothing for empty array', async () => {
-      await runner.cancel([])
+    it("does nothing for empty array", async () => {
+      await runner.cancel([]);
 
-      expect(mockPayload.jobs.cancel).not.toHaveBeenCalled()
-      expect(mockPayload.delete).not.toHaveBeenCalled()
-    })
-  })
+      expect(mockPayload.jobs.cancel).not.toHaveBeenCalled();
+      expect(mockPayload.delete).not.toHaveBeenCalled();
+    });
+  });
 
-  describe('run', () => {
-    it('returns not_found when task does not exist', async () => {
-      mockPayload.find.mockResolvedValue({ docs: [] })
+  describe("run", () => {
+    it("returns not_found when task does not exist", async () => {
+      mockPayload.find.mockResolvedValue({ docs: [] });
 
-      const result = await runner.run('nonexistent')
+      const result = await runner.run("nonexistent");
 
-      expect(result).toEqual({ success: false, error: 'not_found' })
-    })
+      expect(result).toEqual({ success: false, error: "not_found" });
+    });
 
-    it('returns already_completed when task is completed', async () => {
-      const completedJob = createJob({ completedAt: '2024-01-01T01:00:00Z' })
-      mockPayload.find.mockResolvedValue({ docs: [completedJob] })
+    it("returns already_completed when task is completed", async () => {
+      const completedJob = createJob({ completedAt: "2024-01-01T01:00:00Z" });
+      mockPayload.find.mockResolvedValue({ docs: [completedJob] });
 
-      const result = await runner.run('job-123')
+      const result = await runner.run("job-123");
 
-      expect(result).toEqual({ success: false, error: 'already_completed' })
-    })
+      expect(result).toEqual({ success: false, error: "already_completed" });
+    });
 
-    it('returns already_running when task is running', async () => {
-      const runningJob = createJob({ processing: true })
-      mockPayload.find.mockResolvedValue({ docs: [runningJob] })
+    it("returns already_running when task is running", async () => {
+      const runningJob = createJob({ processing: true });
+      mockPayload.find.mockResolvedValue({ docs: [runningJob] });
 
-      const result = await runner.run('job-123')
+      const result = await runner.run("job-123");
 
-      expect(result).toEqual({ success: false, error: 'already_running' })
-    })
+      expect(result).toEqual({ success: false, error: "already_running" });
+    });
 
-    it('runs task and returns success', async () => {
-      const pendingJob = createJob()
-      mockPayload.find.mockResolvedValue({ docs: [pendingJob] })
+    it("runs task and returns success", async () => {
+      const pendingJob = createJob();
+      mockPayload.find.mockResolvedValue({ docs: [pendingJob] });
 
-      const result = await runner.run('job-123')
+      const result = await runner.run("job-123");
 
-      expect(result).toEqual({ success: true })
-      expect(mockPayload.jobs.runByID).toHaveBeenCalledWith({ id: 'job-123' })
-    })
-  })
+      expect(result).toEqual({ success: true });
+      expect(mockPayload.jobs.runByID).toHaveBeenCalledWith({ id: "job-123" });
+    });
+  });
 
-  describe('findByCollection', () => {
-    it('finds tasks by collection slug', async () => {
+  describe("findByCollection", () => {
+    it("finds tasks by collection slug", async () => {
       // Mock returns only jobs matching the collection (simulating DB where clause)
       const jobs = [
-        createJob({ id: 'job-1', input: { collection: { relationTo: 'posts', value: 'doc-1' } } }),
-        createJob({ id: 'job-2', input: { collection: { relationTo: 'posts', value: 'doc-2' } } }),
-      ]
-      mockPayload.find.mockResolvedValue({ docs: jobs })
+        createJob({
+          id: "job-1",
+          input: { collection: { relationTo: "posts", value: "doc-1" } },
+        }),
+        createJob({
+          id: "job-2",
+          input: { collection: { relationTo: "posts", value: "doc-2" } },
+        }),
+      ];
+      mockPayload.find.mockResolvedValue({ docs: jobs });
 
-      const tasks = await runner.findByCollection('posts')
+      const tasks = await runner.findByCollection("posts");
 
-      expect(tasks).toHaveLength(2)
-      expect(tasks[0].id).toBe('job-1')
-      expect(tasks[1].id).toBe('job-2')
-    })
+      expect(tasks).toHaveLength(2);
+      expect(tasks[0].id).toBe("job-1");
+      expect(tasks[1].id).toBe("job-2");
+    });
 
-    it('filters by document ids when provided', async () => {
+    it("filters by document ids when provided", async () => {
       // Mock returns only jobs matching collection and document ids (simulating DB where clause)
       const jobs = [
-        createJob({ id: 'job-1', input: { collection: { relationTo: 'posts', value: 'doc-1' } } }),
-        createJob({ id: 'job-2', input: { collection: { relationTo: 'posts', value: 'doc-2' } } }),
-      ]
-      mockPayload.find.mockResolvedValue({ docs: jobs })
+        createJob({
+          id: "job-1",
+          input: { collection: { relationTo: "posts", value: "doc-1" } },
+        }),
+        createJob({
+          id: "job-2",
+          input: { collection: { relationTo: "posts", value: "doc-2" } },
+        }),
+      ];
+      mockPayload.find.mockResolvedValue({ docs: jobs });
 
-      const tasks = await runner.findByCollection('posts' as CollectionSlug, ['doc-1', 'doc-2'])
+      const tasks = await runner.findByCollection("posts" as CollectionSlug, [
+        "doc-1",
+        "doc-2",
+      ]);
 
-      expect(tasks).toHaveLength(2)
-      expect(tasks[0].id).toBe('job-1')
-      expect(tasks[1].id).toBe('job-2')
-    })
+      expect(tasks).toHaveLength(2);
+      expect(tasks[0].id).toBe("job-1");
+      expect(tasks[1].id).toBe("job-2");
+    });
 
-    it('returns normalized tasks', async () => {
+    it("returns normalized tasks", async () => {
       const job = createJob({
-        id: 'job-123',
-        completedAt: '2024-01-01T01:00:00Z',
-      })
-      mockPayload.find.mockResolvedValue({ docs: [job] })
+        id: "job-123",
+        completedAt: "2024-01-01T01:00:00Z",
+      });
+      mockPayload.find.mockResolvedValue({ docs: [job] });
 
-      const tasks = await runner.findByCollection('posts' as CollectionSlug)
+      const tasks = await runner.findByCollection("posts" as CollectionSlug);
 
       expect(tasks[0]).toMatchObject({
-        id: 'job-123',
-        status: 'completed',
+        id: "job-123",
+        status: "completed",
         input: {
-          collectionSlug: 'posts',
-          collectionId: 'doc-123',
+          collectionSlug: "posts",
+          collectionId: "doc-123",
         },
-      })
-    })
-  })
-})
+      });
+    });
+
+    it("does not put `collection.value` into the SQL where clause", async () => {
+      // Filtering by value happens in memory (see PayloadJobsTaskRunner.findByCollection
+      // for the full reasoning). The WHERE sent to Payload must narrow only by
+      // taskSlug + relationTo — never by `input.collection.value`, otherwise we
+      // re-introduce the SQLite type-coercion bug this code path works around.
+      await runner.findByCollection("posts" as CollectionSlug, [5, 6]);
+
+      const whereArg = mockPayload.find.mock.calls[0][0].where;
+      expect(whereArg).toEqual({
+        and: [
+          { taskSlug: { equals: "translate_document" } },
+          { "input.collection.relationTo": { equals: "posts" } },
+        ],
+      });
+      expect(JSON.stringify(whereArg)).not.toContain("input.collection.value");
+    });
+
+    it("filters in memory and matches both number- and string-typed stored values", async () => {
+      // payload.find returns the full per-collection set; the runner narrows
+      // it client-side by `collection.value`. Both legacy (number) and new
+      // (string) stored shapes must match when the caller passes either type.
+      const legacyJob = createJob({
+        id: "legacy-job",
+        input: {
+          collection: { relationTo: "posts" as CollectionSlug, value: 5 },
+        },
+      });
+      const newJob = createJob({
+        id: "new-job",
+        input: {
+          collection: { relationTo: "posts" as CollectionSlug, value: "7" },
+        },
+      });
+      const unrelatedJob = createJob({
+        id: "unrelated",
+        input: {
+          collection: { relationTo: "posts" as CollectionSlug, value: "99" },
+        },
+      });
+      mockPayload.find.mockResolvedValue({
+        docs: [legacyJob, newJob, unrelatedJob],
+      });
+
+      const tasks = await runner.findByCollection("posts" as CollectionSlug, [
+        5,
+        "7",
+      ]);
+
+      expect(tasks.map((t) => t.id).sort()).toEqual(["legacy-job", "new-job"]);
+    });
+
+    it("returns every task in the collection when documentIds is omitted", async () => {
+      const jobs = [
+        createJob({
+          id: "a",
+          input: { collection: { relationTo: "posts", value: "1" } },
+        }),
+        createJob({
+          id: "b",
+          input: { collection: { relationTo: "posts", value: "2" } },
+        }),
+      ];
+      mockPayload.find.mockResolvedValue({ docs: jobs });
+
+      const tasks = await runner.findByCollection("posts" as CollectionSlug);
+
+      expect(tasks.map((t) => t.id)).toEqual(["a", "b"]);
+    });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.ts
@@ -1,9 +1,9 @@
-import type { Payload, Where, CollectionSlug } from 'payload'
+import type { Payload, Where, CollectionSlug } from "payload";
 
-import type { TaskRunner } from '../TaskRunner.interface'
-import type { Task, TaskInput, RunResult } from '../types'
-import type { PayloadJobsRunnerConfig, PayloadJob } from './types'
-import { normalizeJob } from './normalizeJob'
+import type { TaskRunner } from "../TaskRunner.interface";
+import type { Task, TaskInput, RunResult } from "../types";
+import type { PayloadJobsRunnerConfig, PayloadJob } from "./types";
+import { normalizeJob } from "./normalizeJob";
 
 /**
  * TaskRunner implementation using Payload Jobs.
@@ -17,18 +17,13 @@ export class PayloadJobsTaskRunner implements TaskRunner {
   ) {}
 
   async enqueue(tasks: TaskInput[]): Promise<void> {
-    const byCollection = this.groupByCollection(tasks)
+    const byCollection = this.groupByCollection(tasks);
 
     for (const [collectionSlug, items] of byCollection) {
-      const documentIds = items.map((t) => t.collectionId)
-      const existing = await this.findJobsInternal({
-        and: [
-          { 'input.collection.relationTo': { equals: collectionSlug } },
-          { 'input.collection.value': { in: documentIds } },
-        ],
-      })
+      const documentIds = items.map((t) => String(t.collectionId));
+      const existing = await this.findByCollection(collectionSlug, documentIds);
       if (existing.length > 0) {
-        await this.cancelInternal(existing.map((t) => t.id))
+        await this.cancelInternal(existing.map((t) => t.id));
       }
     }
 
@@ -39,6 +34,15 @@ export class PayloadJobsTaskRunner implements TaskRunner {
           queue: this.config.queueName,
           input: {
             collection: {
+              // Pass `value` through verbatim. The Payload Jobs `input` schema
+              // declares this as a `relationship` field, which validates the
+              // value's type against the target collection's ID type (number
+              // for autoincrement, string for uuid). Coercing to string here
+              // would silently fail validation for number-id collections and
+              // leave jobs stuck in processing without ever invoking the
+              // task handler. `findByCollection` reads back via in-memory
+              // filtering and normalizes both sides with String(...) for the
+              // comparison, so it does not need write-side normalization.
               relationTo: task.collectionSlug,
               value: task.collectionId,
             },
@@ -49,79 +53,163 @@ export class PayloadJobsTaskRunner implements TaskRunner {
           },
         }),
       ),
-    )
+    );
   }
 
   async cancel(taskIds: string[]): Promise<void> {
-    if (taskIds.length === 0) return
-    await this.cancelInternal(taskIds)
+    if (taskIds.length === 0) return;
+    await this.cancelInternal(taskIds);
   }
 
   async run(taskId: string): Promise<RunResult> {
-    const tasks = await this.findJobsInternal({ id: { equals: taskId } }, { limit: 1 })
-    const task = tasks[0]
+    const tasks = await this.findJobsInternal(
+      { id: { equals: taskId } },
+      { limit: 1 },
+    );
+    const task = tasks[0];
 
     if (!task) {
-      return { success: false, error: 'not_found' }
+      return { success: false, error: "not_found" };
     }
     if (task.completedAt) {
-      return { success: false, error: 'already_completed' }
+      return { success: false, error: "already_completed" };
     }
-    if (task.status === 'running') {
-      return { success: false, error: 'already_running' }
+    if (task.status === "running") {
+      return { success: false, error: "already_running" };
     }
 
-    this.payload.jobs.runByID({ id: taskId })
-    return { success: true }
+    this.payload.jobs.runByID({ id: taskId });
+    return { success: true };
   }
 
-  async findByCollection(collectionSlug: CollectionSlug, documentIds?: Array<string | number>): Promise<Task[]> {
-    const where: Where = documentIds?.length
-      ? {
-          and: [
-            { 'input.collection.relationTo': { equals: collectionSlug } },
-            { 'input.collection.value': { in: documentIds } },
-          ],
-        }
-      : { 'input.collection.relationTo': { equals: collectionSlug } }
-
-    return this.findJobsInternal(where, { pagination: false })
+  /**
+   * Find translation jobs for a collection, optionally narrowed by document IDs.
+   *
+   * IMPORTANT — why we filter `collection.value` in memory instead of in WHERE
+   * ------------------------------------------------------------------------
+   * The "natural" implementation would be a single `payload.find` with the
+   * full where clause:
+   *
+   *     where: {
+   *       and: [
+   *         { 'input.collection.relationTo': { equals: collectionSlug } },
+   *         { 'input.collection.value':      { in: documentIds } },
+   *       ],
+   *     }
+   *
+   * This DOES NOT work on SQLite (and is unreliable on any adapter) because
+   * of two compounding bugs in Payload's drizzle layer.
+   *
+   * 1. The `input` field on `payload-jobs` is declared `type: 'json'`. The
+   *    drizzle path resolver (`@payloadcms/drizzle/queries/getTableColumnFromPath`)
+   *    has no `case 'json'` branch, so the value is left as a raw column and
+   *    the path segments are passed through to `parseParams.js`, which on
+   *    SQLite builds raw SQL using `convertPathToJSONTraversal` — generating
+   *    expressions like `input->>'collection'->>'value'`.
+   *
+   * 2. When `parseParams.js` formats the right-hand side of `in`/`not_in`
+   *    (and even `equals` when `!isNaN(val)`), it inlines values via JS
+   *    template literals WITHOUT wrapping strings in quotes. The string
+   *    `'1'` from our WHERE becomes raw `1` in the SQL. Drizzle therefore
+   *    emits queries like:
+   *
+   *        WHERE input->>'collection'->>'value' IN (1)
+   *
+   *    even though the caller passed `['1']` (an array of strings).
+   *
+   * On SQLite, `->>` preserves the JSON value's type — if the stored JSON
+   * has `"value": "1"` (a JSON string), `->>` returns SQLite TEXT `'1'`;
+   * if the JSON has `"value": 1` (a JSON number), `->>` returns INTEGER `1`.
+   * SQLite's `IN (...)` does NOT coerce between TEXT and INTEGER. So:
+   *
+   *     TEXT '1'    IN (1)    → false   (text vs integer, no match)
+   *     INTEGER 1   IN ('1')  → false   (integer vs text, no match)
+   *
+   * Combined with bug #2 above, any value passed by the caller — even if
+   * we normalize it to a string on write — gets re-coerced to a number in
+   * the generated SQL and never matches the stored JSON.
+   *
+   * Postgres avoids most of this because `jsonb_path_query` returns text
+   * uniformly and PG's type coercion is more permissive, but the same
+   * un-quoted-string bug technically affects it too.
+   *
+   * Why we don't fix it upstream / patch the dep
+   * --------------------------------------------
+   * - This plugin is published to npm. Consumers install it with their own
+   *   Payload version and would not receive any local `bun patch` /
+   *   `patch-package` overrides on `@payloadcms/drizzle`. The plugin must
+   *   work against vanilla Payload.
+   * - A PR to Payload core is the proper long-term fix, but the plugin
+   *   cannot block on its merge/release cycle.
+   * - Forcing a non-numeric prefix on the stored ID (e.g., `"id:1"`) would
+   *   work around bug #2, but bloats the data shape and breaks anything
+   *   that reads `input.collection.value` expecting a plain id.
+   *
+   * Why in-memory filtering is acceptable here
+   * ------------------------------------------
+   * We narrow the SQL query to `taskSlug + relationTo` (both string
+   * equality, which Payload quotes correctly), then filter the result set
+   * by `collection.value` in JavaScript. Per-collection job sets are
+   * small (typically <100 rows; the plugin actively cancels superseded
+   * jobs so they don't accumulate), so a Set-membership check in JS is
+   * effectively free.
+   *
+   * If/when the upstream drizzle bug is fixed (or this plugin gains a
+   * mirror collection with indexed flat columns), this method can collapse
+   * back to a single SQL query.
+   */
+  async findByCollection(
+    collectionSlug: CollectionSlug,
+    documentIds?: Array<string | number>,
+  ): Promise<Task[]> {
+    const tasks = await this.findJobsInternal(
+      { "input.collection.relationTo": { equals: collectionSlug } },
+      { pagination: false },
+    );
+    if (!documentIds?.length) return tasks;
+    const wanted = new Set(documentIds.map(String));
+    return tasks.filter((t) => wanted.has(String(t.input.collectionId)));
   }
 
   /**
    * Group tasks by collection slug
    */
-  private groupByCollection(tasks: TaskInput[]): Map<CollectionSlug, TaskInput[]> {
-    const map = new Map<CollectionSlug, TaskInput[]>()
+  private groupByCollection(
+    tasks: TaskInput[],
+  ): Map<CollectionSlug, TaskInput[]> {
+    const map = new Map<CollectionSlug, TaskInput[]>();
     for (const task of tasks) {
-      const existing = map.get(task.collectionSlug) ?? []
-      existing.push(task)
-      map.set(task.collectionSlug, existing)
+      const existing = map.get(task.collectionSlug) ?? [];
+      existing.push(task);
+      map.set(task.collectionSlug, existing);
     }
-    return map
+    return map;
   }
 
   /**
    * Internal cancel implementation
    */
   private async cancelInternal(taskIds: string[]): Promise<void> {
-    if (taskIds.length === 0) return
+    if (taskIds.length === 0) return;
 
     await this.payload.jobs.cancel({
       where: { id: { in: taskIds } },
       queue: this.config.queueName,
-    })
+    });
 
     await this.payload.delete({
       collection: this.config.jobsCollection,
       where: { id: { in: taskIds } },
-    })
+    });
   }
 
   /**
    * Internal method to find jobs with where clause
    */
-  private async findJobsInternal(where: Where, params?: { limit?: number; pagination?: boolean }): Promise<Task[]> {
+  private async findJobsInternal(
+    where: Where,
+    params?: { limit?: number; pagination?: boolean },
+  ): Promise<Task[]> {
     const response = await this.payload.find({
       collection: this.config.jobsCollection,
       limit: params?.limit,
@@ -129,8 +217,8 @@ export class PayloadJobsTaskRunner implements TaskRunner {
       where: {
         and: [{ taskSlug: { equals: this.config.taskName } }, where],
       },
-    })
+    });
 
-    return (response.docs as PayloadJob[]).map(normalizeJob)
+    return (response.docs as PayloadJob[]).map(normalizeJob);
   }
 }

--- a/packages/payload-plugin-translator/src/server/shared/index.ts
+++ b/packages/payload-plugin-translator/src/server/shared/index.ts
@@ -1,15 +1,23 @@
 // HTTP utilities
-export { ServerResponse, withErrorHandler, withAccessCheck } from './http'
+export { ServerResponse, withErrorHandler, withAccessCheck } from "./http";
 
 // Access control
-export { AnyAccessGuard } from './access'
-export type { AccessGuard, AccessGuardRequest, Handler } from './access'
+export { AnyAccessGuard } from "./access";
+export type { AccessGuard, AccessGuardRequest, Handler } from "./access";
 
 // General utilities
-export { isEmpty, isObject, normalizePath, pipe, getByPath, setByPath, filterLocalizedFields } from './utils'
+export {
+  isEmpty,
+  isObject,
+  normalizePath,
+  pipe,
+  getByPath,
+  setByPath,
+  filterLocalizedFields,
+} from "./utils";
 
 // Field guards
-export type { TranslatableField } from './guards'
+export type { TranslatableField } from "./guards";
 export {
   isTranslatableField,
   isLocalizedField,
@@ -17,11 +25,14 @@ export {
   isTabsField,
   isBlockItem,
   hasFields,
-} from './guards'
+} from "./guards";
 
 // Field config
-export { isFieldExcludedFromTranslation, getTranslateKitFieldConfig } from './field-config'
-export type { TranslateKitFieldConfig } from './field-config'
+export {
+  isFieldExcludedFromTranslation,
+  getTranslateKitFieldConfig,
+} from "./field-config";
+export type { TranslateKitFieldConfig } from "./field-config";
 
 // Lexical utilities
 export {
@@ -29,5 +40,8 @@ export {
   isEmptyRichText,
   traverseLexicalTree,
   collectSerializedLexicalTextNodes,
-} from './lexical'
-export type { SerializedTextNodeRef } from './lexical'
+} from "./lexical";
+export type { SerializedTextNodeRef } from "./lexical";
+
+// Validation primitives
+export { JobIdSchema } from "./validation";

--- a/packages/payload-plugin-translator/src/server/shared/validation/index.ts
+++ b/packages/payload-plugin-translator/src/server/shared/validation/index.ts
@@ -1,0 +1,1 @@
+export { JobIdSchema } from "./jobId";

--- a/packages/payload-plugin-translator/src/server/shared/validation/jobId.test.ts
+++ b/packages/payload-plugin-translator/src/server/shared/validation/jobId.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+
+import { JobIdSchema } from './jobId'
+
+describe('JobIdSchema', () => {
+  describe('accepts and normalizes', () => {
+    it('accepts a numeric autoincrement id and converts to string', () => {
+      const result = JobIdSchema.safeParse(42)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBe('42')
+    })
+
+    it('accepts zero as a valid id', () => {
+      const result = JobIdSchema.safeParse(0)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBe('0')
+    })
+
+    it('accepts a UUID string verbatim', () => {
+      const uuid = '550e8400-e29b-41d4-a716-446655440000'
+      const result = JobIdSchema.safeParse(uuid)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBe(uuid)
+    })
+
+    it('accepts a MongoDB ObjectId hex string verbatim', () => {
+      const objectId = '507f1f77bcf86cd799439011'
+      const result = JobIdSchema.safeParse(objectId)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBe(objectId)
+    })
+
+    it('accepts a custom slug-style string', () => {
+      const result = JobIdSchema.safeParse('post-123_v2')
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBe('post-123_v2')
+    })
+
+    it('accepts a stringified numeric id', () => {
+      const result = JobIdSchema.safeParse('42')
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBe('42')
+    })
+
+    it('accepts a nanoid', () => {
+      // 21-char default nanoid alphabet (A-Z, a-z, 0-9, _, -)
+      const nanoid = 'V1StGXR8_Z5jdHi6B-myT'
+      const result = JobIdSchema.safeParse(nanoid)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBe(nanoid)
+    })
+
+    it('accepts a cuid', () => {
+      // collision-resistant unique id, starts with `c` + base36 fields
+      const cuid = 'cl0a1b2c3d4e5f6g7h8i9j'
+      const result = JobIdSchema.safeParse(cuid)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBe(cuid)
+    })
+
+    it('accepts a ULID', () => {
+      // Crockford base32, 26 chars, lexicographically sortable
+      const ulid = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+      const result = JobIdSchema.safeParse(ulid)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBe(ulid)
+    })
+
+    it('accepts a composite/tenanted id with a separator', () => {
+      // some apps namespace ids by tenant/scope
+      const composite = 'tenant-1/post-42'
+      const result = JobIdSchema.safeParse(composite)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBe(composite)
+    })
+
+    it('accepts a Sanity-style document id', () => {
+      // Sanity uses dot-separated namespaces (e.g. drafts.<docId>)
+      const sanityId = 'drafts.a1b2c3d4-e5f6-7890-abcd-ef0123456789'
+      const result = JobIdSchema.safeParse(sanityId)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBe(sanityId)
+    })
+
+    it('accepts an id with Unicode characters', () => {
+      // some apps use human-readable slugs with diacritics or non-Latin scripts
+      const unicodeId = 'статья-1'
+      const result = JobIdSchema.safeParse(unicodeId)
+      expect(result.success).toBe(true)
+      if (result.success) expect(result.data).toBe(unicodeId)
+    })
+  })
+
+  describe('rejects', () => {
+    it('rejects the empty string', () => {
+      expect(JobIdSchema.safeParse('').success).toBe(false)
+    })
+
+    it("rejects the literal 'undefined' string (common HTTP serialization bug)", () => {
+      expect(JobIdSchema.safeParse('undefined').success).toBe(false)
+    })
+
+    it('rejects NaN', () => {
+      expect(JobIdSchema.safeParse(NaN).success).toBe(false)
+    })
+
+    it('rejects Infinity', () => {
+      expect(JobIdSchema.safeParse(Infinity).success).toBe(false)
+    })
+
+    it('rejects null', () => {
+      expect(JobIdSchema.safeParse(null).success).toBe(false)
+    })
+
+    it('rejects undefined', () => {
+      expect(JobIdSchema.safeParse(undefined).success).toBe(false)
+    })
+
+    it('rejects booleans', () => {
+      expect(JobIdSchema.safeParse(true).success).toBe(false)
+      expect(JobIdSchema.safeParse(false).success).toBe(false)
+    })
+
+    it('rejects objects (no implicit toString coercion to "[object Object]")', () => {
+      expect(JobIdSchema.safeParse({}).success).toBe(false)
+      expect(JobIdSchema.safeParse({ id: '1' }).success).toBe(false)
+    })
+
+    it('rejects arrays', () => {
+      expect(JobIdSchema.safeParse([]).success).toBe(false)
+      expect(JobIdSchema.safeParse([1, 2]).success).toBe(false)
+    })
+  })
+})

--- a/packages/payload-plugin-translator/src/server/shared/validation/jobId.ts
+++ b/packages/payload-plugin-translator/src/server/shared/validation/jobId.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+/**
+ * Zod schema for a Payload document/job ID over the HTTP boundary.
+ *
+ * Accepts the two shapes IDs can arrive in: a JS string (UUID, MongoDB
+ * ObjectId hex, custom string id) or a JS number (SQLite/Postgres integer
+ * autoincrement). Anything else (null, undefined, boolean, object, array)
+ * is rejected by the union itself. The schema normalizes to a non-empty
+ * string so callers can compare and Set-membership-check uniformly.
+ *
+ * NOTE: This is intentionally a wire-format guard, not a domain check. We
+ * do not pattern-match for UUID v4 or ObjectId here — different deployments
+ * use different ID formats, and a stricter regex would lock the plugin to
+ * one adapter. Callers that need DB-specific validation should layer it
+ * on top.
+ */
+export const JobIdSchema = z
+  .union([
+    z.string().refine((val) => val.length > 0 && val !== "undefined", {
+      message: "ID must be a non-empty string",
+    }),
+    z.number().finite(),
+  ])
+  .transform(String);


### PR DESCRIPTION
 PROBLEM

  When the plugin queried the `payload-jobs` collection by a nested JSON
  path on `input.collection.value`, Payload's drizzle layer generated SQL
  that inlined string values without quotes:

    where: { 'input.collection.value': { in: ['1'] } }
    →  ... WHERE input->>'collection'->>'value' IN (1)

  On SQLite this never matched, because:
    - `->>` preserves the JSON value's native type (TEXT for "1", INTEGER for 1)
    - SQLite's `IN (...)` does not coerce between TEXT and INTEGER
  So `findByCollection` returned an empty array even when the job existed
  in the database — translation jobs appeared lost to the admin UI, and
  the pre-flight "cancel existing" check inside `enqueue` could not find
  its own previously-queued tasks.

  The bug lives in `@payloadcms/drizzle`'s `parseParams.ts` (the in/equals
  JSON-path branch uses `${escapeSQLValue(v)}` in a template literal,
  which omits surrounding single quotes) and in the missing `case 'json'`
  in `getTableColumnFromPath.ts`. It is not fixable from inside this
  plugin — patches on transitive deps don't ship through npm.

  FIX

  `PayloadJobsTaskRunner.findByCollection` no longer filters
  `collection.value` in the WHERE clause. The SQL query narrows by
  `taskSlug + relationTo` only (both pure string equality, which Payload
  quotes correctly), and the resulting set is then filtered in memory
  with `Set(documentIds.map(String))`. Per-collection result sets are
  small (typically <100 rows; superseded jobs are actively cancelled),
  so the JS filter is effectively free.

  `enqueue` also stops coercing `task.collectionId` to a string before
  calling `payload.jobs.queue`. After the WHERE workaround the coercion
  was no longer needed for findability, and it was actively harmful:
  Payload's Jobs `input` schema declares `collection` as a `relationship`
  field, which validates the value's runtime type against the target
  collection's ID type (number for autoincrement, string for uuid).
  Stringified ids silently failed validation and left jobs stuck in
  `processing` without ever invoking the task handler.

  SIDE FIX

  While in this area, the cancel / run-translation / get-document-status
  endpoints previously declared their job-id input as `z.string()` and
  rejected requests from integer-id collections with a 400 at the HTTP
  boundary. A shared `JobIdSchema` (string | number → non-empty string)
  now lives under `server/shared/validation/` and is wired into all
  three endpoint models. It deliberately accepts any wire-format ID
  (integer, UUID, ObjectId, nanoid, cuid, ULID, composite, Unicode slug)
  and rejects only programmer errors (null, undefined, NaN, Infinity,
  boolean, object, array, empty string).

  TESTS
  
    - `JobIdSchema` — 21 unit cases (12 accept paths covering all real
      ID formats, 9 reject paths covering wire-format errors)
    - `PayloadJobsTaskRunner` — new test asserts the WHERE clause sent
      to `payload.find` does NOT contain `input.collection.value`
      (regression guard for re-introducing the SQLite bug); new test
      verifies the in-memory filter matches both number- and
      string-typed stored values; existing tests updated to expect
      `collectionId` passed through verbatim on write
    - `CancelHandler` — new tests for numeric ids and mixed-type id
      arrays

  DOCS
  
    - Removed the misleading "Known Issues → SQLite: Nested JSON queries
      not supported" section from the plugin README — it was overstated
      (SQLite ≥ 3.38 does support `->>` chains) and incorrect about the
      real failure mode.
    - Repaired three broken markdown tables in the README that had been
      silently swallowing columns because of unescaped `|` inside
      union-type cells (`string | ChatModel`, `boolean | DryRunConfig`,
      `false | { cron, limit }`, `Promise<... | null>`). Now uses `\|`.

  UPSTREAM

  The drizzle adapter bug deserves a fix in Payload core. The detailed
  file:line analysis and a minimal reproducer are documented inline in
  the JSDoc on `PayloadJobsTaskRunner.findByCollection`;