### PR TITLE
chore(translator): decouple SyncRunner from configure→create ordering

### DIFF
--- a/packages/payload-plugin-translator/docs/plans/2026-06-08-translation-levels-plan.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-08-translation-levels-plan.md
@@ -13,7 +13,7 @@ text-like fields + wrappers (richText write-back deferred). Default levels stay
 
 - **0a. Contract tests for the 6 routes.** Pin path + method + access-guard + error-wrapper →
   status/body for `enqueue`, `run/:id`, `cancel`, `cancel-by-collection`, `get-document-status`,
-  `get-collection-status`. (Handlers already cover status codes; this pins the route *wiring* so the
+  `get-collection-status`. (Handlers already cover status codes; this pins the route _wiring_ so the
   Phase 1 relocation is verifiably behavior-preserving.) Lowest-risk; can be partial if Phase 1
   keeps route construction identical.
 - **0b. `translateContent()` + subtree resolver.** No core change (pipeline already pure). Add a
@@ -21,10 +21,25 @@ text-like fields + wrappers (richText write-back deferred). Default levels stay
   `{ [name]: value }`; add `translateContent(subtreeSchema, values, src, tgt)` that calls the
   existing `TranslationPipeline`. Unit-test on a leaf field, a group wrapper, and a nested
   array/blocks subtree. **Direct building block of Phase 2.**
-- **0c. Idempotent `configure()` + de-couple `SyncRunner`.** Guard `PayloadJobsRunnerProvider.configure`
-  against double-registering task/autoRun (so two levels sharing a runner configure it once). Remove
-  `SyncRunnerProvider`'s mutable `this.handler` / "create() throws unless configure() first" coupling.
-  Prerequisite for per-level runners.
+- **0c. De-couple `SyncRunner` from configure→create ordering.** Prerequisite for per-level runners.
+
+  `SyncRunnerProvider` stashed `this.handler` in `configure()` and `create()` threw unless it was set
+  first — a temporal coupling on mutable instance state (needed because `SyncTaskRunner` runs the
+  translation inline on enqueue, with no Payload task to bake the handler into). Fix: the handler now
+  flows through `create(payload, context)`, and the plugin binds the context **once** into a narrow
+  `TaskRunnerFactory` (`{ create(payload) }`) that the 6 routes depend on. The provider keeps no
+  mutable handler state and `create()` is a pure function of its arguments — no "configure() first"
+  ordering. Routes never `configure()`, so the narrower factory type is also more honest.
+
+  > **Idempotent `configure()` — moved to Phase 1, not done here.** An earlier 0c draft added a guard
+  > inside `PayloadJobsRunnerProvider.configure()` (skip if the task slug is already in
+  > `config.jobs.tasks`) so two levels sharing a runner wouldn't double-register task/autoRun/onInit.
+  > Dropped: it's a content-sniffing belt at the wrong layer, and moving the state onto the provider
+  > (an instance `configured` flag, "singleton") is worse — the flag sticks across `Config` objects
+  > and would silently skip registration on hot-reload / a second `buildConfig`. Idempotency belongs
+  > at the **orchestration layer**: Phase 1 configures each _distinct_ runner exactly once via
+  > `new Set(levels.map(l => l.runner))`, deduped by instance identity. Until levels exist there is a
+  > single runner configured exactly once — so no guard is needed today, and the provider stays pure.
 
 ## Phase 1 — Levels refactoring (no new features)
 
@@ -33,7 +48,10 @@ text-like fields + wrappers (richText write-back deferred). Default levels stay
 - Move the existing admin components (document popup → `documentLevel`, bulk dashboard →
   `collectionLevel`) into their level modules.
 - The 6 job-API routes stay **one shared bundle**, registered when any job-based level is present.
-- Per-level runner with **deduplication** (configure each distinct runner once — uses 0c).
+- Per-level runner with **deduplication**: configure each _distinct_ runner exactly once —
+  `new Set(levels.map(l => l.runner ?? rootRunner))`, deduped by instance identity. **This is where
+  `configure()` idempotency lives** — no guard inside the provider. Each distinct runner also gets one
+  bound `TaskRunnerFactory` (introduced in 0c), so no `create()`-site changes are needed here.
 - Add optional `levels` config field, default `[documentLevel(), collectionLevel()]`. Omitted =
   exactly today's behavior.
 - Exit criteria: Phase 0a contract tests + existing suite green (pure relocation).
@@ -42,7 +60,7 @@ text-like fields + wrappers (richText write-back deferred). Default levels stay
 
 - `fieldLevel({ mode: 'in-place' })` factory.
 - `POST {basePath}/field` — synchronous endpoint: receives `{ collectionSlug, fieldPath, value,
-  targetLng }`, runs `translateContent` (0b), returns the translated subtree. **No persistence.**
+targetLng }`, runs `translateContent` (0b), returns the translated subtree. **No persistence.**
 - Security: enforce `AccessGuard`; validate `fieldPath` exists in the collection `schemaMap`; content
   size limit.
 - Tests: leaf + wrapper; localized-only (non-localized skipped); access denied; unknown fieldPath.

--- a/packages/payload-plugin-translator/src/plugin.ts
+++ b/packages/payload-plugin-translator/src/plugin.ts
@@ -1,19 +1,19 @@
-import type { CollectionConfig, Config } from 'payload'
+import type { CollectionConfig, Config } from "payload";
 
-import { CacheProviderExport } from './client/app/cache/CacheProvider.export'
-import { BulkDocumentTranslationDashboard } from './client/widgets/bulk-translation-dashboard/ui/BulkTranslationDashboard.export'
-import { TranslateDocumentExport } from './client/widgets/translate-document'
-import type { AccessGuard } from './types/AccessGuard'
-import type { TranslationProvider } from './server/modules/translation-providers'
-import type { TaskRunnerProvider } from './server/modules/task-runner'
-import { TranslateDocumentHandler } from './server/features/translate-document'
-import { createEnqueueRoute } from './server/features/enqueue-translation'
-import { createRunRoute } from './server/features/run-translation'
-import { createCancelRoute } from './server/features/cancel'
-import { createCancelByCollectionRoute } from './server/features/cancel-by-collection'
-import { createGetDocumentStatusRoute } from './server/features/get-document-status'
-import { createGetCollectionStatusRoute } from './server/features/get-collection-status'
-import { normalizePath, pipe } from './server/shared'
+import { CacheProviderExport } from "./client/app/cache/CacheProvider.export";
+import { BulkDocumentTranslationDashboard } from "./client/widgets/bulk-translation-dashboard/ui/BulkTranslationDashboard.export";
+import { TranslateDocumentExport } from "./client/widgets/translate-document";
+import type { AccessGuard } from "./types/AccessGuard";
+import type { TranslationProvider } from "./server/modules/translation-providers";
+import type { TaskRunnerProvider, TaskRunnerContext, TaskRunnerFactory } from "./server/modules/task-runner";
+import { TranslateDocumentHandler } from "./server/features/translate-document";
+import { createEnqueueRoute } from "./server/features/enqueue-translation";
+import { createRunRoute } from "./server/features/run-translation";
+import { createCancelRoute } from "./server/features/cancel";
+import { createCancelByCollectionRoute } from "./server/features/cancel-by-collection";
+import { createGetDocumentStatusRoute } from "./server/features/get-document-status";
+import { createGetCollectionStatusRoute } from "./server/features/get-collection-status";
+import { normalizePath, pipe } from "./server/shared";
 
 export type TranslatorPluginConfig = {
   /**
@@ -21,34 +21,34 @@ export type TranslatorPluginConfig = {
    * IMPORTANT: Must be the original collection objects, NOT sanitized configs from payload.collections.
    * Original schemas preserve `localized: true` on nested fields.
    */
-  collections: CollectionConfig[]
+  collections: CollectionConfig[];
   /**
    * Translation provider implementation (e.g., OpenAI, DeepL).
    * Handles the actual text translation.
    */
-  translationProvider: TranslationProvider
+  translationProvider: TranslationProvider;
   /**
    * Task runner backend for background task execution.
    * Use createPayloadJobsRunner() for Payload Jobs integration.
    */
-  runner: TaskRunnerProvider
+  runner: TaskRunnerProvider;
   /**
    * Access guard for translation endpoints.
    * Controls who can trigger translations via API.
    * @default undefined (no access restrictions)
    */
-  access?: AccessGuard
+  access?: AccessGuard;
   /**
    * Base path for all translation API endpoints.
    * Useful to avoid conflicts with existing routes.
    * @example '/my-translate' results in '/my-translate/enqueue', '/my-translate/run/:id', etc.
    * @default '/translate'
    */
-  basePath?: string
-}
+  basePath?: string;
+};
 
 /** @deprecated Use `TranslatorPluginConfig` instead */
-export type TranslateCollectionPluginConfig = TranslatorPluginConfig
+export type TranslateCollectionPluginConfig = TranslatorPluginConfig;
 
 /** @deprecated Use `translatorPlugin` function instead */
 export class TranslateCollectionPlugin {
@@ -56,7 +56,7 @@ export class TranslateCollectionPlugin {
 
   init(): (config: Config) => Promise<Config> {
     return async (config) => {
-      const { access, translationProvider, basePath: rawBasePath = '/translate' } = this.pluginConfig
+      const { access, translationProvider, basePath: rawBasePath = "/translate" } = this.pluginConfig;
 
       // Build schema map from deep-cloned collections
       // Deep clone is required because Payload mutates the original collection objects,
@@ -66,14 +66,12 @@ export class TranslateCollectionPlugin {
       // TODO: Consider introducing a FieldLike interface with only the properties
       // used by the pipeline (name, type, localized, fields, blocks, tabs, custom)
       // to make the contract explicit and avoid reliance on JSON round-trip.
-      const schemaMap = new Map(
-        this.pluginConfig.collections.map((col) => [col.slug, JSON.parse(JSON.stringify(col.fields))]),
-      )
-      const collectionSlugs = new Set(schemaMap.keys())
-      const basePath = normalizePath(rawBasePath)
-      const translateHandler = new TranslateDocumentHandler(translationProvider, schemaMap)
+      const schemaMap = new Map(this.pluginConfig.collections.map((col) => [col.slug, JSON.parse(JSON.stringify(col.fields))]));
+      const collectionSlugs = new Set(schemaMap.keys());
+      const basePath = normalizePath(rawBasePath);
+      const translateHandler = new TranslateDocumentHandler(translationProvider, schemaMap);
 
-      const runnerConfigModifier = this.pluginConfig.runner.configure({
+      const runnerContext: TaskRunnerContext = {
         handler: async (payload, input) => {
           await translateHandler.handle(payload, {
             collection: input.collection,
@@ -82,45 +80,51 @@ export class TranslateCollectionPlugin {
             targetLng: input.targetLng,
             strategy: input.strategy,
             publishOnTranslation: input.publishOnTranslation,
-          })
+          });
         },
         collections: Array.from(collectionSlugs),
-      })
+      };
+      const runnerConfigModifier = this.pluginConfig.runner.configure(runnerContext);
+
+      // Bind the context once so routes receive a self-sufficient factory: the
+      // runner needs no mutable per-instance handler state and create() has no
+      // "configure() must run first" ordering coupling (translator plan, 0c).
+      const taskRunnerFactory: TaskRunnerFactory = {
+        create: (payload) => this.pluginConfig.runner.create(payload, runnerContext.handler),
+      };
 
       return pipe<Config>(
         // 1. Set up UI component provider import
         (cfg) => {
-          if (!cfg.admin) cfg.admin = {}
-          if (!cfg.admin.components) cfg.admin.components = {}
-          if (!cfg.admin.components.providers) cfg.admin.components.providers = []
+          if (!cfg.admin) cfg.admin = {};
+          if (!cfg.admin.components) cfg.admin.components = {};
+          if (!cfg.admin.components.providers) cfg.admin.components.providers = [];
 
-          cfg.admin.components.providers.push(new CacheProviderExport(basePath))
-          return cfg
+          cfg.admin.components.providers.push(new CacheProviderExport(basePath));
+          return cfg;
         },
 
         // 2. Set up UI component import
         (cfg) => {
           cfg.collections?.forEach((collection) => {
             if (!collectionSlugs.has(collection.slug)) {
-              return
+              return;
             }
 
-            if (!collection.admin) collection.admin = {}
-            if (!collection.admin.components) collection.admin.components = {}
-            if (!collection.admin.components.edit) collection.admin.components.edit = {}
+            if (!collection.admin) collection.admin = {};
+            if (!collection.admin.components) collection.admin.components = {};
+            if (!collection.admin.components.edit) collection.admin.components.edit = {};
             if (!collection.admin.components.edit.beforeDocumentControls) {
-              collection.admin.components.edit.beforeDocumentControls = []
+              collection.admin.components.edit.beforeDocumentControls = [];
             }
             if (!collection.admin.components.beforeListTable) {
-              collection.admin.components.beforeListTable = []
+              collection.admin.components.beforeListTable = [];
             }
 
-            collection.admin.components.edit.beforeDocumentControls.push(
-              new TranslateDocumentExport(collection, access),
-            )
-            collection.admin.components.beforeListTable.push(new BulkDocumentTranslationDashboard(access))
-          })
-          return cfg
+            collection.admin.components.edit.beforeDocumentControls.push(new TranslateDocumentExport(collection, access));
+            collection.admin.components.beforeListTable.push(new BulkDocumentTranslationDashboard(access));
+          });
+          return cfg;
         },
 
         // 3. Runner configures jobs/tasks/autorun
@@ -128,22 +132,22 @@ export class TranslateCollectionPlugin {
 
         // 4. Add global endpoints
         (cfg) => {
-          if (!cfg.endpoints) cfg.endpoints = []
-          const collectionConfig = { availableCollections: collectionSlugs }
+          if (!cfg.endpoints) cfg.endpoints = [];
+          const collectionConfig = { availableCollections: collectionSlugs };
           cfg.endpoints.push(
             ...[
-              createEnqueueRoute(this.pluginConfig.runner, collectionConfig, access, basePath),
-              createRunRoute(this.pluginConfig.runner, access, basePath),
-              createCancelRoute(this.pluginConfig.runner, access, basePath),
-              createCancelByCollectionRoute(collectionConfig, this.pluginConfig.runner, access, basePath),
-              createGetDocumentStatusRoute(collectionConfig, this.pluginConfig.runner, access, basePath),
-              createGetCollectionStatusRoute(collectionConfig, this.pluginConfig.runner, access, basePath),
-            ],
-          )
-          return cfg
-        },
-      )(config)
-    }
+              createEnqueueRoute(taskRunnerFactory, collectionConfig, access, basePath),
+              createRunRoute(taskRunnerFactory, access, basePath),
+              createCancelRoute(taskRunnerFactory, access, basePath),
+              createCancelByCollectionRoute(collectionConfig, taskRunnerFactory, access, basePath),
+              createGetDocumentStatusRoute(collectionConfig, taskRunnerFactory, access, basePath),
+              createGetCollectionStatusRoute(collectionConfig, taskRunnerFactory, access, basePath),
+            ]
+          );
+          return cfg;
+        }
+      )(config);
+    };
   }
 }
 
@@ -164,8 +168,8 @@ export class TranslateCollectionPlugin {
  * ```
  */
 export function translatorPlugin(config: TranslatorPluginConfig): (config: Config) => Promise<Config> {
-  return new TranslateCollectionPlugin(config).init()
+  return new TranslateCollectionPlugin(config).init();
 }
 
 /** @deprecated Use `translatorPlugin` instead */
