### PR TITLE
docs(translator): Phase 1 levels design + reconcile plan docs

### DIFF
--- a/packages/payload-plugin-translator/docs/DEPRECATIONS.md
+++ b/packages/payload-plugin-translator/docs/DEPRECATIONS.md
@@ -34,7 +34,7 @@ the single source of truth — code annotations link here by anchor instead of d
 
 - **What:** the `collection` field (Payload `relationship`) in the translate task `inputSchema`.
 - **Status:** live
-- **Deprecated:** 2026-06-05 / PR #TBD
+- **Deprecated:** 2026-06-05 / PR #18 (shipped in 0.3.0)
 - **Replacement:** flat text reference — `collection_slug` + `collection_id`.
 - **Remove in:** next major
 - **Why:** the relationship field validates the stored value's type against the target collection's

--- a/packages/payload-plugin-translator/docs/plans/2026-06-05-foundation-prep-plan.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-05-foundation-prep-plan.md
@@ -1,7 +1,7 @@
 # Foundation Prep Plan
 
 **Date:** 2026-06-05
-**Status:** Proposed
+**Status:** In progress (§1 shipped; §2 mostly shipped — see PR refs; §3 API unification still queued for the major)
 **Related:** [Translation Levels Design](./2026-06-05-translation-levels-design.md)
 
 ## Overview
@@ -36,23 +36,24 @@ cost.
 
 ## 2. Levels prerequisites (minor)
 
