### PR TITLE
chore(translator): approve translation-levels design + implementation plan

### DIFF
--- a/packages/payload-plugin-translator/docs/plans/2026-06-05-foundation-prep-plan.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-05-foundation-prep-plan.md
@@ -1,0 +1,101 @@
+# Foundation Prep Plan
+
+**Date:** 2026-06-05
+**Status:** Proposed
+**Related:** [Translation Levels Design](./2026-06-05-translation-levels-design.md)
+
+## Overview
+
+Prepare the plugin foundation for upcoming features (translation levels, field-level translation)
+through **non-breaking minor releases**: fix reliability issues in the jobs pipeline, extract the
+internals the levels design depends on, unify and deprecate redundant API surface. Everything
+deprecated here is removed in **one** major release — no drip-feed of breaking changes.
+
+Priority order: **reliability → core extraction + contract tests → API unification → process**.
+Reliability goes first: any new feature built on top of jobs that silently hang multiplies support
+cost.
+
+---
+
+## 1. Jobs reliability (minor, highest priority) — ✅ SHIPPED in 0.4.0
+
+- [x] **Stale-lock recovery.** Shipped: `staleJobTimeoutMs` (default 5 min, validated), boot-time
+      `reclaimStaleJobs`, and manual `run()` clears a stale lock before re-running. (Threshold is a
+      flat configurable default, not "2× cron interval" — it must exceed the longest single run,
+      which the cron interval does not capture.)
+- [x] **ID type handling.** Shipped via the ID-agnostic migration (0.3.0): job input stores a flat
+      text reference (`collection_slug`/`collection_id`); `type ID = string`; coercion at the write
+      boundary. Regression tests cover number-id and string-id collections.
+- [x] **Force-run actually executes.** Root cause found during this work: `payload.jobs.runByID`
+      is broken on the drizzle/sqlite adapter (writes `processing: true`, returns no rows). `run()`
+      now executes via the `where`-based picker (`payload.jobs.run({ queue, where, limit })`).
+- [ ] **Failure observability** (open, deferred): `run()` returns `{ success: true }` even when the
+      picker ran nothing (failed/`hasError` job, future `waitUntil`, or an autorun race). A faithful
+      fix inspects the `jobs.run` result and adds an internal `RunResult` variant + handler mapping.
+      Bounded today (the admin status-poll converges to the real state).
+
+## 2. Levels prerequisites (minor)
+
+- [ ] **Contract tests for the 6 existing routes** (request/response shapes: `enqueue`, `run/:id`,
+      `cancel`, `cancel-by-collection`, `get-document-status`, `get-collection-status`) — written
+      **before** any relocation, so "pure refactoring, tests stay green" is verifiable.
+- [ ] **Subtree `translateContent()` wrapper** — NOT a core extraction. Investigated: the core is
+      already pure and reusable. `TranslationPipeline.execute({ schema, sourceData, targetData,
+      sourceLng, targetLng })` is a relative recursive walk over any `Field[]` + matching data
+      (collector/reconciler/mutator carry no DB, root, or absolute-path assumptions), so a schema
+      subtree + partial data works unchanged. Work needed: a resolver that, for a declared field
+      path, produces `[fieldConfig]` + data rooted as `{ [name]: value }`, and a thin
+      `translateContent()` entry that calls the existing pipeline. Prerequisite for `POST /field`.
+- [ ] **Idempotent `runner.configure()`** + the "one runner is configured exactly once" contract —
+      required before per-level runners. Includes removing the temporal coupling in
+      `SyncRunnerProvider` (`create()` throws unless `configure()` was called first — mutable
+      provider state).
+- [ ] **Introduce optional `levels` config field** with default `[documentLevel(),
+    collectionLevel()]` — non-breaking by construction. (Implementation itself tracked by the
+      levels design doc; this item is only the config surface + back-compat default.)
+
+## 3. API surface unification (minor: deprecate, major: remove)
+
+- [ ] **Unify `cancel`.** `POST {basePath}/cancel` accepts `{ ids: string[] } | { collection: slug }`
+      (exactly one of the two, validated). `cancel-by-collection` becomes a thin alias delegating to
+      the same handler.
+- [ ] **Deprecation pass over existing aliases** — make sure every item is annotated uniformly and
+      scheduled for the same major removal. The authoritative list (status, replacement, removal
+      target, code refs) lives in the [Deprecations Ledger](../DEPRECATIONS.md); this checklist item
+      is just "annotate everything in the ledger uniformly and link each symbol back to its entry."
+- [ ] **DECIDE: fate of `run/:id` (force-run).** Its only purpose is skipping the ≤1 min wait for
+      the cron picker. Options:
+  - _keep + fix_: real UX value; requires the stale-lock fix above so it stops refusing dead jobs
+    (recommended);
+  - _deprecate_: the document popup's Run button goes away in the major as well.
+- [ ] **DECIDE: merge the two status routes in the major?** `get-document-status` +
+      `get-collection-status` → single `status?collection=&ids=`. If yes — same pattern: unified
+      route in a minor, old ones become deprecated aliases.
+
+## 4. Deprecation mechanics (process, in parallel)
+
+- [ ] **Uniform deprecation pattern**: `@deprecated` JSDoc + one-time runtime `console.warn` +
+      a link to the symbol's entry in the [Deprecations Ledger](../DEPRECATIONS.md) (the ledger is
+      the single source of truth — keyed by date + PR, removal target = next major, since
+      semantic-release assigns versions at merge time).
+- [ ] **Release mapping** (semantic-release): deprecations ship as `feat:` (minor), removals as
+      `feat!:` (major). All removals land in a single major release.
+- [ ] **Audit the minimum supported `payload` peer version.** The peer range is `^3.0.0`, but the
+      Jobs API changed noticeably within 3.x. Document "tested with >= 3.x.y" in a minor; raise the
+      floor in the major.
+
+---
+
+## Out of scope
+
+- The translation levels implementation itself (field level, per-level runners, control injection) —
+  tracked by the [levels design doc](./2026-06-05-translation-levels-design.md). This plan only
+  clears the ground for it.
+- Any breaking change shipped outside the single planned major release.
+
+## Open decisions
+
+1. Fate of `run/:id` — keep + fix (recommended) vs deprecate.
+2. Merge `get-document-status` / `get-collection-status` into one `status` route in the major — yes/no.
+3. Stale-lock threshold value (proposal: 2× autoRun cron interval).
+4. Fix location for the enqueue ID-type issue — zod boundary vs runner write-side.