-export const createTranslatePlugin = translatorPlugin
+export const createTranslatePlugin = translatorPlugin;

--- a/packages/payload-plugin-translator/src/server/features/cancel-by-collection/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/cancel-by-collection/handler.test.ts
@@ -1,37 +1,37 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { Payload, PayloadRequest, CollectionSlug } from 'payload'
-import { CancelByCollectionHandler } from './handler'
-import type { CancelConfig } from './model'
-import type { TaskRunnerProvider, TaskRunner, Task } from '../../modules/task-runner'
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Payload, PayloadRequest, CollectionSlug } from "payload";
+import { CancelByCollectionHandler } from "./handler";
+import type { CancelConfig } from "./model";
+import type { TaskRunnerFactory, TaskRunner, Task } from "../../modules/task-runner";
 
-describe('CancelByCollectionHandler', () => {
-  let handler: CancelByCollectionHandler
-  let mockTaskRunner: TaskRunner
-  let mockTaskRunnerFactory: TaskRunnerProvider
-  let config: CancelConfig
+describe("CancelByCollectionHandler", () => {
+  let handler: CancelByCollectionHandler;
+  let mockTaskRunner: TaskRunner;
+  let mockTaskRunnerFactory: TaskRunnerFactory;
+  let config: CancelConfig;
 
   const createMockTask = (overrides: Partial<Task> = {}): Task => ({
-    id: 'task-123',
-    status: 'pending',
+    id: "task-123",
+    status: "pending",
     input: {
-      collectionSlug: 'posts' as CollectionSlug,
-      collectionId: 'doc-123',
-      sourceLng: 'en',
-      targetLng: 'de',
-      strategy: 'overwrite',
+      collectionSlug: "posts" as CollectionSlug,
+      collectionId: "doc-123",
+      sourceLng: "en",
+      targetLng: "de",
+      strategy: "overwrite",
       publishOnTranslation: false,
     },
-    createdAt: '2024-01-01T00:00:00Z',
-    updatedAt: '2024-01-01T01:00:00Z',
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T01:00:00Z",
     cancelled: false,
     ...overrides,
-  })
+  });
 
   const createMockRequest = (params: Record<string, string> = {}): PayloadRequest =>
     ({
       payload: {} as Payload,
       routeParams: params,
-    }) as unknown as PayloadRequest
+    }) as unknown as PayloadRequest;
 
   beforeEach(() => {
     mockTaskRunner = {
@@ -39,125 +39,118 @@ describe('CancelByCollectionHandler', () => {
       cancel: vi.fn().mockResolvedValue(undefined),
       run: vi.fn(),
       findByCollection: vi.fn().mockResolvedValue([]),
-    }
+    };
 
     mockTaskRunnerFactory = {
       create: vi.fn().mockReturnValue(mockTaskRunner),
-      configure: vi.fn(),
-    }
+    };
 
     config = {
-      availableCollections: new Set(['posts', 'pages'] as CollectionSlug[]),
-    }
+      availableCollections: new Set(["posts", "pages"] as CollectionSlug[]),
+    };
 
-    handler = new CancelByCollectionHandler(config, mockTaskRunnerFactory)
-  })
+    handler = new CancelByCollectionHandler(config, mockTaskRunnerFactory);
+  });
 
-  describe('validation', () => {
-    it('returns validation error for missing collection_slug', async () => {
-      const req = createMockRequest({})
+  describe("validation", () => {
+    it("returns validation error for missing collection_slug", async () => {
+      const req = createMockRequest({});
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-      const body = await response.json()
-      expect(body.message).toBe('Validation error')
-    })
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.message).toBe("Validation error");
+    });
 
-    it('returns validation error for empty collection_slug', async () => {
-      const req = createMockRequest({ collection_slug: '' })
+    it("returns validation error for empty collection_slug", async () => {
+      const req = createMockRequest({ collection_slug: "" });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-    })
-  })
+      expect(response.status).toBe(400);
+    });
+  });
 
-  describe('collection availability', () => {
-    it('returns bad request for unavailable collection', async () => {
-      const req = createMockRequest({ collection_slug: 'users' })
+  describe("collection availability", () => {
+    it("returns bad request for unavailable collection", async () => {
+      const req = createMockRequest({ collection_slug: "users" });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-      const body = await response.json()
-      expect(body.message).toBe('Collection not available for translation')
-    })
-  })
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.message).toBe("Collection not available for translation");
+    });
+  });
 
