### PR TITLE
chore(translator): translateContent() groundwork for field-level translation

### DIFF
--- a/packages/payload-plugin-translator/src/server/features/translate-document/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-document/handler.test.ts
@@ -1,52 +1,48 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { Payload, CollectionSlug } from 'payload'
-import { APIError } from 'payload'
-import { TranslateDocumentHandler } from './handler'
-import type { TranslationProvider } from '../../modules/translation-providers'
-import type { CollectionSchemaMap, TranslateDocumentInput } from './model'
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Payload, CollectionSlug } from "payload";
+import { APIError } from "payload";
+import { TranslateDocumentHandler } from "./handler";
+import type { TranslationProvider } from "../../modules/translation-providers";
+import type { CollectionSchemaMap, TranslateDocumentInput } from "./model";
 
-// Mock TranslationPipeline
-vi.mock('../../modules/translation-pipeline', () => ({
-  TranslationPipeline: vi.fn().mockImplementation(() => ({
-    execute: vi.fn().mockResolvedValue(null),
-  })),
-}))
+// Mock the translation core — the handler's unit tests isolate its
+// orchestration (fetch / strategy plumbing / save), not the pipeline itself.
+// translateContent returns the translated data directly, or null when there is
+// nothing to translate.
+vi.mock("../../modules/translation-pipeline", () => ({
+  translateContent: vi.fn().mockResolvedValue(null),
+}));
 
-// Mock createTranslationStrategy
-vi.mock('../../modules/translation-pipeline/strategies', () => ({
-  createTranslationStrategy: vi.fn().mockReturnValue({}),
-}))
-
-describe('TranslateDocumentHandler', () => {
-  let handler: TranslateDocumentHandler
-  let mockTranslationProvider: TranslationProvider
-  let mockSchemaMap: CollectionSchemaMap
-  let mockPayload: Payload
+describe("TranslateDocumentHandler", () => {
+  let handler: TranslateDocumentHandler;
+  let mockTranslationProvider: TranslationProvider;
+  let mockSchemaMap: CollectionSchemaMap;
+  let mockPayload: Payload;
 
   const createInput = (overrides: Partial<TranslateDocumentInput> = {}): TranslateDocumentInput => ({
-    collection: 'posts' as CollectionSlug,
-    collectionId: 'doc-123',
-    sourceLng: 'en',
-    targetLng: 'de',
-    strategy: 'overwrite',
+    collection: "posts" as CollectionSlug,
+    collectionId: "doc-123",
+    sourceLng: "en",
+    targetLng: "de",
+    strategy: "overwrite",
     publishOnTranslation: false,
     ...overrides,
-  })
+  });
 
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.clearAllMocks();
 
     mockTranslationProvider = {
       translate: vi.fn().mockResolvedValue({}),
-    }
+    };
 
     mockSchemaMap = new Map([
-      ['posts' as CollectionSlug, [{ name: 'title', type: 'text', localized: true }]],
-      ['pages' as CollectionSlug, [{ name: 'content', type: 'richText', localized: true }]],
-    ]) as CollectionSchemaMap
+      ["posts" as CollectionSlug, [{ name: "title", type: "text", localized: true }]],
+      ["pages" as CollectionSlug, [{ name: "content", type: "richText", localized: true }]],
+    ]) as CollectionSchemaMap;
 
     mockPayload = {
-      findByID: vi.fn().mockResolvedValue({ id: 'doc-123', title: 'Test' }),
+      findByID: vi.fn().mockResolvedValue({ id: "doc-123", title: "Test" }),
       update: vi.fn().mockResolvedValue({}),
       collections: {
         posts: {
@@ -62,165 +58,191 @@ describe('TranslateDocumentHandler', () => {
           },
         },
       },
-    } as unknown as Payload
+    } as unknown as Payload;
 
-    handler = new TranslateDocumentHandler(mockTranslationProvider, mockSchemaMap)
-  })
+    handler = new TranslateDocumentHandler(mockTranslationProvider, mockSchemaMap);
+  });
 
-  describe('schema validation', () => {
-    it('throws APIError when collection not in schemaMap', async () => {
-      const input = createInput({ collection: 'unknown' as CollectionSlug })
+  describe("schema validation", () => {
+    it("throws APIError when collection not in schemaMap", async () => {
+      const input = createInput({ collection: "unknown" as CollectionSlug });
 
-      await expect(handler.handle(mockPayload, input)).rejects.toThrow(APIError)
-      await expect(handler.handle(mockPayload, input)).rejects.toThrow('Collection "unknown" not found in schemaMap')
-    })
-  })
+      await expect(handler.handle(mockPayload, input)).rejects.toThrow(APIError);
+      await expect(handler.handle(mockPayload, input)).rejects.toThrow('Collection "unknown" not found in schemaMap');
+    });
+  });
 