-- [ ] **Contract tests for the 6 existing routes** (request/response shapes: `enqueue`, `run/:id`,
-      `cancel`, `cancel-by-collection`, `get-document-status`, `get-collection-status`) — written
-      **before** any relocation, so "pure refactoring, tests stay green" is verifiable.
-- [ ] **Subtree `translateContent()` wrapper** — NOT a core extraction. Investigated: the core is
-      already pure and reusable. `TranslationPipeline.execute({ schema, sourceData, targetData,
-      sourceLng, targetLng })` is a relative recursive walk over any `Field[]` + matching data
-      (collector/reconciler/mutator carry no DB, root, or absolute-path assumptions), so a schema
-      subtree + partial data works unchanged. Work needed: a resolver that, for a declared field
-      path, produces `[fieldConfig]` + data rooted as `{ [name]: value }`, and a thin
-      `translateContent()` entry that calls the existing pipeline. Prerequisite for `POST /field`.
-- [ ] **Idempotent `runner.configure()`** + the "one runner is configured exactly once" contract —
-      required before per-level runners. Includes removing the temporal coupling in
-      `SyncRunnerProvider` (`create()` throws unless `configure()` was called first — mutable
-      provider state).
+- [x] **Contract tests for the 6 existing routes** (`enqueue`, `run/:id`, `cancel`,
+      `cancel-by-collection`, `get-document-status`, `get-collection-status`) — ✅ shipped (PR #24):
+      path + method + access-guard wiring pinned, before any relocation, so "pure refactoring, tests
+      stay green" is verifiable. (Also extracted the 6 into a `createTranslationRoutes()` bundle.)
+- [x] **`translateContent()` wrapper** — ✅ shipped (PR #22). NOT a core extraction: the core is
+      already pure and reusable (`TranslationPipeline.execute({ schema, sourceData, targetData,
+      sourceLng, targetLng })` is a relative recursive walk over any `Field[]` + matching data —
+      collector/reconciler/mutator carry no DB, root, or absolute-path assumptions). The **subtree
+      resolver** (declared field path → `[fieldConfig]` + data rooted as `{ [name]: value }`) was
+      **deferred to Phase 2** — it has no caller until `POST /field`, so building it now was premature.
+- [x] **De-couple `SyncRunner` from the configure→create ordering** — ✅ shipped (PR #23): the handler
+      flows through `create(payload, handler)`; no mutable provider state, no "configure() first"
+      coupling. **Idempotent `runner.configure()` / "one runner configured once" was dropped** — it is
+      an orchestration concern and moot in Phase 1 (single root runner, configured once); it returns
+      only if per-level runners are added later.
 - [ ] **Introduce optional `levels` config field** with default `[documentLevel(),
-    collectionLevel()]` — non-breaking by construction. (Implementation itself tracked by the
-      levels design doc; this item is only the config surface + back-compat default.)
+    collectionLevel()]` — non-breaking by construction. (Phase 1 — see the
+      [Phase 1 design](./2026-06-09-translation-levels-phase1-design.md).)
 
 ## 3. API surface unification (minor: deprecate, major: remove)
 

--- a/packages/payload-plugin-translator/docs/plans/2026-06-05-jobs-id-agnostic-migration.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-05-jobs-id-agnostic-migration.md
@@ -1,7 +1,7 @@
 # Jobs ID-Agnostic Migration (expand/contract)
 
 **Date:** 2026-06-05
-**Status:** Proposed
+**Status:** ✅ Shipped (0.3.0 / PR #18) — the deprecated relationship fallback is removed in the next major
 **Related:** [Foundation Prep Plan](./2026-06-05-foundation-prep-plan.md) · [Deprecations Ledger](../DEPRECATIONS.md#jobs-input-collection-field)
 
 ## Overview

--- a/packages/payload-plugin-translator/docs/plans/2026-06-05-translation-levels-design.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-05-translation-levels-design.md
@@ -36,29 +36,22 @@ translatorPlugin({
   translationProvider: createOpenAIProvider({ ... }),
   runner: createPayloadJobsRunner(),          // stays = default runner for job-based levels
   levels: [
-    documentLevel(),                          // inherits root runner
-    collectionLevel({ runner: otherRunner }), // or its own
+    documentLevel(),                          // job-based, uses the root runner
+    collectionLevel(),                        // job-based, uses the root runner (per-level runner override is a future addition)
     fieldLevel({ mode: 'in-place' }),         // no runner at all
   ],
 })
 ```
 
-```ts
-interface TranslationLevel {
-  readonly name: string; // 'field' | 'document' | 'collection' | custom
-  configure(ctx: TranslationLevelContext): (config: Config) => Config;
-}
-
-type TranslationLevelContext = {
-  collections: CollectionSlug[];
-  schemaMap: Map<string, Field[]>;
-  basePath: string;
-  access?: AccessGuard;
-  translateDocument: TaskHandler; // for job-based levels (existing TranslateDocumentHandler)
-  translateContent: ContentTranslator; // for the field level: (values, src?, tgt) => translated
-  defaultRunner?: TaskRunnerProvider; // root runner inheritance
-};
-```
+> **Interface superseded — see the [Phase 1 design](./2026-06-09-translation-levels-phase1-design.md)
+> (authoritative).** The concrete level interface evolved during implementation. In short: a level
+> exposes `extend(ctx)` (not `configure()` returning a config modifier); the context provides
+> generic contribution primitives (`addEndpoints`, `addAdminProvider`, `addCollectionComponent`,
+> deduped by the plugin) instead of raw `translateDocument` / `translateContent` / `defaultRunner`;
+> there is **no public `name`/`kind`** and no `ensureJobApi` (levels are a closed-but-openable set
+> produced by factories); and `document`/`collection` share one runner while `field` is sync via
+> `translateContent` (per-level runner deferred). The earlier interface sketch was removed from this
+> doc to avoid two conflicting definitions.
 
 ### Backwards compatibility
 
@@ -67,7 +60,7 @@ type TranslationLevelContext = {
 
 ### Implementation pitfalls to handle
 
-- **Job infrastructure deduplication**: `document` and `collection` both need the task + autoRun registered. When they share one runner, its `configure()` must run exactly once — the plugin collects the _distinct set_ of runners across levels and configures each once.
+- **Job infrastructure deduplication**: `document` and `collection` both need the task + autoRun registered. **Phase 1 keeps a single root runner**, configured exactly once — no dedup needed; the runner-agnostic routes are contributed by both doc-levels and deduped by content. Once a per-level runner override exists (a future addition), the plugin collects the _distinct set_ of runners across levels and configures each once.
 
 ### Endpoints: not split per level
 
@@ -152,5 +145,5 @@ For text fields it is a trivial dispatch by path. For **Lexical richText** it re
 
 1. **Non-localized fields inside a declared wrapper → SKIPPED.** The field level translates only `localized` fields, exactly like the document level (`FieldChunkCollector` already gates on `isLocalizedField`). A non-localized value is shared across all locales, so translating it in place would corrupt every other locale. This means **no core change** — the existing pipeline's gate is correct as-is. (Superseded the earlier "translate the whole subtree" lean.)
 2. **richText → deferred (follow-up).** The bottleneck is purely the **client-side write-back** into the Lexical editor state, not translation: the server pipeline (`RichTextExpander`) already handles richText. MVP = text-like fields and wrappers, no richText write-back.
-3. **A separate, on-demand future feature** (not this work): a "translate this content" *utility* that translates a field's text regardless of `localized` — its only real value is richText (round-tripping richText through an external tool mangles formatting). It needs both relaxing the `isLocalizedField` gate AND the deferred richText write-back, so it is naturally a later, opt-in addition.
+3. **A separate, on-demand future feature** (not this work): a "translate this content" _utility_ that translates a field's text regardless of `localized` — its only real value is richText (round-tripping richText through an external tool mangles formatting). It needs both relaxing the `isLocalizedField` gate AND the deferred richText write-back, so it is naturally a later, opt-in addition.
 4. Naming/UX of the control button and the endpoint payload shape — settled during implementation.

--- a/packages/payload-plugin-translator/docs/plans/2026-06-08-translation-levels-plan.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-08-translation-levels-plan.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-08
 **Status:** Ready
-**Design:** [translation-levels-design](./2026-06-05-translation-levels-design.md) · **Groundwork:** [foundation-prep-plan](./2026-06-05-foundation-prep-plan.md)
+**Design:** [translation-levels-design](./2026-06-05-translation-levels-design.md) · **Phase 1 design:** [translation-levels-phase1-design](./2026-06-09-translation-levels-phase1-design.md) · **Groundwork:** [foundation-prep-plan](./2026-06-05-foundation-prep-plan.md)
 
 Ordered, each step a self-contained PR. Field-level translation = `in-place` mode (translate the
 current unsaved form value into the current locale, synchronously, no DB), localized fields only,
@@ -11,17 +11,19 @@ text-like fields + wrappers (richText write-back deferred). Default levels stay
 
 ## Phase 0 — Groundwork (prerequisites, each shippable alone)
 
-- **0a. Contract tests for the 6 routes.** Pin path + method + access-guard + error-wrapper →
-  status/body for `enqueue`, `run/:id`, `cancel`, `cancel-by-collection`, `get-document-status`,
-  `get-collection-status`. (Handlers already cover status codes; this pins the route _wiring_ so the
-  Phase 1 relocation is verifiably behavior-preserving.) Lowest-risk; can be partial if Phase 1
-  keeps route construction identical.
-- **0b. `translateContent()` + subtree resolver.** No core change (pipeline already pure). Add a
-  resolver: given a declared field config + form value(s), produce `[fieldConfig]` + data rooted as
-  `{ [name]: value }`; add `translateContent(subtreeSchema, values, src, tgt)` that calls the
-  existing `TranslationPipeline`. Unit-test on a leaf field, a group wrapper, and a nested
-  array/blocks subtree. **Direct building block of Phase 2.**
-- **0c. De-couple `SyncRunner` from configure→create ordering.** Prerequisite for per-level runners.
+- **0a. Contract tests for the 6 routes.** ✅ Shipped (PR #24). Pinned path + method + access-guard
+  wiring for `enqueue`, `run/:id`, `cancel`, `cancel-by-collection`, `get-document-status`,
+  `get-collection-status` (status/body for the wrappers are covered by their own unit tests). Also
+  extracted the 6 registrations into one `createTranslationRoutes()` bundle, so the Phase 1
+  relocation is verifiably behavior-preserving.
+- **0b. `translateContent()`.** ✅ Shipped (PR #22). No core change (pipeline already pure):
+  `translateContent({ schema, sourceData, targetData?, sourceLng, targetLng, translationProvider,
+strategy? })` is a thin reusable entry over the existing `TranslationPipeline`. Unit-tested on a
+  leaf field, a group wrapper, and nested array/blocks. The subtree **resolver** (declared field
+  path → `[fieldConfig]` + data rooted as `{ [name]: value }`) was **deferred to Phase 2** — it has
+  no caller until the `POST /field` endpoint, so building it now was premature. **Direct building
+  block of Phase 2.**
+- **0c. De-couple `SyncRunner` from configure→create ordering.** ✅ Shipped (PR #23). Prerequisite for per-level runners.
 
   `SyncRunnerProvider` stashed `this.handler` in `configure()` and `create()` threw unless it was set
   first — a temporal coupling on mutable instance state (needed because `SyncTaskRunner` runs the
@@ -37,9 +39,11 @@ text-like fields + wrappers (richText write-back deferred). Default levels stay
   > Dropped: it's a content-sniffing belt at the wrong layer, and moving the state onto the provider
   > (an instance `configured` flag, "singleton") is worse — the flag sticks across `Config` objects
   > and would silently skip registration on hot-reload / a second `buildConfig`. Idempotency belongs
-  > at the **orchestration layer**: Phase 1 configures each _distinct_ runner exactly once via
-  > `new Set(levels.map(l => l.runner))`, deduped by instance identity. Until levels exist there is a
-  > single runner configured exactly once — so no guard is needed today, and the provider stays pure.
+  > at the **orchestration layer**. Phase 1 keeps a **single root runner** configured exactly once
+  > (no dedup needed); the runner-agnostic document-translation routes are contributed by the
+  > doc-levels and deduped by content (see the Phase 1 design). A future per-level runner override
+  > would configure each _distinct_ runner once via `new Set(...)`, deduped by instance identity. So
+  > no guard is needed today, and the provider stays pure.
 
 ## Phase 1 — Levels refactoring (no new features)
 
@@ -48,10 +52,12 @@ text-like fields + wrappers (richText write-back deferred). Default levels stay
 - Move the existing admin components (document popup → `documentLevel`, bulk dashboard →
   `collectionLevel`) into their level modules.
 - The 6 job-API routes stay **one shared bundle**, registered when any job-based level is present.
-- Per-level runner with **deduplication**: configure each _distinct_ runner exactly once —
-  `new Set(levels.map(l => l.runner ?? rootRunner))`, deduped by instance identity. **This is where
-  `configure()` idempotency lives** — no guard inside the provider. Each distinct runner also gets one
-  bound `TaskRunnerFactory` (introduced in 0c), so no `create()`-site changes are needed here.
+- **Single shared doc-translation runner** (per-level runner deferred). `documentLevel` and
+  `collectionLevel` share the top-level `runner` (sync or async), configured once. They contribute
+  the runner-agnostic 6-route bundle via generic context primitives, deduped by content; the
+  `CacheProvider` is plugin-level. `field` uses `translateContent` (sync), no runner. Per-level
+  runners (which need a breaking route split) are deferred to the major — see the
+  [Phase 1 design](./2026-06-09-translation-levels-phase1-design.md).
 - Add optional `levels` config field, default `[documentLevel(), collectionLevel()]`. Omitted =
   exactly today's behavior.
 - Exit criteria: Phase 0a contract tests + existing suite green (pure relocation).
@@ -82,7 +88,7 @@ targetLng }`, runs `translateContent` (0b), returns the translated subtree. **No
 
 ## Release shape
 
-- Phase 0: `refactor`/`fix` (patch). Phase 1: `feat` (minor), non-breaking (default levels unchanged).
+- Phase 0: shipped as `chore` (no release) — internal groundwork, no user-facing change. Phase 1: `feat` (minor), non-breaking (default levels unchanged).
 - Phase 2–3: `feat` (minor) — the new field level is opt-in via `levels` + `control: true`.
 - No breaking change; the deprecated job-input relationship field and API unification (foundation-prep
   §3) remain queued for the single planned major.

--- a/packages/payload-plugin-translator/docs/plans/2026-06-09-translation-levels-phase1-design.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-09-translation-levels-phase1-design.md
@@ -1,0 +1,311 @@
+# Translation Levels — Phase 1 Design (Levels Architecture)
+
+**Date:** 2026-06-09
+**Status:** Draft
+**Plan:** [translation-levels-plan](./2026-06-08-translation-levels-plan.md) ·
+**Design:** [translation-levels-design](./2026-06-05-translation-levels-design.md)
+
+Phase 1 introduces the **levels** architecture: a composable way to declare which
+translation surfaces the plugin exposes. It is **behaviour-preserving** — the default
+levels reproduce today's plugin exactly. No new user-facing features here; the
+field-level server and client land in Phases 2–3.
+
+## Concept
+
+A **level** is a self-contained translation surface. Three are planned:
+
+- `documentLevel()` — per-document translation (popup control on the document edit
+  view). Runs through the **shared doc-translation runner** (async/job by default; the
+  runner is swappable to sync).
+- `collectionLevel()` — bulk collection translation (dashboard on the list view). Same
+  shared doc-translation runner.
+- `fieldLevel({ mode })` — in-place field translation. **Always synchronous**, no
+  runner/queue — runs `translateContent` directly. (Server is Phase 2; here we only fix
+  its shape in the interface.)
+
+The plugin composes a list of levels and assembles the Payload config from their
+contributions. Default: `[documentLevel(), collectionLevel()]` — exactly today's
+behaviour. Omitting `levels` is unchanged.
+
+## Public API — closed, but forward-compatible
+
+Levels are a **closed set** today: produced only by our factories, selected via an
+array. There is **no public `kind` discriminator** and no externally-implementable
+contract yet — but the surface is deliberately shaped so that opening it later
+(anyone implements their own level) is **additive and non-breaking**.
+
+```ts
+// Public exports
+export interface TranslationLevel {
+  /** @internal Not a stable contract yet — produce via the factories below. */
+  extend(ctx: LevelContext): void;
+}
+
+export function documentLevel(options?: DocumentLevelOptions): TranslationLevel;
+export function collectionLevel(
+  options?: CollectionLevelOptions,
+): TranslationLevel;
+export function fieldLevel(options: FieldLevelOptions): TranslationLevel; // Phase 2
+
+// Config (added to TranslatorPluginConfig)
+type TranslatorPluginConfig = {
+  // …existing fields…
+  /**
+   * Which translation surfaces to enable.
+   * @default [documentLevel(), collectionLevel()]
+   */
+  levels?: TranslationLevel[];
+};
+```
+
+Why this shape opens cheaply later:
+
+- **Array of factory objects, not a string enum.** `levels: TranslationLevel[]` — not
+  `('document' | 'collection')[]`. Opening = also accepting user-built
+  `TranslationLevel`s in the same array → purely additive. A string enum would force a
+  breaking migration and can't carry per-level options.
+- **`LevelContext` is not exported.** External code cannot type its own `extend`, so
+  levels are de-facto closed. Opening = export `LevelContext` + drop the `@internal`
+  tag. No renames, no signature changes.
+- **The internal `extend(ctx)` contract is designed now as if it were public** (clean,
+  no leaked machinery), so exposure is a pure visibility change rather than a redesign.
+
+## Internal contract — `extend(ctx)` + `LevelContext`
+
+A level contributes by calling **generic primitives** on the context — it never mutates
+the raw Payload config directly. The plugin **deduplicates by content**, so shared
+infrastructure registers once no matter how many levels ask for it. This keeps the
+fiddly config plumbing (`collection.admin.components.edit ??= {}` …) in one place and
+makes a level trivially unit-testable: assert which primitives it called against a mock
+context.
+
+```ts
+/** @internal — public-ready shape, kept internal until external levels are needed. */
+interface LevelContext {
+  // --- read-only context ---
+  readonly collections: CollectionConfig[]; // managed collections (original configs)
+  readonly schemaMap: CollectionSchemaMap; // slug -> localized field schema
+  readonly basePath: string; // normalized, e.g. "/translate"
+  readonly access?: AccessGuard;
+  readonly translationProvider: TranslationProvider;
+  readonly taskRunnerFactory: TaskRunnerFactory; // shared doc-translation runner (bound in 0c)
+
+  // --- generic contribution primitives ---
+  /** Register endpoints. The plugin deduplicates by method + path, so two levels
+   *  adding the same bundle collapse to one set. */
+  addEndpoints(endpoints: Endpoint[]): void;
+  /** Attach an admin component to a slot on every managed collection. */
+  addCollectionComponent(
+    slot: CollectionAdminSlot,
+    make: (collection: CollectionConfig) => RawPayloadComponentExport,
+  ): void;
+}
+
+type CollectionAdminSlot = "beforeDocumentControls" | "beforeListTable";
+```
+
+**No `kind`, no "job" in the contract.** A level expresses what it needs by _calling_
+generic primitives, not by declaring a category. There is deliberately **no
+`ensureJobApi()`** — that would re-leak our queue taxonomy into the (future-public)
+context, the same smell we removed with `kind`. Instead:
+
+- the **document-translation API** (the 6-route bundle from #24) is **runner-agnostic** —
+  `createSyncRunner()` drives it exactly as the job runner does — so it is not a "job"
+  concept. `documentLevel`/`collectionLevel` both contribute it via an internal shared
+  helper (`useDocTranslationApi`, below), and the plugin **dedups by method + path** so
+  it registers once;
+- "register shared infra once" is plain content dedup at the orchestration layer — not
+  an idempotency flag keyed on a named capability.
+
+## The three levels
+
+```ts
+// Internal shared helper — the runner-agnostic document-translation API (the 6-route
+// bundle from #24), bound to the shared runner. Both doc-based levels reuse it; the
+// plugin dedups by method+path so it registers once.
+function useDocTranslationApi(ctx: LevelContext) {
+  ctx.addEndpoints(
+    createTranslationRoutes({
+      taskRunnerFactory: ctx.taskRunnerFactory,
+      collectionConfig: {
+        availableCollections: new Set(ctx.collections.map((c) => c.slug)),
+      },
+      access: ctx.access,
+      basePath: ctx.basePath,
+    }),
+  );
+}
+
+// document — uses the shared doc-translation runner (sync or async)
+function documentLevel(): TranslationLevel {
+  return {
+    extend(ctx) {
+      useDocTranslationApi(ctx);
+      ctx.addCollectionComponent(
+        "beforeDocumentControls",
+        (collection) => new TranslateDocumentExport(collection, ctx.access),
+      );
+    },
+  };
+}
+
+// collection — same shared doc-translation runner + API
+function collectionLevel(): TranslationLevel {
+  return {
+    extend(ctx) {
+      useDocTranslationApi(ctx);
+      ctx.addCollectionComponent(
+        "beforeListTable",
+        () => new BulkDocumentTranslationDashboard(ctx.access),
+      );
+    },
+  };
+}
+
+// field — always synchronous, no runner: its own endpoint runs translateContent (0b)
+// directly. (Phase 2 supplies createFieldRoute; shape only here.)
+function fieldLevel(options: FieldLevelOptions): TranslationLevel {
+  return {
+    extend(ctx) {
+      ctx.addEndpoints([
+        createFieldRoute(
+          ctx.schemaMap,
+          ctx.translationProvider,
+          ctx.access,
+          ctx.basePath,
+        ),
+      ]);
+      // The per-field control UI is wired separately, at field-declaration time,
+      // via withFieldTranslation(field, { control: true }) — NOT here. (Phase 3)
+    },
+  };
+}
+```
+
+`fieldLevel` is the proof the abstraction is right: it needs no document-translation
+API and no runner — it is request → response via `translateContent` — and its UI
+attaches per-field (through the existing `withFieldTranslation` wrapper), not
+per-collection. The generic primitives accommodate it with no special-casing.
+
+## Plugin orchestration
+
+`plugin.init()` collapses from the hard-coded 4-step `pipe` into: build context → run
+each level's `extend` → build config.
+
+```
+init(config):
+  schemaMap, collectionSlugs, basePath, translateHandler   // unchanged
+  runnerContext, taskRunnerFactory                         // unchanged (one root runner)
+
+  levels = config.levels ?? [documentLevel(), collectionLevel()]
+
+  ctx = makeLevelContext({ collections, schemaMap, basePath, access,
+                           translationProvider, taskRunnerFactory })
+  for (const level of levels) level.extend(ctx)            // accumulate contributions
+
+  // plugin-level infra (not a level concern) — added straight to the config:
+  config.admin.components.providers.push(new CacheProviderExport(basePath)) // client cache — always, once
+  runnerConfigModifier = runner.configure(runnerContext)                    // root runner configured once
+
+  return ctx.applyTo(config, runnerConfigModifier)         // dedup endpoints (method+path) → pipe
+```
+
+`ctx.applyTo` deduplicates the accumulated endpoints by content (method + path) before
+composing them, so two doc-levels each contributing the 6-route bundle collapse to one
+set. The `CacheProvider` is **plugin-level** — always needed for requests/caching, so
+the plugin adds it directly to `config.admin.components.providers` (once, regardless of
+which levels are active). It is **not** a `LevelContext` primitive: no level
+contributes it, so `addAdminProvider` would be dead surface.
+
+## Runners — one shared doc-translation runner + two backends by request shape
+
+`document` and `collection` form one **document-translation domain**: they share the
+6-route bundle, so they share **one runner** — the top-level `runner`, configurable as
+sync (`createSyncRunner()`) or async (`createPayloadJobsRunner()`, the default). It is
+configured once. There is no per-level runner: the shared routes have a single
+`taskRunnerFactory`, so document and collection cannot diverge to different runners
+without splitting the routes (deferred — below).
+
+`field` is **not** in this domain. It is always synchronous (request → response) and
+runs `translateContent` (0b) in its own endpoint — no runner, no queue, no polling. So
+there are **two execution backends, by request shape**:
+
+- `TaskRunnerProvider` — document tracking (enqueue → poll status → DB write), sync or async;
+- `translateContent` — field (value in → value out), always sync.
+
+Generalizing one runner to serve both was considered and **rejected**: the contracts
+differ fundamentally (fire-and-track-with-DB-side-effect vs request→response, `void`
+vs a returned value), and `field` needs none of the job machinery (status, cancel,
+persistence). Two small backends beat one leaky generic one.
+
+**Deferred to the planned major:** per-level runners (e.g. `document` sync while
+`collection` is async) require splitting the shared 6-route bundle into per-level
+endpoints — a **breaking** REST change. Batched into the major alongside the API
+unification, not done in this non-breaking relocation. (Note: `document` is already
+async today, so the only thing per-level runners would add to the doc domain is a
+_synchronous_ document path — questionable value, since sync blocks the HTTP request
+for LLM latency, worse UX than the existing non-blocking poll. 0c's `SyncRunner`
+decoupling already makes the eventual split cheap.)
+
+## Forward-compatibility recipe (closed → open)
+
+When external levels become a real requirement:
+
+1. Export `LevelContext` (and `CollectionAdminSlot`).
+2. Remove `@internal` from `TranslationLevel.extend`.
+3. Freeze the `LevelContext` shape as public API.
+
+All three are additive. Existing `levels: [documentLevel(), …]` configs keep compiling
+unchanged; users merely gain the ability to pass their own `TranslationLevel`.
+
+## Alternatives considered
+
+| Approach            | Shape                                                   | Pros                                                           | Cons                                                                                                                         |
+| ------------------- | ------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Levels (chosen)** | `levels: [documentLevel(), fieldLevel({…})]`            | composes; carries per-level options; cheapest to open later    | needs a "level" abstraction                                                                                                  |
+| Boolean flags       | `{ documentTranslation: true, fieldTranslation: {…} }`  | simplest, most discoverable                                    | doesn't compose; **opening externally = breaking migration**; config grows one key per feature                               |
+| Nested preset       | `{ surfaces: { document: {…}, field: {…} } }`           | grouped, still simple                                          | same downsides as flags, slightly tidier                                                                                     |
+| Sub-plugins         | `plugins: [translatorCore(), fieldTranslation()]`       | **inherently open** (anyone ships a Payload plugin); idiomatic | shared infra (runner / routes / schemaMap / cache) is hard to coordinate across separate plugins; ordering; more boilerplate |
+| Per-collection      | `collections: [{ collection: Posts, surfaces: [...] }]` | granular (per collection)                                      | different axis, more complex; can be layered on top of levels later                                                          |
+| Monolith + one flag | today + `enableFieldTranslation`                        | minimal change (YAGNI)                                         | doesn't satisfy "control which surfaces are on"                                                                              |
+
+The forward-compatibility requirement (closed now, cheap to open) is what rules out
+flags / nested presets (most painful to open) and confirms the levels array. Sub-plugins
+are the only natively-open option but are expensive _today_ because of the shared
+infrastructure — levels are effectively "sub-plugins coordinated inside one plugin".
+
+## Decisions
+
+- **Closed levels** via factories + array config (not a string enum / flags) —
+  composable, carries options, cheapest to open later.
+- **No public `kind`, no `ensureJobApi`** — the context exposes only the two primitives
+  levels actually use (`addEndpoints`, `addCollectionComponent`); the plugin dedups
+  endpoints by content. The runner-agnostic document-translation API is an internal
+  shared helper, not a "job" capability on the context.
+- **Internal `extend(ctx)` + builder-style `LevelContext`**, designed public-ready,
+  kept `@internal`.
+- **Two execution backends by request shape:** `TaskRunnerProvider` (document, sync/async)
+  - `translateContent` (field, sync). The runner is not generalized.
+- **One shared doc-translation runner**; per-level runners deferred to the planned major
+  (they need a breaking route split).
+- **`CacheProvider` is plugin-level** — always needed for requests/caching, added
+  directly to the config by the plugin. Not a `LevelContext` primitive (no level
+  contributes it), so `addAdminProvider` stays out of the interface. Its own QueryClient
+  is isolated and nests safely under any host-app react-query provider.
+
+## Exit criteria
+
+- `levels` omitted ⇒ behaviour identical to today (default
+  `[documentLevel(), collectionLevel()]`).
+- Phase 0a route-contract tests + the bundle-contract test + the full existing suite
+  stay green (pure relocation).
+- New unit tests: each level's `extend` calls the expected `ctx` primitives (mock ctx);
+  endpoint dedup by (method + path) collapses two doc-levels' bundles to one set.
+
+## Out of scope (later phases)
+
+- **Phase 2:** `fieldLevel` server — the real `POST {basePath}/field` synchronous
+  endpoint (built on `translateContent` from 0b).
+- **Phase 3:** per-field control UI via `withFieldTranslation(field, { control: true })`
+  - form-state write-back.
+- **Phase 4:** richText write-back into Lexical; `from-locale` mode.


### PR DESCRIPTION
Docs only — no code. `chore` / no release.

## Adds
- **Phase 1 levels design** (`2026-06-09-translation-levels-phase1-design.md`) — the authoritative interface for the levels refactor:
  - closed-but-openable `TranslationLevel` (factories + `levels: TranslationLevel[]`), no public `kind`;
  - internal `extend(ctx)` with **two generic primitives** — `addEndpoints` (deduped by method+path) + `addCollectionComponent`;
  - **one shared doc-translation runner** for `document`+`collection`; `field` is a synchronous `translateContent` path → **two execution backends by request shape** (runner not generalized);
  - `CacheProvider` is plugin-level (added directly, not a `LevelContext` primitive);
  - per-level runners + per-level endpoints **deferred to the planned major** (they need a breaking route split).

## Reconciles existing docs with what shipped in 0a/0b/0c
- **plan**: 0a/0b/0c marked shipped (#24/#22/#23); 0b drops the deferred subtree resolver; Phase 1 = single shared runner; release shape = `chore`/no-release.
- **design** (approved): the stale interface sketch is superseded by the Phase 1 doc (no two conflicting definitions).
- **foundation-prep**: shipped items checked off; status bumped.
- **DEPRECATIONS** + **jobs-id-agnostic-migration**: `PR #TBD` → `#18`, status → shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)