-  describe('no tasks to cancel', () => {
-    it('returns 204 when no tasks exist for collection', async () => {
-      ;(mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([])
+  describe("no tasks to cancel", () => {
+    it("returns 204 when no tasks exist for collection", async () => {
+      (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
-      const req = createMockRequest({ collection_slug: 'posts' })
-      const response = await handler.handle(req)
+      const req = createMockRequest({ collection_slug: "posts" });
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(204)
-      expect(response.body).toBeNull()
-    })
+      expect(response.status).toBe(204);
+      expect(response.body).toBeNull();
+    });
 
-    it('returns 204 when all tasks are already completed', async () => {
+    it("returns 204 when all tasks are already completed", async () => {
+      const tasks = [createMockTask({ id: "task-1", status: "completed" }), createMockTask({ id: "task-2", status: "failed" })];
+      (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue(tasks);
+
+      const req = createMockRequest({ collection_slug: "posts" });
+      const response = await handler.handle(req);
+
+      expect(response.status).toBe(204);
+      expect(mockTaskRunner.cancel).not.toHaveBeenCalled();
+    });
+
+    it("returns 204 when all tasks are running (not pending)", async () => {
+      const tasks = [createMockTask({ id: "task-1", status: "running" }), createMockTask({ id: "task-2", status: "running" })];
+      (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue(tasks);
+
+      const req = createMockRequest({ collection_slug: "posts" });
+      const response = await handler.handle(req);
+
+      expect(response.status).toBe(204);
+      expect(mockTaskRunner.cancel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cancelling pending tasks", () => {
+    it("cancels only pending tasks", async () => {
       const tasks = [
-        createMockTask({ id: 'task-1', status: 'completed' }),
-        createMockTask({ id: 'task-2', status: 'failed' }),
-      ]
-      ;(mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue(tasks)
+        createMockTask({ id: "task-1", status: "pending" }),
+        createMockTask({ id: "task-2", status: "running" }),
+        createMockTask({ id: "task-3", status: "pending" }),
+        createMockTask({ id: "task-4", status: "completed" }),
+      ];
+      (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue(tasks);
 
-      const req = createMockRequest({ collection_slug: 'posts' })
-      const response = await handler.handle(req)
+      const req = createMockRequest({ collection_slug: "posts" });
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(204)
-      expect(mockTaskRunner.cancel).not.toHaveBeenCalled()
-    })
+      expect(response.status).toBe(204);
+      expect(mockTaskRunner.cancel).toHaveBeenCalledWith(["task-1", "task-3"]);
+    });
 
-    it('returns 204 when all tasks are running (not pending)', async () => {
-      const tasks = [
-        createMockTask({ id: 'task-1', status: 'running' }),
-        createMockTask({ id: 'task-2', status: 'running' }),
-      ]
-      ;(mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue(tasks)
+    it("calls findByCollection with correct collection slug", async () => {
+      const req = createMockRequest({ collection_slug: "pages" });
 
-      const req = createMockRequest({ collection_slug: 'posts' })
-      const response = await handler.handle(req)
+      await handler.handle(req);
 
-      expect(response.status).toBe(204)
-      expect(mockTaskRunner.cancel).not.toHaveBeenCalled()
-    })
-  })
+      expect(mockTaskRunner.findByCollection).toHaveBeenCalledWith("pages");
+    });
 
-  describe('cancelling pending tasks', () => {
-    it('cancels only pending tasks', async () => {
-      const tasks = [
-        createMockTask({ id: 'task-1', status: 'pending' }),
-        createMockTask({ id: 'task-2', status: 'running' }),
-        createMockTask({ id: 'task-3', status: 'pending' }),
-        createMockTask({ id: 'task-4', status: 'completed' }),
-      ]
-      ;(mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue(tasks)
+    it("creates task runner with request payload", async () => {
+      const mockPayload = { collections: {} } as Payload;
+      const req = createMockRequest({ collection_slug: "posts" });
+      (req as any).payload = mockPayload;
 
-      const req = createMockRequest({ collection_slug: 'posts' })
-      const response = await handler.handle(req)
+      await handler.handle(req);
 
-      expect(response.status).toBe(204)
-      expect(mockTaskRunner.cancel).toHaveBeenCalledWith(['task-1', 'task-3'])
-    })
-
-    it('calls findByCollection with correct collection slug', async () => {
-      const req = createMockRequest({ collection_slug: 'pages' })
-
-      await handler.handle(req)
-
-      expect(mockTaskRunner.findByCollection).toHaveBeenCalledWith('pages')
-    })
-
-    it('creates task runner with request payload', async () => {
-      const mockPayload = { collections: {} } as Payload
-      const req = createMockRequest({ collection_slug: 'posts' })
-      ;(req as any).payload = mockPayload
-
-      await handler.handle(req)
-
-      expect(mockTaskRunnerFactory.create).toHaveBeenCalledWith(mockPayload)
-    })
-  })
-})
+      expect(mockTaskRunnerFactory.create).toHaveBeenCalledWith(mockPayload);
+    });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/features/cancel-by-collection/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/cancel-by-collection/handler.ts
@@ -1,11 +1,11 @@
 import type { PayloadRequest } from "payload";
 
 import { ServerResponse } from "../../shared";
-import type { TaskRunnerProvider } from "../../modules/task-runner";
+import type { TaskRunnerFactory } from "../../modules/task-runner";
 import { isCollectionAvailable } from "../_lib/collection-utils";
 
-import { CancelByCollectionInputSchema } from './model';
-import type { CancelConfig } from './model';
+import { CancelByCollectionInputSchema } from "./model";
+import type { CancelConfig } from "./model";
 
 /**
  * Cancels all pending translation tasks for a collection
@@ -13,7 +13,7 @@ import type { CancelConfig } from './model';
 export class CancelByCollectionHandler {
   constructor(
     private readonly config: CancelConfig,
-    private readonly taskRunnerFactory: TaskRunnerProvider
+    private readonly taskRunnerFactory: TaskRunnerFactory
   ) {}
 
   async handle(req: PayloadRequest): Promise<Response> {

--- a/packages/payload-plugin-translator/src/server/features/cancel-by-collection/route.ts
+++ b/packages/payload-plugin-translator/src/server/features/cancel-by-collection/route.ts
@@ -1,26 +1,21 @@
-import type { Endpoint } from 'payload'
+import type { Endpoint } from "payload";
 
-import { withErrorHandler, withAccessCheck } from '../../shared'
-import type { AccessGuard } from '../../shared'
-import type { TaskRunnerProvider } from '../../modules/task-runner'
+import { withErrorHandler, withAccessCheck } from "../../shared";
+import type { AccessGuard } from "../../shared";
+import type { TaskRunnerFactory } from "../../modules/task-runner";
 
-import type { CancelConfig } from './model'
-import { CancelByCollectionHandler } from './handler'
+import type { CancelConfig } from "./model";
+import { CancelByCollectionHandler } from "./handler";
 
 /**
  * Creates the cancel by collection endpoint
  */
-export function createCancelByCollectionRoute(
-  config: CancelConfig,
-  taskRunnerFactory: TaskRunnerProvider,
-  access?: AccessGuard,
-  basePath = '/translate',
-): Endpoint {
-  const handler = new CancelByCollectionHandler(config, taskRunnerFactory)
+export function createCancelByCollectionRoute(config: CancelConfig, taskRunnerFactory: TaskRunnerFactory, access?: AccessGuard, basePath = "/translate"): Endpoint {
+  const handler = new CancelByCollectionHandler(config, taskRunnerFactory);
 
   return {
     path: `${basePath}/cancel-by-collection/:collection_slug`,
-    method: 'delete',
+    method: "delete",
     handler: withAccessCheck(withErrorHandler(handler.handle.bind(handler)), access),
-  }
+  };
 }

--- a/packages/payload-plugin-translator/src/server/features/cancel/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/cancel/handler.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Payload, PayloadRequest } from "payload";
 import { CancelHandler } from "./handler";
-import type { TaskRunner, TaskRunnerProvider } from "../../modules/task-runner";
+import type { TaskRunner, TaskRunnerFactory } from "../../modules/task-runner";
 
 describe("CancelHandler", () => {
   let handler: CancelHandler;
   let mockTaskRunner: TaskRunner;
-  let mockTaskRunnerFactory: TaskRunnerProvider;
+  let mockTaskRunnerFactory: TaskRunnerFactory;
 
   const createMockRequest = (body: unknown): PayloadRequest =>
     ({
@@ -24,7 +24,6 @@ describe("CancelHandler", () => {
 
     mockTaskRunnerFactory = {
       create: vi.fn().mockReturnValue(mockTaskRunner),
-      configure: vi.fn(),
     };
 
     handler = new CancelHandler(mockTaskRunnerFactory);
@@ -73,11 +72,7 @@ describe("CancelHandler", () => {
 
       await handler.handle(req);
 
-      expect(mockTaskRunner.cancel).toHaveBeenCalledWith([
-        "task-1",
-        "task-2",
-        "task-3",
-      ]);
+      expect(mockTaskRunner.cancel).toHaveBeenCalledWith(["task-1", "task-2", "task-3"]);
     });
 
     it("coerces numeric ids to strings (autoincrement DB ids)", async () => {

--- a/packages/payload-plugin-translator/src/server/features/cancel/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/cancel/handler.ts
@@ -1,7 +1,7 @@
 import type { PayloadRequest } from "payload";
 
 import { ServerResponse } from "../../shared";
-import type { TaskRunnerProvider } from "../../modules/task-runner";
+import type { TaskRunnerFactory } from "../../modules/task-runner";
 
 import { CancelInputSchema } from "./model";
 
@@ -9,11 +9,13 @@ import { CancelInputSchema } from "./model";
  * Cancels and deletes translation tasks by IDs
  */
 export class CancelHandler {
-  constructor(private readonly taskRunnerFactory: TaskRunnerProvider) {}
+  constructor(private readonly taskRunnerFactory: TaskRunnerFactory) {}
 
   async handle(req: PayloadRequest): Promise<Response> {
     const validationResult = CancelInputSchema.safeParse(await req.json?.());
-    if (validationResult.error) return ServerResponse.validationError(validationResult.error.issues);
+    if (validationResult.error) {
+      return ServerResponse.validationError(validationResult.error.issues);
+    }
 
     const { ids } = validationResult.data;
     const runner = this.taskRunnerFactory.create(req.payload);

--- a/packages/payload-plugin-translator/src/server/features/cancel/route.ts
+++ b/packages/payload-plugin-translator/src/server/features/cancel/route.ts
@@ -1,24 +1,20 @@
-import type { Endpoint } from 'payload'
+import type { Endpoint } from "payload";
 
-import { withErrorHandler, withAccessCheck } from '../../shared'
-import type { AccessGuard } from '../../shared'
-import type { TaskRunnerProvider } from '../../modules/task-runner'
+import { withErrorHandler, withAccessCheck } from "../../shared";
+import type { AccessGuard } from "../../shared";
+import type { TaskRunnerFactory } from "../../modules/task-runner";
 
-import { CancelHandler } from './handler'
+import { CancelHandler } from "./handler";
 
 /**
  * Creates the batch cancel endpoint
  */
-export function createCancelRoute(
-  taskRunnerFactory: TaskRunnerProvider,
-  access?: AccessGuard,
-  basePath = '/translate',
-): Endpoint {
-  const handler = new CancelHandler(taskRunnerFactory)
+export function createCancelRoute(taskRunnerFactory: TaskRunnerFactory, access?: AccessGuard, basePath = "/translate"): Endpoint {
+  const handler = new CancelHandler(taskRunnerFactory);
 
   return {
     path: `${basePath}/cancel`,
-    method: 'delete',
+    method: "delete",
     handler: withAccessCheck(withErrorHandler(handler.handle.bind(handler)), access),
-  }
+  };
 }

--- a/packages/payload-plugin-translator/src/server/features/enqueue-translation/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/enqueue-translation/handler.test.ts
@@ -1,146 +1,145 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { Payload, PayloadRequest, CollectionSlug } from 'payload'
-import { EnqueueTranslationHandler } from './handler'
-import type { EnqueueConfig } from './model'
-import type { TaskRunnerProvider, TaskRunner } from '../../modules/task-runner'
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Payload, PayloadRequest, CollectionSlug } from "payload";
+import { EnqueueTranslationHandler } from "./handler";
+import type { EnqueueConfig } from "./model";
+import type { TaskRunnerFactory, TaskRunner } from "../../modules/task-runner";
 
 // Mock collection-utils
-vi.mock('../_lib/collection-utils', () => ({
+vi.mock("../_lib/collection-utils", () => ({
   isCollectionAvailable: vi.fn((slug: string, available: Set<string>) => (available.has(slug) ? slug : null)),
-  getAllCollectionIds: vi.fn().mockResolvedValue(['doc-1', 'doc-2', 'doc-3']),
-}))
+  getAllCollectionIds: vi.fn().mockResolvedValue(["doc-1", "doc-2", "doc-3"]),
+}));
 
-describe('EnqueueTranslationHandler', () => {
-  let handler: EnqueueTranslationHandler
-  let mockTaskRunner: TaskRunner
-  let mockTaskRunnerFactory: TaskRunnerProvider
-  let config: EnqueueConfig
+describe("EnqueueTranslationHandler", () => {
+  let handler: EnqueueTranslationHandler;
+  let mockTaskRunner: TaskRunner;
+  let mockTaskRunnerFactory: TaskRunnerFactory;
+  let config: EnqueueConfig;
 
   const createMockRequest = (body: unknown): PayloadRequest =>
     ({
       payload: {} as Payload,
       json: vi.fn().mockResolvedValue(body),
-    }) as unknown as PayloadRequest
+    }) as unknown as PayloadRequest;
 
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.clearAllMocks();
 
     mockTaskRunner = {
       enqueue: vi.fn().mockResolvedValue(undefined),
       cancel: vi.fn(),
       run: vi.fn(),
       findByCollection: vi.fn(),
-    }
+    };
 
     mockTaskRunnerFactory = {
       create: vi.fn().mockReturnValue(mockTaskRunner),
-      configure: vi.fn(),
-    }
+    };
 
     config = {
-      availableCollections: new Set(['posts', 'pages'] as CollectionSlug[]),
-    }
+      availableCollections: new Set(["posts", "pages"] as CollectionSlug[]),
+    };
 
-    handler = new EnqueueTranslationHandler(config, mockTaskRunnerFactory)
-  })
+    handler = new EnqueueTranslationHandler(config, mockTaskRunnerFactory);
+  });
 
-  describe('validation', () => {
-    it('returns validation error for missing required fields', async () => {
-      const req = createMockRequest({})
+  describe("validation", () => {
+    it("returns validation error for missing required fields", async () => {
+      const req = createMockRequest({});
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-    })
+      expect(response.status).toBe(400);
+    });
 
-    it('returns validation error for missing source_lng', async () => {
+    it("returns validation error for missing source_lng", async () => {
       const req = createMockRequest({
-        target_lng: 'de',
-        collection_slug: 'posts',
-        collection_id: ['doc-1'],
-      })
+        target_lng: "de",
+        collection_slug: "posts",
+        collection_id: ["doc-1"],
+      });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-    })
-  })
+      expect(response.status).toBe(400);
+    });
+  });
 
-  describe('collection availability', () => {
-    it('returns bad request for unavailable collection', async () => {
+  describe("collection availability", () => {
+    it("returns bad request for unavailable collection", async () => {
       const req = createMockRequest({
-        source_lng: 'en',
-        target_lng: 'de',
-        collection_slug: 'users',
-        collection_id: ['doc-1'],
-        strategy: 'overwrite',
-      })
+        source_lng: "en",
+        target_lng: "de",
+        collection_slug: "users",
+        collection_id: ["doc-1"],
+        strategy: "overwrite",
+      });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-      const body = await response.json()
-      expect(body.message).toContain('not available for translation')
-    })
-  })
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.message).toContain("not available for translation");
+    });
+  });
 
-  describe('success responses', () => {
-    it('enqueues tasks for specific documents', async () => {
+  describe("success responses", () => {
+    it("enqueues tasks for specific documents", async () => {
       const req = createMockRequest({
-        source_lng: 'en',
-        target_lng: 'de',
-        collection_slug: 'posts',
-        collection_id: ['doc-1', 'doc-2'],
-        strategy: 'overwrite',
-      })
+        source_lng: "en",
+        target_lng: "de",
+        collection_slug: "posts",
+        collection_id: ["doc-1", "doc-2"],
+        strategy: "overwrite",
+      });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(200)
-      const body = await response.json()
-      expect(body.data).toEqual({ success: true, queued: 2 })
-    })
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.data).toEqual({ success: true, queued: 2 });
+    });
 
-    it('calls runner.enqueue with correct tasks', async () => {
+    it("calls runner.enqueue with correct tasks", async () => {
       const req = createMockRequest({
-        source_lng: 'en',
-        target_lng: 'fr',
-        collection_slug: 'posts',
-        collection_id: ['doc-123'],
-        strategy: 'skip_existing',
-      })
+        source_lng: "en",
+        target_lng: "fr",
+        collection_slug: "posts",
+        collection_id: ["doc-123"],
+        strategy: "skip_existing",
+      });
 
-      await handler.handle(req)
+      await handler.handle(req);
 
       expect(mockTaskRunner.enqueue).toHaveBeenCalledWith([
         {
-          collectionSlug: 'posts',
-          collectionId: 'doc-123',
-          sourceLng: 'en',
-          targetLng: 'fr',
-          strategy: 'skip_existing',
+          collectionSlug: "posts",
+          collectionId: "doc-123",
+          sourceLng: "en",
+          targetLng: "fr",
+          strategy: "skip_existing",
           publishOnTranslation: false,
         },
-      ])
-    })
+      ]);
+    });
 
     // Note: select_all test skipped - requires non-empty collection_id in schema validation
     // This is a schema design decision that should be tested at integration level
 
-    it('creates task runner with request payload', async () => {
-      const mockPayload = { collections: {} } as Payload
+    it("creates task runner with request payload", async () => {
+      const mockPayload = { collections: {} } as Payload;
       const req = createMockRequest({
-        source_lng: 'en',
-        target_lng: 'de',
-        collection_slug: 'posts',
-        collection_id: ['doc-1'],
-        strategy: 'overwrite',
-      })
-      ;(req as any).payload = mockPayload
+        source_lng: "en",
+        target_lng: "de",
+        collection_slug: "posts",
+        collection_id: ["doc-1"],
+        strategy: "overwrite",
+      });
+      (req as any).payload = mockPayload;
 
-      await handler.handle(req)
+      await handler.handle(req);
 
-      expect(mockTaskRunnerFactory.create).toHaveBeenCalledWith(mockPayload)
-    })
-  })
-})
+      expect(mockTaskRunnerFactory.create).toHaveBeenCalledWith(mockPayload);
+    });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/features/enqueue-translation/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/enqueue-translation/handler.ts
@@ -1,11 +1,11 @@
 import type { PayloadRequest } from "payload";
 
 import { ServerResponse } from "../../shared";