-  describe('document fetching', () => {
-    it('fetches source document with source locale', async () => {
-      const input = createInput({ sourceLng: 'en' })
+  describe("document fetching", () => {
+    it("fetches source document with source locale", async () => {
+      const input = createInput({ sourceLng: "en" });
 
-      await handler.handle(mockPayload, input)
+      await handler.handle(mockPayload, input);
 
       expect(mockPayload.findByID).toHaveBeenCalledWith({
-        collection: 'posts',
-        id: 'doc-123',
-        locale: 'en',
+        collection: "posts",
+        id: "doc-123",
+        locale: "en",
         depth: 0,
-      })
-    })
+      });
+    });
 
-    it('fetches target document with target locale and no fallback', async () => {
-      const input = createInput({ targetLng: 'de' })
+    it("fetches target document with target locale and no fallback", async () => {
+      const input = createInput({ targetLng: "de" });
 
-      await handler.handle(mockPayload, input)
+      await handler.handle(mockPayload, input);
 
       expect(mockPayload.findByID).toHaveBeenCalledWith({
-        collection: 'posts',
-        id: 'doc-123',
-        locale: 'de',
+        collection: "posts",
+        id: "doc-123",
+        locale: "de",
         fallbackLocale: false,
         depth: 0,
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('success responses', () => {
-    it('returns success when no translation needed (pipeline returns null)', async () => {
-      const input = createInput()
+  describe("translateContent invocation", () => {
+    it("forwards fetched docs, strategy and locales to translateContent", async () => {
+      const { translateContent } = await import("../../modules/translation-pipeline");
+      (translateContent as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
-      const result = await handler.handle(mockPayload, input)
+      const input = createInput({
+        sourceLng: "en",
+        targetLng: "fr",
+        strategy: "overwrite",
+      });
 
-      expect(result).toEqual({ success: true })
-      expect(mockPayload.update).not.toHaveBeenCalled()
-    })
+      await handler.handle(mockPayload, input);
 
-    it('returns success after saving translated document', async () => {
-      const { TranslationPipeline } = await import('../../modules/translation-pipeline')
-      ;(TranslationPipeline as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
-        execute: vi.fn().mockResolvedValue({ translatedData: { title: 'Übersetzter Titel' } }),
-      }))
+      expect(translateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schema: [{ name: "title", type: "text", localized: true }],
+          sourceData: { id: "doc-123", title: "Test" },
+          targetData: { id: "doc-123", title: "Test" },
+          sourceLng: "en",
+          targetLng: "fr",
+          strategy: "overwrite",
+          translationProvider: mockTranslationProvider,
+        })
+      );
+    });
+  });
 
-      const input = createInput()
-      const result = await handler.handle(mockPayload, input)
+  describe("success responses", () => {
+    it("returns success when no translation needed (pipeline returns null)", async () => {
+      const { translateContent } = await import("../../modules/translation-pipeline");
+      (translateContent as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
-      expect(result).toEqual({ success: true })
-    })
-  })
+      const input = createInput();
 
-  describe('saving translated documents', () => {
+      const result = await handler.handle(mockPayload, input);
+
+      expect(result).toEqual({ success: true });
+      expect(mockPayload.update).not.toHaveBeenCalled();
+    });
+
+    it("returns success after saving translated document", async () => {
+      const { translateContent } = await import("../../modules/translation-pipeline");
+      (translateContent as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ title: "Übersetzter Titel" });
+
+      const input = createInput();
+      const result = await handler.handle(mockPayload, input);
+
+      expect(result).toEqual({ success: true });
+    });
+  });
+
+  describe("saving translated documents", () => {
     beforeEach(async () => {
-      const { TranslationPipeline } = await import('../../modules/translation-pipeline')
-      ;(TranslationPipeline as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => ({
-        execute: vi.fn().mockResolvedValue({ translatedData: { title: 'Translated' } }),
-      }))
-    })
+      const { translateContent } = await import("../../modules/translation-pipeline");
+      (translateContent as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ title: "Translated" });
+    });
 
-    it('saves document with target locale and source as fallback', async () => {
-      const input = createInput({ sourceLng: 'en', targetLng: 'fr' })
+    it("saves document with target locale and source as fallback", async () => {
+      const input = createInput({ sourceLng: "en", targetLng: "fr" });
 
-      await handler.handle(mockPayload, input)
+      await handler.handle(mockPayload, input);
 
       expect(mockPayload.update).toHaveBeenCalledWith(
         expect.objectContaining({
-          collection: 'posts',
-          id: 'doc-123',
-          locale: 'fr',
-          fallbackLocale: 'en',
-        }),
-      )
-    })
+          collection: "posts",
+          id: "doc-123",
+          locale: "fr",
+          fallbackLocale: "en",
+        })
+      );
+    });
 
-    it('saves document without autosave when versions not enabled', async () => {
-      const input = createInput()
+    it("saves document without autosave when versions not enabled", async () => {
+      const input = createInput();
 
-      await handler.handle(mockPayload, input)
+      await handler.handle(mockPayload, input);
 
       expect(mockPayload.update).toHaveBeenCalledWith(
         expect.objectContaining({
           autosave: false,
-        }),
-      )
-    })
+        })
+      );
+    });
 