--- a/packages/payload-plugin-translator/docs/plans/2026-06-05-translation-levels-design.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-05-translation-levels-design.md
@@ -1,0 +1,156 @@
+# Translation Levels Design
+
+**Date:** 2026-06-05
+**Status:** Approved (2026-06-08)
+**Implementation plan:** [translation-levels-plan](./2026-06-08-translation-levels-plan.md)
+
+## Overview
+
+Introduce **translation levels** as a first-class plugin concept: the plugin config declares at which levels translation is available — `collection`, `document`, and the new `field` level. Field-level translation translates the current **unsaved form value** synchronously and writes the result back into the form, so it works in both create and edit modes and never touches the database.
+
+## Problem
+
+- The plugin only supports whole-document and bulk-collection translation. There is no way to translate a single field or a logical group of fields (group / tabs / array / blocks subtree).
+- Document/collection UI and endpoints are hardcoded in `plugin.ts` — consumers cannot disable a level or configure levels independently.
+- Both existing levels are forced through a single `runner`. Field-level translation must be synchronous (form value in → translated value out), which the `TaskRunnerProvider` contract cannot express: `TaskHandlerInput` is document-centric (`{ collection, collectionId, ... }`) — it translates a **saved** document by id and writes to the DB. Even `createSyncRunner()` executes the document pipeline; it cannot serve form-state translation.
+
+## Key insight: field level is not a runner concern
+
+The runner becomes an attribute of a **level**, not of the plugin. The field level does not use a runner at all:
+
+| Level        | Semantics                                  | Execution                                                                  |
+| ------------ | ------------------------------------------ | -------------------------------------------------------------------------- |
+| `collection` | N saved documents → DB                     | runner (payload-jobs / sync / future inngest, qstash)                      |
+| `document`   | 1 saved document → DB                      | runner                                                                     |
+| `field`      | form value → response → form, DB untouched | synchronous endpoint → `translationProvider.translate()` directly, no jobs |
+
+Field translation is a stateless request/response: the client sends the current (unsaved) value, the server runs it through the translation provider, the client writes the result into form state. This is what makes create-mode support trivial — no document needs to exist.
+
+## Config API
+
+Levels are an array of objects implementing one narrow interface ("a level is a mini-plugin contributing config"). All level-specific options live in factory functions, not in the interface.
+
+```ts
+translatorPlugin({
+  collections: [Pages],
+  translationProvider: createOpenAIProvider({ ... }),
+  runner: createPayloadJobsRunner(),          // stays = default runner for job-based levels
+  levels: [
+    documentLevel(),                          // inherits root runner
+    collectionLevel({ runner: otherRunner }), // or its own
+    fieldLevel({ mode: 'in-place' }),         // no runner at all
+  ],
+})
+```
+
+```ts
+interface TranslationLevel {
+  readonly name: string; // 'field' | 'document' | 'collection' | custom
+  configure(ctx: TranslationLevelContext): (config: Config) => Config;
+}
+
+type TranslationLevelContext = {
+  collections: CollectionSlug[];
+  schemaMap: Map<string, Field[]>;
+  basePath: string;
+  access?: AccessGuard;
+  translateDocument: TaskHandler; // for job-based levels (existing TranslateDocumentHandler)
+  translateContent: ContentTranslator; // for the field level: (values, src?, tgt) => translated
+  defaultRunner?: TaskRunnerProvider; // root runner inheritance
+};
+```
+
+### Backwards compatibility
+
+- `levels` omitted → defaults to `[documentLevel(), collectionLevel()]` — exactly the current behavior.
+- Root `runner` stays required as long as at least one job-based level is active.
+
+### Implementation pitfalls to handle
+
+- **Job infrastructure deduplication**: `document` and `collection` both need the task + autoRun registered. When they share one runner, its `configure()` must run exactly once — the plugin collects the _distinct set_ of runners across levels and configures each once.
+
+### Endpoints: not split per level
+
+The 6 existing routes are **one shared job-translation API**, not per-level APIs. Both job-based
+widgets go through the same client entity layer (`client/entities/translation/api`): the document
+widget and the bulk dashboard both call `enqueue` (single id, id array, or `select_all`), and
+document statuses are consumed by both the edit view and the list view. Scoping routes to levels was
+considered and rejected:
+
+- shared ownership (whose `enqueue`?) would require route deduplication between levels — accidental complexity;
+- the routes are a documented public API that consumers may call programmatically; admin-UI level
+  configuration must not change the REST surface.
+
+Decision: the existing 6 routes are registered as one bundle whenever at least one job-based level
+is configured. The net API change of this design is exactly **one new route** — `POST
+{basePath}/field` — added because its contract (stateless "values in → translated values out", no
+job, no persistence) is not expressible by any of the existing document-id-based routes, and
+overloading `enqueue` with a sync no-persistence mode would be worse than a dedicated route.
+
+## Translation direction (field level)
+
+Hard constraint: **the Payload admin form holds state for the current locale only**. Switching locales reloads the form from the DB; in create mode other locales do not exist yet. Therefore "pick a target locale and write the translation into the form" is not implementable without saving to the DB (which is document-level semantics).
+
+Two modes are compatible with unsaved-form semantics (both write into the **current** locale's form):
+
+1. **`in-place`** — the user writes in whatever language is convenient, hits the button, and the value is replaced with a translation into the current locale. No language picker. The OpenAI provider already supports source auto-detection (the prompt is built with an optional `sourceLang`). Works in create and edit modes.
+2. **`from-locale`** — the user is on locale B with an empty field → "translate from locale A" → take the **saved** value from locale A, translate, put into form B. A language picker exists, but it selects the **source**, not the target. Edit mode only (requires a saved document).
+
+Decision: **MVP = `in-place`**; `from-locale` is a second iteration (`mode: 'in-place' | 'from-locale' | 'both'` in `fieldLevel()`). "Translate into a selected locale" is rejected — it breaks the no-save invariant.
+
+## Declaring field controls
+
+Reuses the existing mechanism — no new API surface:
+
+```ts
+withFieldTranslation(field, { control: true }); // leaf field
+withFieldTranslation(groupField, { control: true }); // wrapper → translates the whole subtree
+```
+
+- The plugin walks the declared collections' schemas at config build time and injects an admin component (the control button) into fields with `control: true`.
+- Child fields get **no** control — only explicit declarations do.
+- `exclude: true` inside a wrapper's subtree keeps working as a filter.
+
+## Architecture changes
+
+```
+server/
+  features/
+    translate-field/          ← new sync endpoint POST {basePath}/field
+  modules/
+    translation-levels/       ← new: TranslationLevel + documentLevel/collectionLevel/fieldLevel
+    translation-pipeline/     ← REUSE as-is: TranslationPipeline.execute({schema, sourceData,
+                                 targetData, ...}) is already pure (no DB). It is a relative
+                                 recursive walk over any Field[] + matching data, so a schema
+                                 subtree + partial data works unchanged. The field level only
+                                 needs a thin subtree resolver + translateContent() wrapper.
+client/
+  features/translate-field/   ← request + form state write-back
+  widgets/field-translation-control/  ← per-field button (injected via admin.components)
+```
+
+### Riskiest part: form state write-back
+
+For text fields it is a trivial dispatch by path. For **Lexical richText** it requires working with editor state and is deferred: the MVP supports text-like fields and wrappers without richText; richText is a follow-up.
+
+### Security
+
+`POST {basePath}/field` is effectively an LLM proxy. It must:
+
+- enforce the existing `AccessGuard`,
+- validate that `fieldPath` exists in the collection's `schemaMap`,
+- enforce a content size limit.
+
+## Milestones
+
+1. **Levels refactoring** (no new features): `TranslationLevel`, move existing widgets (admin components) into `documentLevel` / `collectionLevel`; the 6 job-API routes stay a shared bundle registered when any job-based level is present; per-level runner with deduplication, back-compat default. Pure relocation — tests stay green.
+2. **Field-level server**: subtree resolver + `translateContent()` wrapper around the existing `TranslationPipeline` (the pipeline is already pure — no core changes) + `POST /field` + tests.
+3. **Field-level client**: control button, form state integration, injection via `control: true`. Text fields + wrappers.
+4. **Second iteration**: richText support, `from-locale` mode.
+
+## Resolved decisions
+
+1. **Non-localized fields inside a declared wrapper → SKIPPED.** The field level translates only `localized` fields, exactly like the document level (`FieldChunkCollector` already gates on `isLocalizedField`). A non-localized value is shared across all locales, so translating it in place would corrupt every other locale. This means **no core change** — the existing pipeline's gate is correct as-is. (Superseded the earlier "translate the whole subtree" lean.)
+2. **richText → deferred (follow-up).** The bottleneck is purely the **client-side write-back** into the Lexical editor state, not translation: the server pipeline (`RichTextExpander`) already handles richText. MVP = text-like fields and wrappers, no richText write-back.
+3. **A separate, on-demand future feature** (not this work): a "translate this content" *utility* that translates a field's text regardless of `localized` — its only real value is richText (round-tripping richText through an external tool mangles formatting). It needs both relaxing the `isLocalizedField` gate AND the deferred richText write-back, so it is naturally a later, opt-in addition.
+4. Naming/UX of the control button and the endpoint payload shape — settled during implementation.

--- a/packages/payload-plugin-translator/docs/plans/2026-06-08-translation-levels-plan.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-08-translation-levels-plan.md
@@ -1,0 +1,70 @@
+# Translation Levels — Implementation Plan
+
+**Date:** 2026-06-08
+**Status:** Ready
+**Design:** [translation-levels-design](./2026-06-05-translation-levels-design.md) · **Groundwork:** [foundation-prep-plan](./2026-06-05-foundation-prep-plan.md)
+
+Ordered, each step a self-contained PR. Field-level translation = `in-place` mode (translate the
+current unsaved form value into the current locale, synchronously, no DB), localized fields only,
+text-like fields + wrappers (richText write-back deferred). Default levels stay
+`[documentLevel(), collectionLevel()]` — fully backwards compatible.
+
+## Phase 0 — Groundwork (prerequisites, each shippable alone)
+
+- **0a. Contract tests for the 6 routes.** Pin path + method + access-guard + error-wrapper →
+  status/body for `enqueue`, `run/:id`, `cancel`, `cancel-by-collection`, `get-document-status`,
+  `get-collection-status`. (Handlers already cover status codes; this pins the route *wiring* so the
+  Phase 1 relocation is verifiably behavior-preserving.) Lowest-risk; can be partial if Phase 1
+  keeps route construction identical.
+- **0b. `translateContent()` + subtree resolver.** No core change (pipeline already pure). Add a
+  resolver: given a declared field config + form value(s), produce `[fieldConfig]` + data rooted as
+  `{ [name]: value }`; add `translateContent(subtreeSchema, values, src, tgt)` that calls the
+  existing `TranslationPipeline`. Unit-test on a leaf field, a group wrapper, and a nested
+  array/blocks subtree. **Direct building block of Phase 2.**
+- **0c. Idempotent `configure()` + de-couple `SyncRunner`.** Guard `PayloadJobsRunnerProvider.configure`
+  against double-registering task/autoRun (so two levels sharing a runner configure it once). Remove
+  `SyncRunnerProvider`'s mutable `this.handler` / "create() throws unless configure() first" coupling.
+  Prerequisite for per-level runners.
+
+## Phase 1 — Levels refactoring (no new features)
+
+- Introduce `TranslationLevel` interface + `documentLevel()` / `collectionLevel()` factories under
+  `modules/translation-levels/`.
+- Move the existing admin components (document popup → `documentLevel`, bulk dashboard →
+  `collectionLevel`) into their level modules.
+- The 6 job-API routes stay **one shared bundle**, registered when any job-based level is present.
+- Per-level runner with **deduplication** (configure each distinct runner once — uses 0c).
+- Add optional `levels` config field, default `[documentLevel(), collectionLevel()]`. Omitted =
+  exactly today's behavior.
+- Exit criteria: Phase 0a contract tests + existing suite green (pure relocation).
+
+## Phase 2 — Field-level server
+
+- `fieldLevel({ mode: 'in-place' })` factory.
+- `POST {basePath}/field` — synchronous endpoint: receives `{ collectionSlug, fieldPath, value,
+  targetLng }`, runs `translateContent` (0b), returns the translated subtree. **No persistence.**
+- Security: enforce `AccessGuard`; validate `fieldPath` exists in the collection `schemaMap`; content
+  size limit.
+- Tests: leaf + wrapper; localized-only (non-localized skipped); access denied; unknown fieldPath.
+
+## Phase 3 — Field-level client
+
+- `withFieldTranslation(field, { control: true })` injects a per-field control (button) via
+  `admin.components` — only where explicitly declared; child fields get nothing.
+- Client feature: call `POST /field` with the current form value, write the result back into form
+  state (text fields + wrappers). Works in create AND edit (unsaved value).
+- Tests for the form-state write-back on text fields.
+
+## Phase 4 — Follow-ups (separate, on demand)
+
+- richText write-back into Lexical editor state (the deferred bottleneck; server already translates richText).
+- `from-locale` mode (translate a saved locale A value into form B; source picker).
+- "Translate this content" utility for non-localized/richText fields (relaxes the `isLocalizedField`
+  gate + needs the richText write-back) — opt-in, not part of the levels MVP.
+
+## Release shape
+
+- Phase 0: `refactor`/`fix` (patch). Phase 1: `feat` (minor), non-breaking (default levels unchanged).
+- Phase 2–3: `feat` (minor) — the new field level is opt-in via `levels` + `control: true`.
+- No breaking change; the deprecated job-input relationship field and API unification (foundation-prep
+  §3) remain queued for the single planned major.


### PR DESCRIPTION
Commits the planning docs (previously local-only) and records the decisions made while building the reliability work.

## What

- **translation-levels-design → Approved.** Open questions resolved:
  - Field level translates **localized fields only** — non-localized are skipped (their value is shared across locales; translating in place would corrupt the others). This matches the existing `FieldChunkCollector` gate → **no core change**.
  - **richText deferred** to a follow-up — the bottleneck is the client-side write-back into the Lexical editor state; the server pipeline already translates richText.
  - A **"translate any content" utility** (non-localized / richText, regardless of locale) is a separate on-demand feature, not the levels MVP.
- **Core-extraction corrected.** Investigation showed `TranslationPipeline.execute` is already pure and walks any `Field[]` + matching data, so a schema **subtree + partial data works unchanged**. Field-level needs only a subtree resolver + `translateContent()` wrapper — not a core rewrite.
- **foundation-prep updated.** §1 jobs reliability marked **shipped in 0.4.0** (stale-lock recovery, ID-agnostic refs, where-based force-run); §2 reflects the no-core-change finding.
- **New implementation plan** (`2026-06-08-translation-levels-plan.md`): Phase 0 groundwork → 1 levels refactor → 2 field server → 3 field client → 4 follow-ups; each phase a self-contained PR, default levels unchanged (backwards compatible).

## Scope

Docs only — no code, no release (`chore`). Sets up the field-level translation feature for implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)