-import type { TaskRunnerProvider } from "../../modules/task-runner";
+import type { TaskRunnerFactory } from "../../modules/task-runner";
 import { isCollectionAvailable, getAllCollectionIds } from "../_lib/collection-utils";
 
-import { EnqueueInputSchema } from './model';
-import type { EnqueueConfig } from './model';
+import { EnqueueInputSchema } from "./model";
+import type { EnqueueConfig } from "./model";
 
 /**
  * Enqueues translation tasks for documents
@@ -13,7 +13,7 @@ import type { EnqueueConfig } from './model';
 export class EnqueueTranslationHandler {
   constructor(
     private readonly config: EnqueueConfig,
-    private readonly taskRunnerFactory: TaskRunnerProvider
+    private readonly taskRunnerFactory: TaskRunnerFactory
   ) {}
 
   async handle(req: PayloadRequest): Promise<Response> {

--- a/packages/payload-plugin-translator/src/server/features/enqueue-translation/route.ts
+++ b/packages/payload-plugin-translator/src/server/features/enqueue-translation/route.ts
@@ -1,26 +1,21 @@
-import type { Endpoint } from 'payload'
+import type { Endpoint } from "payload";
 
-import { withErrorHandler, withAccessCheck } from '../../shared'
-import type { AccessGuard } from '../../shared'
-import type { TaskRunnerProvider } from '../../modules/task-runner'
+import { withErrorHandler, withAccessCheck } from "../../shared";
+import type { AccessGuard } from "../../shared";
+import type { TaskRunnerFactory } from "../../modules/task-runner";
 
-import type { EnqueueConfig } from './model'
-import { EnqueueTranslationHandler } from './handler'
+import type { EnqueueConfig } from "./model";
+import { EnqueueTranslationHandler } from "./handler";
 
 /**
  * Creates the enqueue translation endpoint
  */
-export function createEnqueueRoute(
-  taskRunnerFactory: TaskRunnerProvider,
-  config: EnqueueConfig,
-  access?: AccessGuard,
-  basePath = '/translate',
-): Endpoint {
-  const handler = new EnqueueTranslationHandler(config, taskRunnerFactory)
+export function createEnqueueRoute(taskRunnerFactory: TaskRunnerFactory, config: EnqueueConfig, access?: AccessGuard, basePath = "/translate"): Endpoint {
+  const handler = new EnqueueTranslationHandler(config, taskRunnerFactory);
 
   return {
     path: `${basePath}/enqueue`,
-    method: 'post',
+    method: "post",
     handler: withAccessCheck(withErrorHandler(handler.handle.bind(handler)), access),
-  }
+  };
 }