-    it('sets _status to draft when versions with drafts enabled', async () => {
-      ;(mockPayload.collections['posts'].config as { versions: unknown }).versions = { drafts: true }
+    it("sets _status to draft when versions with drafts enabled", async () => {
+      (mockPayload.collections["posts"].config as { versions: unknown }).versions = { drafts: true };
 
-      const input = createInput()
-      await handler.handle(mockPayload, input)
-
-      expect(mockPayload.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            _status: 'draft',
-          }),
-        }),
-      )
-    })
-
-    it('sets _status to published when publishOnTranslation is true', async () => {
-      ;(mockPayload.collections['posts'].config as { versions: unknown }).versions = { drafts: true }
-
-      const input = createInput({ publishOnTranslation: true })
-      await handler.handle(mockPayload, input)
+      const input = createInput();
+      await handler.handle(mockPayload, input);
 
       expect(mockPayload.update).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
-            _status: 'published',
+            _status: "draft",
           }),
-        }),
-      )
-    })
+        })
+      );
+    });
 
-    it('uses autosave when drafts with autosave enabled and not publishing', async () => {
-      ;(mockPayload.collections['posts'].config as { versions: unknown }).versions = {
+    it("sets _status to published when publishOnTranslation is true", async () => {
+      (mockPayload.collections["posts"].config as { versions: unknown }).versions = { drafts: true };
+
+      const input = createInput({ publishOnTranslation: true });
+      await handler.handle(mockPayload, input);
+
+      expect(mockPayload.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            _status: "published",
+          }),
+        })
+      );
+    });
+
+    it("uses autosave when drafts with autosave enabled and not publishing", async () => {
+      (mockPayload.collections["posts"].config as { versions: unknown }).versions = {
         drafts: { autosave: true },
-      }
+      };
 
-      const input = createInput()
-      await handler.handle(mockPayload, input)
+      const input = createInput();
+      await handler.handle(mockPayload, input);
 
       expect(mockPayload.update).toHaveBeenCalledWith(
         expect.objectContaining({
           autosave: true,
-        }),
-      )
-    })
+        })
+      );
+    });
 
-    it('does not use autosave when publishing', async () => {
-      ;(mockPayload.collections['posts'].config as { versions: unknown }).versions = {
+    it("does not use autosave when publishing", async () => {
+      (mockPayload.collections["posts"].config as { versions: unknown }).versions = {
         drafts: { autosave: true },
-      }
+      };
 
-      const input = createInput({ publishOnTranslation: true })
-      await handler.handle(mockPayload, input)
+      const input = createInput({ publishOnTranslation: true });
+      await handler.handle(mockPayload, input);
 
       expect(mockPayload.update).toHaveBeenCalledWith(
         expect.objectContaining({
           autosave: false,
-        }),
-      )
-    })
-  })
-})
+        })
+      );
+    });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/features/translate-document/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-document/handler.ts
@@ -3,8 +3,7 @@ import { APIError } from "payload";
 
 import type { Handler } from "../../shared";
 import type { TranslationProvider } from "../../modules/translation-providers";
-import { TranslationPipeline } from "../../modules/translation-pipeline";
-import { createTranslationStrategy } from "../../modules/translation-pipeline/strategies";
+import { translateContent } from "../../modules/translation-pipeline";
 
 import type { CollectionSchemaMap, TranslateDocumentInput, TranslateDocumentOutput } from "./model";
 
@@ -43,23 +42,19 @@ export class TranslateDocumentHandler implements Handler<TranslateDocumentInput,
       depth: 0,
     });
 
