### PR TITLE
fix(translator): use ZodError.issues instead of removed .errors (zod v4)

### DIFF
--- a/packages/payload-plugin-translator/src/server/features/cancel-by-collection/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/cancel-by-collection/handler.ts
@@ -1,10 +1,11 @@
-import type { PayloadRequest } from 'payload'
+import type { PayloadRequest } from "payload";
 
-import { ServerResponse } from '../../shared'
-import type { TaskRunnerProvider } from '../../modules/task-runner'
-import { isCollectionAvailable } from '../_lib/collection-utils'
+import { ServerResponse } from "../../shared";
+import type { TaskRunnerProvider } from "../../modules/task-runner";
+import { isCollectionAvailable } from "../_lib/collection-utils";
 
-import { CancelByCollectionInputSchema, type CancelConfig } from './model'
+import { CancelByCollectionInputSchema } from './model';
+import type { CancelConfig } from './model';
 
 /**
  * Cancels all pending translation tasks for a collection
@@ -12,28 +13,25 @@ import { CancelByCollectionInputSchema, type CancelConfig } from './model'
 export class CancelByCollectionHandler {
   constructor(
     private readonly config: CancelConfig,
-    private readonly taskRunnerFactory: TaskRunnerProvider,
+    private readonly taskRunnerFactory: TaskRunnerProvider
   ) {}
 
   async handle(req: PayloadRequest): Promise<Response> {
-    const validationResult = CancelByCollectionInputSchema.safeParse(req.routeParams)
-    if (validationResult.error) return ServerResponse.validationError(validationResult.error.errors)
+    const validationResult = CancelByCollectionInputSchema.safeParse(req.routeParams);
+    if (validationResult.error) return ServerResponse.validationError(validationResult.error.issues);
 
-    const collectionSlug = isCollectionAvailable(
-      validationResult.data.collection_slug,
-      this.config.availableCollections,
-    )
-    if (!collectionSlug) return ServerResponse.badRequest('Collection not available for translation')
+    const collectionSlug = isCollectionAvailable(validationResult.data.collection_slug, this.config.availableCollections);
+    if (!collectionSlug) return ServerResponse.badRequest("Collection not available for translation");
 
-    const runner = this.taskRunnerFactory.create(req.payload)
-    const tasks = await runner.findByCollection(collectionSlug)
-    if (tasks.length === 0) return ServerResponse.noContent()
+    const runner = this.taskRunnerFactory.create(req.payload);
+    const tasks = await runner.findByCollection(collectionSlug);
+    if (tasks.length === 0) return ServerResponse.noContent();
 
-    const pendingTaskIds = tasks.filter((task) => task.status === 'pending').map((task) => task.id)
-    if (pendingTaskIds.length === 0) return ServerResponse.noContent()
+    const pendingTaskIds = tasks.filter((task) => task.status === "pending").map((task) => task.id);
+    if (pendingTaskIds.length === 0) return ServerResponse.noContent();
 
-    await runner.cancel(pendingTaskIds)
+    await runner.cancel(pendingTaskIds);
 
-    return ServerResponse.noContent()
+    return ServerResponse.noContent();
   }
 }

--- a/packages/payload-plugin-translator/src/server/features/cancel/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/cancel/handler.ts
@@ -1,9 +1,9 @@
-import type { PayloadRequest } from 'payload'
+import type { PayloadRequest } from "payload";
 
-import { ServerResponse } from '../../shared'
-import type { TaskRunnerProvider } from '../../modules/task-runner'
+import { ServerResponse } from "../../shared";
+import type { TaskRunnerProvider } from "../../modules/task-runner";
 
-import { CancelInputSchema } from './model'
+import { CancelInputSchema } from "./model";
 
 /**
  * Cancels and deletes translation tasks by IDs
@@ -12,13 +12,13 @@ export class CancelHandler {
   constructor(private readonly taskRunnerFactory: TaskRunnerProvider) {}
 
   async handle(req: PayloadRequest): Promise<Response> {
-    const validationResult = CancelInputSchema.safeParse(await req.json?.())
-    if (validationResult.error) return ServerResponse.validationError(validationResult.error.errors)
+    const validationResult = CancelInputSchema.safeParse(await req.json?.());
+    if (validationResult.error) return ServerResponse.validationError(validationResult.error.issues);
 
-    const { ids } = validationResult.data
-    const runner = this.taskRunnerFactory.create(req.payload)
-    await runner.cancel(ids)
+    const { ids } = validationResult.data;
+    const runner = this.taskRunnerFactory.create(req.payload);
+    await runner.cancel(ids);
 
-    return ServerResponse.noContent()
+    return ServerResponse.noContent();
   }
 }

--- a/packages/payload-plugin-translator/src/server/features/enqueue-translation/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/enqueue-translation/handler.ts
@@ -1,10 +1,11 @@
-import type { PayloadRequest } from 'payload'
+import type { PayloadRequest } from "payload";
 
-import { ServerResponse } from '../../shared'
-import type { TaskRunnerProvider } from '../../modules/task-runner'
-import { isCollectionAvailable, getAllCollectionIds } from '../_lib/collection-utils'
+import { ServerResponse } from "../../shared";
+import type { TaskRunnerProvider } from "../../modules/task-runner";
+import { isCollectionAvailable, getAllCollectionIds } from "../_lib/collection-utils";
 
-import { EnqueueInputSchema, type EnqueueConfig } from './model'
+import { EnqueueInputSchema } from './model';
+import type { EnqueueConfig } from './model';
 
 /**
  * Enqueues translation tasks for documents
@@ -12,22 +13,21 @@ import { EnqueueInputSchema, type EnqueueConfig } from './model'
 export class EnqueueTranslationHandler {
   constructor(
     private readonly config: EnqueueConfig,
-    private readonly taskRunnerFactory: TaskRunnerProvider,
+    private readonly taskRunnerFactory: TaskRunnerProvider
   ) {}
 
   async handle(req: PayloadRequest): Promise<Response> {
-    const validationResult = EnqueueInputSchema.safeParse(await req.json?.())
-    if (validationResult.error) return ServerResponse.validationError(validationResult.error.errors)
+    const validationResult = EnqueueInputSchema.safeParse(await req.json?.());
+    if (validationResult.error) return ServerResponse.validationError(validationResult.error.issues);
 
-    const { source_lng, target_lng, collection_slug, collection_id, select_all, strategy, publish_on_translation } =
-      validationResult.data
+    const { source_lng, target_lng, collection_slug, collection_id, select_all, strategy, publish_on_translation } = validationResult.data;
 
-    const collectionSlug = isCollectionAvailable(collection_slug, this.config.availableCollections)
-    if (!collectionSlug) return ServerResponse.badRequest('Content of this collection is not available for translation')
+    const collectionSlug = isCollectionAvailable(collection_slug, this.config.availableCollections);
+    if (!collectionSlug) return ServerResponse.badRequest("Content of this collection is not available for translation");
 
-    const collectionIds = select_all ? await getAllCollectionIds(req.payload, collectionSlug) : collection_id
+    const collectionIds = select_all ? await getAllCollectionIds(req.payload, collectionSlug) : collection_id;
 
-    const runner = this.taskRunnerFactory.create(req.payload)
+    const runner = this.taskRunnerFactory.create(req.payload);
     const tasks = collectionIds.map((id) => ({
       collectionSlug,
       collectionId: id,
@@ -35,10 +35,10 @@ export class EnqueueTranslationHandler {
       targetLng: target_lng,
       strategy: strategy,
       publishOnTranslation: publish_on_translation,
-    }))
+    }));
 
-    await runner.enqueue(tasks)
+    await runner.enqueue(tasks);
 
-    return ServerResponse.success({ success: true, queued: tasks.length })
+    return ServerResponse.success({ success: true, queued: tasks.length });
   }
 }

--- a/packages/payload-plugin-translator/src/server/features/get-collection-status/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-collection-status/handler.ts
@@ -1,10 +1,11 @@
-import type { PayloadRequest } from 'payload'
+import type { PayloadRequest } from "payload";
 
-import { ServerResponse } from '../../shared'
-import type { TaskRunnerProvider } from '../../modules/task-runner'
-import { isCollectionAvailable } from '../_lib/collection-utils'
+import { ServerResponse } from "../../shared";
+import type { TaskRunnerProvider } from "../../modules/task-runner";
+import { isCollectionAvailable } from "../_lib/collection-utils";
 
-import { GetCollectionStatusInputSchema, type GetCollectionStatusConfig } from './model'
+import { GetCollectionStatusInputSchema } from './model';
+import type { GetCollectionStatusConfig } from './model';
 
 /**
  * Gets translation status for all documents in a collection
@@ -12,27 +13,24 @@ import { GetCollectionStatusInputSchema, type GetCollectionStatusConfig } from '
 export class GetCollectionStatusHandler {
   constructor(
     private readonly config: GetCollectionStatusConfig,
-    private readonly taskRunnerFactory: TaskRunnerProvider,
+    private readonly taskRunnerFactory: TaskRunnerProvider
   ) {}
 
   async handle(req: PayloadRequest): Promise<Response> {
-    const validationResult = GetCollectionStatusInputSchema.safeParse(req.routeParams)
-    if (validationResult.error) return ServerResponse.validationError(validationResult.error.errors)
+    const validationResult = GetCollectionStatusInputSchema.safeParse(req.routeParams);
+    if (validationResult.error) return ServerResponse.validationError(validationResult.error.issues);
 
-    const collectionSlug = isCollectionAvailable(
-      validationResult.data.collection_slug,
-      this.config.availableCollections,
-    )
-    if (!collectionSlug) return ServerResponse.badRequest('Collection not available for translation')
+    const collectionSlug = isCollectionAvailable(validationResult.data.collection_slug, this.config.availableCollections);
+    if (!collectionSlug) return ServerResponse.badRequest("Collection not available for translation");
 
-    const runner = this.taskRunnerFactory.create(req.payload)
-    const tasks = await runner.findByCollection(collectionSlug)
+    const runner = this.taskRunnerFactory.create(req.payload);
+    const tasks = await runner.findByCollection(collectionSlug);
 
     return ServerResponse.success({
       docs: tasks.map((task) => ({
         id: task.id,
         status: task.status,
       })),
-    })
+    });
   }
 }

--- a/packages/payload-plugin-translator/src/server/features/get-document-status/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-document-status/handler.ts
@@ -1,10 +1,11 @@
-import type { PayloadRequest } from 'payload'
+import type { PayloadRequest } from "payload";
 
-import { ServerResponse } from '../../shared'
-import type { TaskRunnerProvider } from '../../modules/task-runner'
-import { isCollectionAvailable } from '../_lib/collection-utils'
+import { ServerResponse } from "../../shared";
+import type { TaskRunnerProvider } from "../../modules/task-runner";
+import { isCollectionAvailable } from "../_lib/collection-utils";
 
-import { GetDocumentStatusInputSchema, type GetDocumentStatusConfig, taskToJobStatusOutput } from './model'
+import { GetDocumentStatusInputSchema, taskToJobStatusOutput } from './model';
+import type { GetDocumentStatusConfig } from './model';
 
 /**
  * Gets the translation status for a specific document
@@ -12,21 +13,21 @@ import { GetDocumentStatusInputSchema, type GetDocumentStatusConfig, taskToJobSt
 export class GetDocumentStatusHandler {
   constructor(
     private readonly config: GetDocumentStatusConfig,
-    private readonly taskRunnerFactory: TaskRunnerProvider,
+    private readonly taskRunnerFactory: TaskRunnerProvider
   ) {}
 
   async handle(req: PayloadRequest): Promise<Response> {
-    const validationResult = GetDocumentStatusInputSchema.safeParse(req.routeParams)
-    if (validationResult.error) return ServerResponse.validationError(validationResult.error.errors)
+    const validationResult = GetDocumentStatusInputSchema.safeParse(req.routeParams);
+    if (validationResult.error) return ServerResponse.validationError(validationResult.error.issues);
 
-    const { collection_slug, collection_id } = validationResult.data
+    const { collection_slug, collection_id } = validationResult.data;
 
-    const collectionSlug = isCollectionAvailable(collection_slug, this.config.availableCollections)
-    if (!collectionSlug) return ServerResponse.badRequest('Collection not available for translation')
+    const collectionSlug = isCollectionAvailable(collection_slug, this.config.availableCollections);
+    if (!collectionSlug) return ServerResponse.badRequest("Collection not available for translation");
 
-    const runner = this.taskRunnerFactory.create(req.payload)
-    const tasks = await runner.findByCollection(collectionSlug, [collection_id])
+    const runner = this.taskRunnerFactory.create(req.payload);
+    const tasks = await runner.findByCollection(collectionSlug, [collection_id]);
 
-    return ServerResponse.success(tasks[0] ? taskToJobStatusOutput(tasks[0]) : null)
+    return ServerResponse.success(tasks[0] ? taskToJobStatusOutput(tasks[0]) : null);
   }
 }

--- a/packages/payload-plugin-translator/src/server/features/run-translation/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/run-translation/handler.ts
@@ -1,9 +1,9 @@
-import type { PayloadRequest } from 'payload'
+import type { PayloadRequest } from "payload";
 
-import { ServerResponse } from '../../shared'
-import type { TaskRunnerProvider } from '../../modules/task-runner'
+import { ServerResponse } from "../../shared";
+import type { TaskRunnerProvider } from "../../modules/task-runner";
 
-import { RunInputSchema } from './model'
+import { RunInputSchema } from "./model";
 
 /**
  * Runs a translation task by ID
@@ -12,22 +12,22 @@ export class RunTranslationHandler {
   constructor(private readonly taskRunnerFactory: TaskRunnerProvider) {}
 
   async handle(req: PayloadRequest): Promise<Response> {
-    const validationResult = RunInputSchema.safeParse(req.routeParams)
-    if (validationResult.error) return ServerResponse.validationError(validationResult.error.errors)
+    const validationResult = RunInputSchema.safeParse(req.routeParams);
+    if (validationResult.error) return ServerResponse.validationError(validationResult.error.issues);
 
-    const { id } = validationResult.data
-    const runner = this.taskRunnerFactory.create(req.payload)
-    const result = await runner.run(id)
+    const { id } = validationResult.data;
+    const runner = this.taskRunnerFactory.create(req.payload);
+    const result = await runner.run(id);
 
     if (!result.success) {
-      if (result.error === 'not_found' || result.error === 'already_completed') {
-        return ServerResponse.notFound('Queued task not found')
+      if (result.error === "not_found" || result.error === "already_completed") {
+        return ServerResponse.notFound("Queued task not found");
       }
-      if (result.error === 'already_running') {
-        return ServerResponse.tooManyRequests('Translation task is already in progress')
+      if (result.error === "already_running") {
+        return ServerResponse.tooManyRequests("Translation task is already in progress");
       }
     }
 
-    return ServerResponse.noContent()
+    return ServerResponse.noContent();
   }
 }


### PR DESCRIPTION
## Problem

The six route handlers (`cancel`, `cancel-by-collection`, `enqueue-translation`, `run-translation`, `get-document-status`, `get-collection-status`) passed `validationResult.error.errors` to `ServerResponse.validationError`. **zod v4 removed the `.errors` alias** in favour of `.issues`. The monorepo hoists `zod@4.4.3`, so the existing code no longer type-checks:

```
Property 'errors' does not exist on type 'ZodError<...>'
```

This breaks `check-types` for the whole package on a clean install (it surfaced after a `bun install` deduplicated `node_modules` and the package began resolving the hoisted `zod@4`).

## Fix

Switch all six handlers from `validationResult.error.errors` → `validationResult.error.issues`. `.issues` is the canonical property present in **both** zod v3 and v4, so this is version-safe.

## Scope

Mechanical, behavior-preserving (the same array of validation issues is passed to `ServerResponse.validationError`). No logic change. Separate from the in-flight manual-run reliability work, which depends on this so its branch can pass the pre-push gate.

## Verification

- `tsgo --noEmit` (translator): ✓ clean
- `vitest`: ✓ 541 passed
- pre-push `turbo run check-types` (whole repo): ✓ passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)