--- a/packages/payload-plugin-translator/src/server/features/get-collection-status/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-collection-status/handler.test.ts
@@ -1,38 +1,38 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { Payload, PayloadRequest, CollectionSlug } from 'payload'
-import { GetCollectionStatusHandler } from './handler'
-import type { GetCollectionStatusConfig } from './model'
-import type { TaskRunnerProvider, TaskRunner, Task } from '../../modules/task-runner'
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Payload, PayloadRequest, CollectionSlug } from "payload";
+import { GetCollectionStatusHandler } from "./handler";
+import type { GetCollectionStatusConfig } from "./model";
+import type { TaskRunnerFactory, TaskRunner, Task } from "../../modules/task-runner";
 
-describe('GetCollectionStatusHandler', () => {
-  let handler: GetCollectionStatusHandler
-  let mockTaskRunner: TaskRunner
-  let mockTaskRunnerFactory: TaskRunnerProvider
-  let config: GetCollectionStatusConfig
+describe("GetCollectionStatusHandler", () => {
+  let handler: GetCollectionStatusHandler;
+  let mockTaskRunner: TaskRunner;
+  let mockTaskRunnerFactory: TaskRunnerFactory;
+  let config: GetCollectionStatusConfig;
 
   const createMockTask = (overrides: Partial<Task> = {}): Task => ({
-    id: 'task-123',
-    status: 'completed',
+    id: "task-123",
+    status: "completed",
     input: {
-      collectionSlug: 'posts' as CollectionSlug,
-      collectionId: 'doc-123',
-      sourceLng: 'en',
-      targetLng: 'de',
-      strategy: 'overwrite',
+      collectionSlug: "posts" as CollectionSlug,
+      collectionId: "doc-123",
+      sourceLng: "en",
+      targetLng: "de",
+      strategy: "overwrite",
       publishOnTranslation: false,
     },
-    createdAt: '2024-01-01T00:00:00Z',
-    updatedAt: '2024-01-01T01:00:00Z',
-    completedAt: '2024-01-01T01:00:00Z',
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T01:00:00Z",
+    completedAt: "2024-01-01T01:00:00Z",
     cancelled: false,
     ...overrides,
-  })
+  });
 
   const createMockRequest = (params: Record<string, string> = {}): PayloadRequest =>
     ({
       payload: {} as Payload,
       routeParams: params,
-    }) as unknown as PayloadRequest
+    }) as unknown as PayloadRequest;
 
   beforeEach(() => {
     mockTaskRunner = {
@@ -40,100 +40,95 @@ describe('GetCollectionStatusHandler', () => {
       cancel: vi.fn(),
       run: vi.fn(),
       findByCollection: vi.fn().mockResolvedValue([]),
-    }
+    };
 
     mockTaskRunnerFactory = {
       create: vi.fn().mockReturnValue(mockTaskRunner),
-      configure: vi.fn(),
-    }
+    };
 
     config = {
-      availableCollections: new Set(['posts', 'pages'] as CollectionSlug[]),
-    }
+      availableCollections: new Set(["posts", "pages"] as CollectionSlug[]),
+    };
 
-    handler = new GetCollectionStatusHandler(config, mockTaskRunnerFactory)
-  })
+    handler = new GetCollectionStatusHandler(config, mockTaskRunnerFactory);
+  });
 
-  describe('validation', () => {
-    it('returns validation error for missing collection_slug', async () => {
-      const req = createMockRequest({})
+  describe("validation", () => {
+    it("returns validation error for missing collection_slug", async () => {
+      const req = createMockRequest({});
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-      const body = await response.json()
-      expect(body.message).toBe('Validation error')
-    })
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.message).toBe("Validation error");
+    });
 
-    it('returns validation error for empty collection_slug', async () => {
-      const req = createMockRequest({ collection_slug: '' })
+    it("returns validation error for empty collection_slug", async () => {
+      const req = createMockRequest({ collection_slug: "" });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-    })
-  })
+      expect(response.status).toBe(400);
+    });
+  });
 
-  describe('collection availability', () => {
-    it('returns bad request for unavailable collection', async () => {
-      const req = createMockRequest({ collection_slug: 'users' })
+  describe("collection availability", () => {
+    it("returns bad request for unavailable collection", async () => {
+      const req = createMockRequest({ collection_slug: "users" });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-      const body = await response.json()
-      expect(body.message).toBe('Collection not available for translation')
-    })
-  })
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.message).toBe("Collection not available for translation");
+    });
+  });
 
-  describe('success responses', () => {
-    it('returns empty docs array when no tasks exist', async () => {
-      ;(mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([])
+  describe("success responses", () => {
+    it("returns empty docs array when no tasks exist", async () => {
+      (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
-      const req = createMockRequest({ collection_slug: 'posts' })
-      const response = await handler.handle(req)
+      const req = createMockRequest({ collection_slug: "posts" });
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(200)
-      const body = await response.json()
-      expect(body.data).toEqual({ docs: [] })
-    })
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.data).toEqual({ docs: [] });
+    });
 
-    it('returns task statuses for all documents in collection', async () => {
-      const tasks = [
-        createMockTask({ id: 'task-1', status: 'completed' }),
-        createMockTask({ id: 'task-2', status: 'pending' }),
-        createMockTask({ id: 'task-3', status: 'running' }),
-      ]
-      ;(mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue(tasks)
+    it("returns task statuses for all documents in collection", async () => {
+      const tasks = [createMockTask({ id: "task-1", status: "completed" }), createMockTask({ id: "task-2", status: "pending" }), createMockTask({ id: "task-3", status: "running" })];
+      (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue(tasks);
 
-      const req = createMockRequest({ collection_slug: 'posts' })
-      const response = await handler.handle(req)
+      const req = createMockRequest({ collection_slug: "posts" });
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(200)
-      const body = await response.json()
+      expect(response.status).toBe(200);
+      const body = await response.json();
       expect(body.data.docs).toEqual([
-        { id: 'task-1', status: 'completed' },
-        { id: 'task-2', status: 'pending' },
-        { id: 'task-3', status: 'running' },
-      ])
-    })
+        { id: "task-1", status: "completed" },
+        { id: "task-2", status: "pending" },
+        { id: "task-3", status: "running" },
+      ]);
+    });
 
-    it('calls findByCollection with correct collection slug', async () => {
-      const req = createMockRequest({ collection_slug: 'pages' })
+    it("calls findByCollection with correct collection slug", async () => {
+      const req = createMockRequest({ collection_slug: "pages" });
 
-      await handler.handle(req)
+      await handler.handle(req);
 
-      expect(mockTaskRunner.findByCollection).toHaveBeenCalledWith('pages')
-    })
+      expect(mockTaskRunner.findByCollection).toHaveBeenCalledWith("pages");
+    });
 
-    it('creates task runner with request payload', async () => {
-      const mockPayload = { collections: {} } as Payload
-      const req = createMockRequest({ collection_slug: 'posts' })
-      ;(req as any).payload = mockPayload
+    it("creates task runner with request payload", async () => {
+      const mockPayload = { collections: {} } as Payload;
+      const req = createMockRequest({ collection_slug: "posts" });
+      (req as any).payload = mockPayload;
 
-      await handler.handle(req)
+      await handler.handle(req);
 
-      expect(mockTaskRunnerFactory.create).toHaveBeenCalledWith(mockPayload)
-    })
-  })
-})
+      expect(mockTaskRunnerFactory.create).toHaveBeenCalledWith(mockPayload);
+    });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/features/get-collection-status/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-collection-status/handler.ts
@@ -1,11 +1,11 @@
 import type { PayloadRequest } from "payload";
 
 import { ServerResponse } from "../../shared";
-import type { TaskRunnerProvider } from "../../modules/task-runner";
+import type { TaskRunnerFactory } from "../../modules/task-runner";
 import { isCollectionAvailable } from "../_lib/collection-utils";
 
-import { GetCollectionStatusInputSchema } from './model';
-import type { GetCollectionStatusConfig } from './model';
+import { GetCollectionStatusInputSchema } from "./model";
+import type { GetCollectionStatusConfig } from "./model";
 
 /**
  * Gets translation status for all documents in a collection
@@ -13,7 +13,7 @@ import type { GetCollectionStatusConfig } from './model';
 export class GetCollectionStatusHandler {
   constructor(
     private readonly config: GetCollectionStatusConfig,
-    private readonly taskRunnerFactory: TaskRunnerProvider
+    private readonly taskRunnerFactory: TaskRunnerFactory
   ) {}
 
   async handle(req: PayloadRequest): Promise<Response> {

--- a/packages/payload-plugin-translator/src/server/features/get-collection-status/route.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-collection-status/route.ts
@@ -1,26 +1,21 @@
-import type { Endpoint } from 'payload'
+import type { Endpoint } from "payload";
 
-import { withErrorHandler, withAccessCheck } from '../../shared'
-import type { AccessGuard } from '../../shared'
-import type { TaskRunnerProvider } from '../../modules/task-runner'
+import { withErrorHandler, withAccessCheck } from "../../shared";
+import type { AccessGuard } from "../../shared";
+import type { TaskRunnerFactory } from "../../modules/task-runner";
 
-import type { GetCollectionStatusConfig } from './model'
-import { GetCollectionStatusHandler } from './handler'
+import type { GetCollectionStatusConfig } from "./model";
+import { GetCollectionStatusHandler } from "./handler";
 
 /**
  * Creates the get collection status endpoint
  */
-export function createGetCollectionStatusRoute(
-  config: GetCollectionStatusConfig,
-  taskRunnerFactory: TaskRunnerProvider,
-  access?: AccessGuard,
-  basePath = '/translate',
-): Endpoint {
-  const handler = new GetCollectionStatusHandler(config, taskRunnerFactory)
+export function createGetCollectionStatusRoute(config: GetCollectionStatusConfig, taskRunnerFactory: TaskRunnerFactory, access?: AccessGuard, basePath = "/translate"): Endpoint {
+  const handler = new GetCollectionStatusHandler(config, taskRunnerFactory);
 
   return {
     path: `${basePath}/collection/:collection_slug`,
-    method: 'get',
+    method: "get",
     handler: withAccessCheck(withErrorHandler(handler.handle.bind(handler)), access),
-  }
+  };
 }

--- a/packages/payload-plugin-translator/src/server/features/get-document-status/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-document-status/handler.test.ts
@@ -1,38 +1,38 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { Payload, PayloadRequest, CollectionSlug } from 'payload'
-import { GetDocumentStatusHandler } from './handler'
-import type { GetDocumentStatusConfig } from './model'
-import type { TaskRunnerProvider, TaskRunner, Task } from '../../modules/task-runner'
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Payload, PayloadRequest, CollectionSlug } from "payload";
+import { GetDocumentStatusHandler } from "./handler";
+import type { GetDocumentStatusConfig } from "./model";
+import type { TaskRunnerFactory, TaskRunner, Task } from "../../modules/task-runner";
 