-    const translationStrategy = createTranslationStrategy(strategy);
-    const pipeline = new TranslationPipeline({
-      translationProvider: this.translationProvider,
-      translationStrategy,
-    });
-
-    const result = await pipeline.execute({
+    const translatedData = await translateContent({
       schema,
       sourceData,
       targetData,
       sourceLng,
       targetLng,
+      translationProvider: this.translationProvider,
+      strategy,
     });
-    if (!result) return { success: true };
+    if (!translatedData) return { success: true };
 
     const collectionConfig = payload.collections[collection].config;
-    await this.saveTranslatedDocument(payload, collection, collectionId, result.translatedData, targetLng, sourceLng, collectionConfig, publishOnTranslation);
+    await this.saveTranslatedDocument(payload, collection, collectionId, translatedData, targetLng, sourceLng, collectionConfig, publishOnTranslation);
 
     return { success: true };
   }

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/index.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/index.ts
@@ -1,3 +1,5 @@
-export { TranslationPipeline } from './TranslationPipeline'
-export type { TranslationStrategy } from './strategies'
-export { OverwriteStrategy, SkipExistingStrategy } from './strategies'
+export { TranslationPipeline } from "./TranslationPipeline";
+export { translateContent } from "./translateContent";
+export type { TranslateContentArgs } from "./translateContent";
+export type { TranslationStrategy } from "./strategies";
+export { OverwriteStrategy, SkipExistingStrategy } from "./strategies";

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/translateContent.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/translateContent.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import type { Field } from "payload";
+
+import type { TranslationProvider } from "../translation-providers";
+import { translateContent } from "./translateContent";
+
+// Deterministic fake provider: prefixes each collected text chunk with "T:".
+// Preserves the numeric keys, as the contract requires.
+const fakeProvider: TranslationProvider = {
+  translate: async (input) => {
+    const out: Record<number, string> = {};
+    for (const key of Object.keys(input)) {
+      out[Number(key)] = `T:${input[Number(key)]}`;
+    }
+    return out;
+  },
+};
+
+const run = (schema: Field[], sourceData: Record<string, unknown>) =>
+  translateContent({
+    schema,
+    sourceData,
+    sourceLng: "en",
+    targetLng: "de",
+    translationProvider: fakeProvider,
+  });
+
+describe("translateContent", () => {
+  it("translates a localized leaf field", async () => {
+    const result = await run([{ name: "title", type: "text", localized: true }], { title: "hello" });
+    expect(result).toEqual({ title: "T:hello" });
+  });
+
+  it("translates localized leaves inside a group wrapper, leaving non-localized values intact", async () => {
+    const schema: Field[] = [
+      {
+        name: "hero",
+        type: "group",
+        fields: [
+          { name: "heading", type: "text", localized: true },
+          { name: "sku", type: "text" }, // non-localized → not translated, preserved
+        ],
+      },
+    ];
+    const result = await run(schema, {
+      hero: { heading: "hi", sku: "ABC-123" },
+    });
+    expect(result).toEqual({ hero: { heading: "T:hi", sku: "ABC-123" } });
+  });
+
+  it("translates localized leaves inside array items", async () => {
+    const schema: Field[] = [
+      {
+        name: "items",
+        type: "array",
+        fields: [{ name: "label", type: "text", localized: true }],
+      },
+    ];
+    const result = await run(schema, {
+      items: [{ label: "a" }, { label: "b" }],
+    });
+    expect(result).toEqual({ items: [{ label: "T:a" }, { label: "T:b" }] });
+  });
+
+  it("translates localized leaves inside blocks", async () => {
+    const schema: Field[] = [
+      {
+        name: "layout",
+        type: "blocks",
+        blocks: [
+          {
+            slug: "cta",
+            fields: [{ name: "text", type: "text", localized: true }],
+          },
+        ],
+      },
+    ];
+    const result = await run(schema, {
+      layout: [{ blockType: "cta", text: "click" }],
+    });
+    expect(result).toEqual({ layout: [{ blockType: "cta", text: "T:click" }] });
+  });
+
+  it("returns null when nothing is translatable (no localized leaves)", async () => {
+    const result = await run([{ name: "sku", type: "text" }], { sku: "ABC" });
+    expect(result).toBeNull();
+  });
+
+  it("respects skip_existing: keeps a non-empty target value", async () => {
+    const result = await translateContent({
+      schema: [{ name: "title", type: "text", localized: true }],
+      sourceData: { title: "hello" },
+      targetData: { title: "bereits übersetzt" },
+      sourceLng: "en",
+      targetLng: "de",
+      translationProvider: fakeProvider,
+      strategy: "skip_existing",
+    });
+    expect(result).toBeNull(); // nothing to translate — target already filled
+  });
+
+  it("respects skip_existing: translates when target is empty", async () => {
+    const result = await translateContent({
+      schema: [{ name: "title", type: "text", localized: true }],
+      sourceData: { title: "hello" },
+      targetData: {},
+      sourceLng: "en",
+      targetLng: "de",
+      translationProvider: fakeProvider,
+      strategy: "skip_existing",
+    });
+    expect(result).toEqual({ title: "T:hello" });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/translateContent.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/translateContent.ts
@@ -1,0 +1,63 @@
+import type { Field } from "payload";
+
+import type { TranslationProvider } from "../translation-providers";
+import { TranslationPipeline } from "./TranslationPipeline";
+import { createTranslationStrategy } from "./strategies";
+import type { TranslationStrategyName } from "./strategies";
+
+export type TranslateContentArgs = {
+  /** Schema subtree to translate (e.g. `[declaredFieldConfig]`). */
+  schema: Field[];
+  /** Source values, rooted to match `schema` (e.g. `{ [fieldName]: value }`). */
+  sourceData: Record<string, unknown>;
+  /**
+   * Existing target-locale values to reconcile against (target wins when
+   * non-empty under `skip_existing`). Defaults to `{}` — i.e. translate the
+   * source in place (`overwrite`).
+   */
+  targetData?: Record<string, unknown>;
+  /** Source language code, or `''` for provider auto-detect. */
+  sourceLng: string;
+  targetLng: string;
+  translationProvider: TranslationProvider;
+  /** @default 'overwrite' */
+  strategy?: TranslationStrategyName;
+};
+
+/**
+ * Translate a content object over a schema subtree — no DB, no document.
+ *
+ * A thin reusable entry over {@link TranslationPipeline}, which is already pure
+ * and walks any `Field[]` + matching data (a subtree + partial data works
+ * unchanged). The document level routes through this wrapper today (instead of
+ * constructing the pipeline inline); the upcoming field level will too —
+ * passing a single declared field's subtree + its current unsaved form value.
+ *
+ * Only `localized` text/richText leaves are translated; non-localized values
+ * are reconciled through unchanged. Returns the translated data (same shape as
+ * `sourceData`) or `null` when nothing was translatable.
+ */
+export async function translateContent({
+  schema,
+  sourceData,
+  targetData = {},
+  sourceLng,
+  targetLng,
+  translationProvider,
+  strategy = "overwrite",
+}: TranslateContentArgs): Promise<Record<string, unknown> | null> {
+  const pipeline = new TranslationPipeline({
+    translationProvider,
+    translationStrategy: createTranslationStrategy(strategy),
+  });
+
+  const result = await pipeline.execute({
+    schema,
+    sourceData,
+    targetData,
+    sourceLng,
+    targetLng,
+  });
+
+  return result ? result.translatedData : null;
+}


### PR DESCRIPTION
**Phase 0b** of the [translation-levels plan](packages/payload-plugin-translator/docs/plans/2026-06-08-translation-levels-plan.md) — internal groundwork, no public API or behavior change.

## What

Add `translateContent({ schema, sourceData, targetData?, sourceLng, targetLng, translationProvider, strategy? })` — a thin reusable entry over the already-pure `TranslationPipeline` that translates a content object **over a schema subtree** (no DB, no document). Route `TranslateDocumentHandler` through it, replacing its inline pipeline construction so the boilerplate lives in one place.

The upcoming field-level endpoint (Phase 2) reuses the same entry to translate a single declared field's **unsaved form value** — the investigation confirmed the pipeline already handles a subtree + partial data unchanged, so no core change was needed.

## Why a wrapper

It now has a real caller (the document handler) — it dedupes the `createTranslationStrategy → new TranslationPipeline → execute → unwrap` boilerplate, and Phase 2 will be its second caller. (The speculative `fieldSubtree` helper was dropped during review — it'll be inlined in the field-feature module when that exists.)

## Scope & release

- Internal only — `translateContent` is exported from the `translation-pipeline` module barrel, **not** from the package entry (`src/index.ts`). Consumers see nothing new.
- Behavior-preserving for the document level (existing handler tests + a new test asserting the handler forwards `schema/sourceData/targetData/locales/strategy/provider` into `translateContent`).
- `chore` → **no release**; the minor bump lands with the actual field-level feature (Phases 2–3).

## Quality

- `tsgo --noEmit` ✓ · `vitest` ✓ **563 passed** (new `translateContent.test.ts`: leaf / group / array / blocks / null / skip_existing both halves) · `ultracite` ✓ 0 errors
- Reviewed via `/simplify` + `/iterative-review` (4 angles + fixer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)