-describe('GetDocumentStatusHandler', () => {
-  let handler: GetDocumentStatusHandler
-  let mockTaskRunner: TaskRunner
-  let mockTaskRunnerFactory: TaskRunnerProvider
-  let config: GetDocumentStatusConfig
+describe("GetDocumentStatusHandler", () => {
+  let handler: GetDocumentStatusHandler;
+  let mockTaskRunner: TaskRunner;
+  let mockTaskRunnerFactory: TaskRunnerFactory;
+  let config: GetDocumentStatusConfig;
 
   const createMockTask = (overrides: Partial<Task> = {}): Task => ({
-    id: 'task-123',
-    status: 'completed',
+    id: "task-123",
+    status: "completed",
     input: {
-      collectionSlug: 'posts' as CollectionSlug,
-      collectionId: 'doc-123',
-      sourceLng: 'en',
-      targetLng: 'de',
-      strategy: 'overwrite',
+      collectionSlug: "posts" as CollectionSlug,
+      collectionId: "doc-123",
+      sourceLng: "en",
+      targetLng: "de",
+      strategy: "overwrite",
       publishOnTranslation: false,
     },
-    createdAt: '2024-01-01T00:00:00Z',
-    updatedAt: '2024-01-01T01:00:00Z',
-    completedAt: '2024-01-01T01:00:00Z',
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T01:00:00Z",
+    completedAt: "2024-01-01T01:00:00Z",
     cancelled: false,
     ...overrides,
-  })
+  });
 
   const createMockRequest = (params: Record<string, string> = {}): PayloadRequest =>
     ({
       payload: {} as Payload,
       routeParams: params,
-    }) as unknown as PayloadRequest
+    }) as unknown as PayloadRequest;
 
   beforeEach(() => {
     mockTaskRunner = {
@@ -40,139 +40,162 @@ describe('GetDocumentStatusHandler', () => {
       cancel: vi.fn(),
       run: vi.fn(),
       findByCollection: vi.fn().mockResolvedValue([]),
-    }
+    };
 
     mockTaskRunnerFactory = {
       create: vi.fn().mockReturnValue(mockTaskRunner),
-      configure: vi.fn(),
-    }
+    };
 
     config = {
-      availableCollections: new Set(['posts', 'pages'] as CollectionSlug[]),
-    }
+      availableCollections: new Set(["posts", "pages"] as CollectionSlug[]),
+    };
 
-    handler = new GetDocumentStatusHandler(config, mockTaskRunnerFactory)
-  })
+    handler = new GetDocumentStatusHandler(config, mockTaskRunnerFactory);
+  });
 
-  describe('validation', () => {
-    it('returns validation error for missing collection_slug', async () => {
-      const req = createMockRequest({ collection_id: 'doc-123' })
+  describe("validation", () => {
+    it("returns validation error for missing collection_slug", async () => {
+      const req = createMockRequest({ collection_id: "doc-123" });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-      const body = await response.json()
-      expect(body.message).toBe('Validation error')
-    })
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.message).toBe("Validation error");
+    });
 
-    it('returns validation error for missing collection_id', async () => {
-      const req = createMockRequest({ collection_slug: 'posts' })
+    it("returns validation error for missing collection_id", async () => {
+      const req = createMockRequest({ collection_slug: "posts" });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-    })
+      expect(response.status).toBe(400);
+    });
 
-    it('returns validation error for empty collection_slug', async () => {
-      const req = createMockRequest({ collection_slug: '', collection_id: 'doc-123' })
+    it("returns validation error for empty collection_slug", async () => {
+      const req = createMockRequest({
+        collection_slug: "",
+        collection_id: "doc-123",
+      });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-    })
-  })
+      expect(response.status).toBe(400);
+    });
+  });
 
-  describe('collection availability', () => {
-    it('returns bad request for unavailable collection', async () => {
-      const req = createMockRequest({ collection_slug: 'users', collection_id: 'doc-123' })
+  describe("collection availability", () => {
+    it("returns bad request for unavailable collection", async () => {
+      const req = createMockRequest({
+        collection_slug: "users",
+        collection_id: "doc-123",
+      });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-      const body = await response.json()
-      expect(body.message).toBe('Collection not available for translation')
-    })
-  })
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.message).toBe("Collection not available for translation");
+    });
+  });
 
-  describe('success responses', () => {
-    it('returns task status when task exists', async () => {
-      const task = createMockTask()
-      ;(mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([task])
+  describe("success responses", () => {
+    it("returns task status when task exists", async () => {
+      const task = createMockTask();
+      (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([task]);
 
-      const req = createMockRequest({ collection_slug: 'posts', collection_id: 'doc-123' })
-      const response = await handler.handle(req)
+      const req = createMockRequest({
+        collection_slug: "posts",
+        collection_id: "doc-123",
+      });
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(200)
-      const body = await response.json()
+      expect(response.status).toBe(200);
+      const body = await response.json();
       expect(body.data).toMatchObject({
-        id: 'task-123',
-        status: 'completed',
+        id: "task-123",
+        status: "completed",
         input: {
           collection: {
-            relationTo: 'posts',
-            value: 'doc-123',
+            relationTo: "posts",
+            value: "doc-123",
           },
-          source_lng: 'en',
-          target_lng: 'de',
+          source_lng: "en",
+          target_lng: "de",
         },
-      })
-    })
+      });
+    });
 
-    it('returns null when no task exists', async () => {
-      ;(mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([])
+    it("returns null when no task exists", async () => {
+      (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
-      const req = createMockRequest({ collection_slug: 'posts', collection_id: 'doc-123' })
-      const response = await handler.handle(req)
+      const req = createMockRequest({
+        collection_slug: "posts",
+        collection_id: "doc-123",
+      });
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(200)
-      const body = await response.json()
-      expect(body.data).toBeNull()
-    })
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.data).toBeNull();
+    });
 
-    it('calls findByCollection with correct parameters', async () => {
-      const req = createMockRequest({ collection_slug: 'posts', collection_id: 'doc-456' })
+    it("calls findByCollection with correct parameters", async () => {
+      const req = createMockRequest({
+        collection_slug: "posts",
+        collection_id: "doc-456",
+      });
 
-      await handler.handle(req)
+      await handler.handle(req);
 
-      expect(mockTaskRunner.findByCollection).toHaveBeenCalledWith('posts', ['doc-456'])
-    })
+      expect(mockTaskRunner.findByCollection).toHaveBeenCalledWith("posts", ["doc-456"]);
+    });
 
-    it('creates task runner with request payload', async () => {
-      const mockPayload = { collections: {} } as Payload
-      const req = createMockRequest({ collection_slug: 'posts', collection_id: 'doc-123' })
-      ;(req as any).payload = mockPayload
+    it("creates task runner with request payload", async () => {
+      const mockPayload = { collections: {} } as Payload;
+      const req = createMockRequest({
+        collection_slug: "posts",
+        collection_id: "doc-123",
+      });
+      (req as any).payload = mockPayload;
 
-      await handler.handle(req)
+      await handler.handle(req);
 
-      expect(mockTaskRunnerFactory.create).toHaveBeenCalledWith(mockPayload)
-    })
-  })
+      expect(mockTaskRunnerFactory.create).toHaveBeenCalledWith(mockPayload);
+    });
+  });
 
-  describe('task status transformation', () => {
-    it('includes error information when present', async () => {
+  describe("task status transformation", () => {
+    it("includes error information when present", async () => {
       const task = createMockTask({
-        status: 'failed',
-        error: { message: 'Translation failed' },
-      })
-      ;(mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([task])
+        status: "failed",
+        error: { message: "Translation failed" },
+      });
+      (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([task]);
 
-      const req = createMockRequest({ collection_slug: 'posts', collection_id: 'doc-123' })
-      const response = await handler.handle(req)
+      const req = createMockRequest({
+        collection_slug: "posts",
+        collection_id: "doc-123",
+      });
+      const response = await handler.handle(req);
 
-      const body = await response.json()
-      expect(body.data.status).toBe('failed')
-      expect(body.data.error).toEqual({ message: 'Translation failed' })
-    })
+      const body = await response.json();
+      expect(body.data.status).toBe("failed");
+      expect(body.data.error).toEqual({ message: "Translation failed" });
+    });
 
-    it('includes cancelled flag', async () => {
-      const task = createMockTask({ cancelled: true })
-      ;(mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([task])
+    it("includes cancelled flag", async () => {
+      const task = createMockTask({ cancelled: true });
+      (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([task]);
 
-      const req = createMockRequest({ collection_slug: 'posts', collection_id: 'doc-123' })
-      const response = await handler.handle(req)
+      const req = createMockRequest({
+        collection_slug: "posts",
+        collection_id: "doc-123",
+      });
+      const response = await handler.handle(req);
 
-      const body = await response.json()
-      expect(body.data.cancelled).toBe(true)
-    })
-  })
-})
+      const body = await response.json();
+      expect(body.data.cancelled).toBe(true);
+    });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/features/get-document-status/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-document-status/handler.ts
@@ -1,11 +1,11 @@
 import type { PayloadRequest } from "payload";
 
 import { ServerResponse } from "../../shared";
-import type { TaskRunnerProvider } from "../../modules/task-runner";
+import type { TaskRunnerFactory } from "../../modules/task-runner";
 import { isCollectionAvailable } from "../_lib/collection-utils";
 
-import { GetDocumentStatusInputSchema, taskToJobStatusOutput } from './model';
-import type { GetDocumentStatusConfig } from './model';
+import { GetDocumentStatusInputSchema, taskToJobStatusOutput } from "./model";
+import type { GetDocumentStatusConfig } from "./model";
 
 /**
  * Gets the translation status for a specific document
@@ -13,7 +13,7 @@ import type { GetDocumentStatusConfig } from './model';
 export class GetDocumentStatusHandler {
   constructor(
     private readonly config: GetDocumentStatusConfig,
-    private readonly taskRunnerFactory: TaskRunnerProvider
+    private readonly taskRunnerFactory: TaskRunnerFactory
   ) {}
 
   async handle(req: PayloadRequest): Promise<Response> {

--- a/packages/payload-plugin-translator/src/server/features/get-document-status/route.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-document-status/route.ts
@@ -1,26 +1,21 @@
-import type { Endpoint } from 'payload'
+import type { Endpoint } from "payload";
 
-import { withErrorHandler, withAccessCheck } from '../../shared'
-import type { AccessGuard } from '../../shared'
-import type { TaskRunnerProvider } from '../../modules/task-runner'
+import { withErrorHandler, withAccessCheck } from "../../shared";
+import type { AccessGuard } from "../../shared";
+import type { TaskRunnerFactory } from "../../modules/task-runner";
 
-import type { GetDocumentStatusConfig } from './model'
-import { GetDocumentStatusHandler } from './handler'
+import type { GetDocumentStatusConfig } from "./model";
+import { GetDocumentStatusHandler } from "./handler";
 
 /**
  * Creates the get document status endpoint
  */
-export function createGetDocumentStatusRoute(
-  config: GetDocumentStatusConfig,
-  taskRunnerFactory: TaskRunnerProvider,
-  access?: AccessGuard,
-  basePath = '/translate',
-): Endpoint {
-  const handler = new GetDocumentStatusHandler(config, taskRunnerFactory)
+export function createGetDocumentStatusRoute(config: GetDocumentStatusConfig, taskRunnerFactory: TaskRunnerFactory, access?: AccessGuard, basePath = "/translate"): Endpoint {
+  const handler = new GetDocumentStatusHandler(config, taskRunnerFactory);
 
   return {
     path: `${basePath}/document/:collection_slug/:collection_id`,
-    method: 'get',
+    method: "get",
     handler: withAccessCheck(withErrorHandler(handler.handle.bind(handler)), access),
-  }
+  };
 }

--- a/packages/payload-plugin-translator/src/server/features/run-translation/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/run-translation/handler.test.ts
@@ -1,18 +1,18 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { Payload, PayloadRequest } from 'payload'
-import { RunTranslationHandler } from './handler'
-import type { TaskRunnerProvider, TaskRunner } from '../../modules/task-runner'
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Payload, PayloadRequest } from "payload";
+import { RunTranslationHandler } from "./handler";
+import type { TaskRunnerFactory, TaskRunner } from "../../modules/task-runner";
 
-describe('RunTranslationHandler', () => {
-  let handler: RunTranslationHandler
-  let mockTaskRunner: TaskRunner
-  let mockTaskRunnerFactory: TaskRunnerProvider
+describe("RunTranslationHandler", () => {
+  let handler: RunTranslationHandler;
+  let mockTaskRunner: TaskRunner;
+  let mockTaskRunnerFactory: TaskRunnerFactory;
 
   const createMockRequest = (params: Record<string, string> = {}): PayloadRequest =>
     ({
       payload: {} as Payload,
       routeParams: params,
-    }) as unknown as PayloadRequest
+    }) as unknown as PayloadRequest;
 
   beforeEach(() => {
     mockTaskRunner = {
@@ -20,107 +20,108 @@ describe('RunTranslationHandler', () => {
       cancel: vi.fn(),
       run: vi.fn().mockResolvedValue({ success: true }),
       findByCollection: vi.fn(),
-    }
+    };
 
     mockTaskRunnerFactory = {
       create: vi.fn().mockReturnValue(mockTaskRunner),
-      configure: vi.fn(),
-    }
+    };
 
-    handler = new RunTranslationHandler(mockTaskRunnerFactory)
-  })
+    handler = new RunTranslationHandler(mockTaskRunnerFactory);
+  });
 
-  describe('validation', () => {
-    it('returns validation error for missing id', async () => {
-      const req = createMockRequest({})
+  describe("validation", () => {
+    it("returns validation error for missing id", async () => {
+      const req = createMockRequest({});
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-      const body = await response.json()
-      expect(body.message).toBe('Validation error')
-    })
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.message).toBe("Validation error");
+    });
 
-    it('returns validation error for empty id', async () => {
-      const req = createMockRequest({ id: '' })
+    it("returns validation error for empty id", async () => {
+      const req = createMockRequest({ id: "" });
 
-      const response = await handler.handle(req)
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(400)
-    })
-  })
+      expect(response.status).toBe(400);
+    });
+  });
 
-  describe('success responses', () => {
-    it('returns 204 on successful run', async () => {
-      ;(mockTaskRunner.run as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true })
+  describe("success responses", () => {
+    it("returns 204 on successful run", async () => {
+      (mockTaskRunner.run as ReturnType<typeof vi.fn>).mockResolvedValue({
+        success: true,
+      });
 
-      const req = createMockRequest({ id: 'task-123' })
-      const response = await handler.handle(req)
+      const req = createMockRequest({ id: "task-123" });
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(204)
-      expect(response.body).toBeNull()
-    })
+      expect(response.status).toBe(204);
+      expect(response.body).toBeNull();
+    });
 
-    it('calls runner.run with correct task id', async () => {
-      const req = createMockRequest({ id: 'task-456' })
+    it("calls runner.run with correct task id", async () => {
+      const req = createMockRequest({ id: "task-456" });
 
-      await handler.handle(req)
+      await handler.handle(req);
 
-      expect(mockTaskRunner.run).toHaveBeenCalledWith('task-456')
-    })
+      expect(mockTaskRunner.run).toHaveBeenCalledWith("task-456");
+    });
 
-    it('creates task runner with request payload', async () => {
-      const mockPayload = { collections: {} } as Payload
-      const req = createMockRequest({ id: 'task-123' })
-      ;(req as any).payload = mockPayload
+    it("creates task runner with request payload", async () => {
+      const mockPayload = { collections: {} } as Payload;
+      const req = createMockRequest({ id: "task-123" });
+      (req as any).payload = mockPayload;
 
-      await handler.handle(req)
+      await handler.handle(req);
 
-      expect(mockTaskRunnerFactory.create).toHaveBeenCalledWith(mockPayload)
-    })
-  })
+      expect(mockTaskRunnerFactory.create).toHaveBeenCalledWith(mockPayload);
+    });
+  });
 
-  describe('error responses', () => {
-    it('returns 404 when task not found', async () => {
-      ;(mockTaskRunner.run as ReturnType<typeof vi.fn>).mockResolvedValue({
+  describe("error responses", () => {
+    it("returns 404 when task not found", async () => {
+      (mockTaskRunner.run as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: false,
-        error: 'not_found',
-      })
+        error: "not_found",
+      });
 
-      const req = createMockRequest({ id: 'non-existent' })
-      const response = await handler.handle(req)
+      const req = createMockRequest({ id: "non-existent" });
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(404)
-      const body = await response.json()
-      expect(body.message).toBe('Queued task not found')
-    })
+      expect(response.status).toBe(404);
+      const body = await response.json();
+      expect(body.message).toBe("Queued task not found");
+    });
 
-    it('returns 404 when task already completed', async () => {
-      ;(mockTaskRunner.run as ReturnType<typeof vi.fn>).mockResolvedValue({
+    it("returns 404 when task already completed", async () => {
+      (mockTaskRunner.run as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: false,
-        error: 'already_completed',
-      })
+        error: "already_completed",
+      });
 
-      const req = createMockRequest({ id: 'completed-task' })
-      const response = await handler.handle(req)
+      const req = createMockRequest({ id: "completed-task" });
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(404)
-      const body = await response.json()
-      expect(body.message).toBe('Queued task not found')
-    })
+      expect(response.status).toBe(404);
+      const body = await response.json();
+      expect(body.message).toBe("Queued task not found");
+    });
 
-    it('returns 429 when task is already running', async () => {
-      ;(mockTaskRunner.run as ReturnType<typeof vi.fn>).mockResolvedValue({
+    it("returns 429 when task is already running", async () => {
+      (mockTaskRunner.run as ReturnType<typeof vi.fn>).mockResolvedValue({
         success: false,
-        error: 'already_running',
-      })
+        error: "already_running",
+      });
 
-      const req = createMockRequest({ id: 'running-task' })
-      const response = await handler.handle(req)
+      const req = createMockRequest({ id: "running-task" });
+      const response = await handler.handle(req);
 
-      expect(response.status).toBe(429)
-      const body = await response.json()
-      expect(body.message).toBe('Translation task is already in progress')
-    })
-  })
-})
+      expect(response.status).toBe(429);
+      const body = await response.json();
+      expect(body.message).toBe("Translation task is already in progress");
+    });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/features/run-translation/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/run-translation/handler.ts
@@ -1,7 +1,7 @@
 import type { PayloadRequest } from "payload";
 
 import { ServerResponse } from "../../shared";
-import type { TaskRunnerProvider } from "../../modules/task-runner";
+import type { TaskRunnerFactory } from "../../modules/task-runner";
 
 import { RunInputSchema } from "./model";
 
@@ -9,7 +9,7 @@ import { RunInputSchema } from "./model";
  * Runs a translation task by ID
  */
 export class RunTranslationHandler {
-  constructor(private readonly taskRunnerFactory: TaskRunnerProvider) {}
+  constructor(private readonly taskRunnerFactory: TaskRunnerFactory) {}
 
   async handle(req: PayloadRequest): Promise<Response> {
     const validationResult = RunInputSchema.safeParse(req.routeParams);

--- a/packages/payload-plugin-translator/src/server/features/run-translation/route.ts
+++ b/packages/payload-plugin-translator/src/server/features/run-translation/route.ts
@@ -1,24 +1,20 @@
-import type { Endpoint } from 'payload'
+import type { Endpoint } from "payload";
 
-import { withErrorHandler, withAccessCheck } from '../../shared'
-import type { AccessGuard } from '../../shared'
-import type { TaskRunnerProvider } from '../../modules/task-runner'
+import { withErrorHandler, withAccessCheck } from "../../shared";
+import type { AccessGuard } from "../../shared";
+import type { TaskRunnerFactory } from "../../modules/task-runner";
 
-import { RunTranslationHandler } from './handler'
+import { RunTranslationHandler } from "./handler";
 
 /**
  * Creates the run translation endpoint
  */
-export function createRunRoute(
-  taskRunnerFactory: TaskRunnerProvider,
-  access?: AccessGuard,
-  basePath = '/translate',
-): Endpoint {
-  const handler = new RunTranslationHandler(taskRunnerFactory)
+export function createRunRoute(taskRunnerFactory: TaskRunnerFactory, access?: AccessGuard, basePath = "/translate"): Endpoint {
+  const handler = new RunTranslationHandler(taskRunnerFactory);
 
   return {
     path: `${basePath}/run/:id`,
-    method: 'post',
+    method: "post",
     handler: withAccessCheck(withErrorHandler(handler.handle.bind(handler)), access),
-  }
+  };
 }

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/TaskRunnerProvider.interface.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/TaskRunnerProvider.interface.ts
@@ -29,6 +29,17 @@ export type TaskRunnerContext = {
 };
 
 /**
+ * The runtime half of a runner: produces a `TaskRunner` for one request.
+ *
+ * Routes depend on this narrow surface — they only ever `create()`, never
+ * `configure()`. The plugin binds the {@link TaskRunnerContext} once at build
+ * time and hands routes a factory, so a `create()` call needs no ambient state.
+ */
+export type TaskRunnerFactory = {
+  create(payload: Payload): TaskRunner;
+};
+
+/**
  * Main interface for pluggable task runner providers.
  *
  * Implementations handle their own initialization (jobs, queues, etc.)
@@ -40,8 +51,15 @@ export type TaskRunnerContext = {
 export interface TaskRunnerProvider {
   /**
    * Creates a TaskRunner instance for runtime operations (enqueue, cancel, find).
+   *
+   * `handler` is supplied by the caller at create time (the plugin binds it
+   * into a {@link TaskRunnerFactory}) — so providers hold no mutable per-instance
+   * state and `create()` does not depend on `configure()` having run. It is the
+   * only runtime dependency (collection metadata is a `configure()`-time concern).
+   * `PayloadJobsRunner` ignores it (the handler is baked into the registered
+   * task at configure time); `SyncRunner` uses it to run translations inline.
    */
-  create(payload: Payload): TaskRunner;
+  create(payload: Payload, handler: TaskHandler): TaskRunner;
 
   /**
    * Configures the runner and returns a Payload config modifier.

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/index.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/index.ts
@@ -1,6 +1,6 @@
-export type { TaskRunnerProvider } from './TaskRunnerProvider.interface'
-export type { Task, TaskStatus } from './types'
-export { createPayloadJobsRunner } from './payload-jobs-runner'
-export type { PayloadJobsRunnerOptions } from './payload-jobs-runner'
-export { createSyncRunner } from './sync-runner'
-export type { TaskRunner } from './TaskRunner.interface'
+export type { TaskRunnerProvider, TaskRunnerFactory, TaskRunnerContext } from "./TaskRunnerProvider.interface";
+export type { Task, TaskStatus } from "./types";
+export { createPayloadJobsRunner } from "./payload-jobs-runner";
+export type { PayloadJobsRunnerOptions } from "./payload-jobs-runner";
+export { createSyncRunner } from "./sync-runner";
+export type { TaskRunner } from "./TaskRunner.interface";

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncRunnerProvider.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncRunnerProvider.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Payload, CollectionSlug } from "payload";
+
+import { createSyncRunner } from "./SyncRunnerProvider";
+import type { TaskRunnerContext } from "../TaskRunnerProvider.interface";
+import type { TaskInput } from "../types";
+
+const fakePayload = {} as Payload;
+
+const makeContext = (handler: TaskRunnerContext["handler"]): TaskRunnerContext => ({
+  handler,
+  collections: ["pages" as CollectionSlug],
+});
+
+const sampleInput: TaskInput = {
+  collectionSlug: "pages" as CollectionSlug,
+  collectionId: "1",
+  sourceLng: "en",
+  targetLng: "de",
+  strategy: "overwrite",
+  publishOnTranslation: false,
+};
+
+describe("SyncRunnerProvider", () => {
+  // The decoupling guarantee (translator plan, 0c): create() takes its handler
+  // from the caller-supplied argument, so it no longer depends on a prior
+  // configure() call mutating instance state.
+  it("create() works without a prior configure() call", () => {
+    const runner = createSyncRunner();
+    expect(() => runner.create(fakePayload, vi.fn())).not.toThrow();
+  });
+
+  it("runs translations through the supplied handler on enqueue", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const runner = createSyncRunner();
+
+    const taskRunner = runner.create(fakePayload, handler);
+    await taskRunner.enqueue([sampleInput]);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      fakePayload,
+      expect.objectContaining({
+        collection: "pages",
+        collectionId: "1",
+        sourceLng: "en",
+        targetLng: "de",
+        strategy: "overwrite",
+        publishOnTranslation: false,
+      })
+    );
+  });
+
+  it("configure() is a no-op modifier (sync runner adds no Payload jobs)", () => {
+    const runner = createSyncRunner();
+    const config = { jobs: {} } as never;
+    expect(runner.configure(makeContext(vi.fn()))(config)).toBe(config);
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncRunnerProvider.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncRunnerProvider.ts
@@ -1,14 +1,14 @@
-import type { Config, Payload } from 'payload'
+import type { Config, Payload } from "payload";
 
-import type { TaskRunner } from '../TaskRunner.interface'
-import type { TaskRunnerProvider, TaskRunnerContext, TaskHandler } from '../TaskRunnerProvider.interface'
-import type { Task } from '../types'
-import type { SyncRunnerOptions } from './types'
-import { SyncTaskRunner } from './SyncTaskRunner'
-import { LazyMap } from '../../../shared/utils'
+import type { TaskRunner } from "../TaskRunner.interface";
+import type { TaskRunnerProvider, TaskHandler } from "../TaskRunnerProvider.interface";
+import type { Task } from "../types";
+import type { SyncRunnerOptions } from "./types";
+import { SyncTaskRunner } from "./SyncTaskRunner";
+import { LazyMap } from "../../../shared/utils";
 
-const DEFAULT_MAX_SIZE = 100
-const DEFAULT_TTL_MS = 60 * 60 * 1000 // 1 hour
+const DEFAULT_MAX_SIZE = 100;
+const DEFAULT_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 /**
  * Synchronous TaskRunnerProvider implementation.
@@ -17,29 +17,31 @@ const DEFAULT_TTL_MS = 60 * 60 * 1000 // 1 hour
  * Useful for development, testing, or simple use cases.
  */
 export class SyncRunnerProvider implements TaskRunnerProvider {
-  private handler?: TaskHandler
-  private readonly tasks: LazyMap<string, Task>
+  private readonly tasks: LazyMap<string, Task>;
 
   constructor(options?: SyncRunnerOptions) {
-    const maxSize = options?.maxSize ?? DEFAULT_MAX_SIZE
-    const ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS
+    const maxSize = options?.maxSize ?? DEFAULT_MAX_SIZE;
+    const ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
 
     this.tasks = new LazyMap<string, Task>({
       maxSize,
       ttlMs,
-      isRemovable: (task) => task.status === 'completed' || task.status === 'failed',
+      isRemovable: (task) => task.status === "completed" || task.status === "failed",
       getTimestamp: (task) => new Date(task.updatedAt).getTime(),
-    })
+    });
   }
 
-  create(payload: Payload): TaskRunner {
-    if (!this.handler) throw new Error('SyncRunnerProvider not configured. Call configure() first.')
-    return new SyncTaskRunner(payload, this.handler, this.tasks)
+  // SyncRunner executes the translation inline on enqueue, so it needs the
+  // handler at create time — taken from the caller-supplied argument rather than
+  // stashed on the instance during configure(). No ambient state, no ordering
+  // coupling: create() is a pure function of its arguments.
+  create(payload: Payload, handler: TaskHandler): TaskRunner {
+    return new SyncTaskRunner(payload, handler, this.tasks);
   }
 
-  configure(context: TaskRunnerContext): (config: Config) => Config {
-    this.handler = context.handler
-    return (config) => config
+  // No config changes needed — translations run synchronously, no Payload jobs.
+  configure(): (config: Config) => Config {
+    return (config) => config;
   }
 }
 
@@ -50,5 +52,5 @@ export class SyncRunnerProvider implements TaskRunnerProvider {
  * Results are stored in memory and lost on server restart.
  */
 export function createSyncRunner(options?: SyncRunnerOptions): TaskRunnerProvider {
-  return new SyncRunnerProvider(options)
+  return new SyncRunnerProvider(options);
 }


### PR DESCRIPTION
**0c** of the [translation-levels plan](packages/payload-plugin-translator/docs/plans/2026-06-08-translation-levels-plan.md) — internal refactor, **no user-facing change**.

## What

Pass the task handler to `TaskRunnerProvider.create(payload, handler)` instead of stashing it on the provider during `configure()`.

- **`SyncRunnerProvider`**: drops mutable `this.handler` and the *"not configured"* throw. `create(payload, handler)` is now a pure function of its arguments — no dependency on `configure()` having run first. `configure()` is a no-op modifier.
- **`TaskRunnerFactory`** (`{ create(payload) }`): the narrow runtime surface the 6 routes actually need (they never `configure()`). The plugin binds the runner context **once** at build time into a factory and hands that to the routes.
- **`PayloadJobsRunnerProvider`**: unchanged — its handler is baked into the registered task at `configure()` time, so it ignores the create-time handler.
- `create()`'s second arg is `TaskHandler` (the only runtime dependency), **not** the full `TaskRunnerContext` — `collections` is a configure-time concern and was never read at create time.

## Why

Removes a temporal coupling (mutable instance state + "configure-before-create" ordering) before Phase 1 introduces per-level runners. The idempotent-`configure()` guard from an earlier 0c draft was **dropped** — idempotency belongs at the plugin orchestration layer (Phase 1 will configure each distinct runner once via a `Set`), not as a content-sniffing guard inside the provider.

## Semver — `chore`, no release

`TaskRunnerProvider.create()` gains a second param and the type is public, but:
- **source-compatible** — existing single-arg `create(payload)` implementations still satisfy the interface (fewer params is assignable in TS; `tsgo` confirms);
- **runtime-compatible** — the extra arg is ignored by such implementations;
- built-in runners (what consumers use via `createPayloadJobsRunner()` / `createSyncRunner()`) are behaviour-preserving.

The minor version bump lands with the `levels` feature in Phase 1.

## Notes

- The large line count is mostly **oxfmt normalization** of touched old-style files (single→double quotes, semicolons) applied by the pre-commit hook; the logical change is small. Reviewers read files from disk, not the diff.
- `PayloadJobsRunnerProvider` deliberately left untouched (kept out of the diff).

## Quality

- `tsgo --noEmit` ✓ · `vitest` ✓ **566 passed** (new `SyncRunnerProvider.test.ts`: create() works without configure(), runs the supplied handler with the full field mapping, configure() is a no-op) · `ultracite` ✓ 0 errors
- Reviewed via `/simplify` (applied: narrow `create` arg to `handler`) + `/iterative-review` (4 angles; one "critical" finding refuted by a green type-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)