### PR TITLE
feat(translator): add configurable translation levels

### DIFF
--- a/packages/payload-plugin-translator/CLAUDE.md
+++ b/packages/payload-plugin-translator/CLAUDE.md
@@ -1,0 +1,34 @@
+# payload-plugin-translator — Agent Guide
+
+Package-specific conventions for `@focus-reactive/payload-plugin-translator`.
+Complements the root [CLAUDE.md](../../CLAUDE.md) — it does not replace it.
+
+## Documenting feature versions
+
+Annotate every new piece of **public API** (anything re-exported from
+`src/index.ts`) with the version it ships in:
+
+- `@since x.y.z` in its JSDoc, and
+- a `Since vX.Y.Z` note in `README.md` next to the feature.
+
+So a reader can tell at a glance whether their installed version has the feature —
+without cross-referencing the changelog. (The pain this avoids: "the docs show it,
+but my version doesn't have it — why can't I use it?")
+
+Determine the version deterministically from the latest published tag + the highest
+bump in the change — e.g. a `feat` on `0.4.0` → `0.5.0`. When it isn't obvious, run
+`bun run multi-semantic-release --dry-run` (from the repo root) to read the exact
+"next release version".
+
+Scope:
+
+- Applies to **additions**. Deprecation/removal targets stay `next major` per
+  [docs/DEPRECATIONS.md](docs/DEPRECATIONS.md) — we don't guess removal versions.
+- Don't backfill `@since` on pre-existing API; the practice starts from the change
+  that introduces it.
+
+## Design docs
+
+Non-trivial work is designed in a committed doc under [docs/plans/](docs/plans)
+before implementation. Deprecations are tracked in
+[docs/DEPRECATIONS.md](docs/DEPRECATIONS.md) (keyed by date + PR, removal = next major).

--- a/packages/payload-plugin-translator/README.md
+++ b/packages/payload-plugin-translator/README.md
@@ -12,6 +12,7 @@ Translation plugin for Payload CMS 3.x. Automatically translate your localized c
 - **Pluggable providers** — use OpenAI or create custom translation providers
 - **Field exclusion** — exclude specific fields from translation via `withFieldTranslation`
 - **Translation strategies** — choose between overwrite all or skip existing translations
+- **Configurable surfaces** — enable the per-document popup and/or the bulk-collection dashboard via the `levels` option _(since v0.5.0)_
 
 ## Installation
 
@@ -33,11 +34,7 @@ yarn add @focus-reactive/payload-plugin-translator
 
 ```typescript
 import { buildConfig } from "payload";
-import {
-  translatorPlugin,
-  createOpenAIProvider,
-  createPayloadJobsRunner,
-} from "@focus-reactive/payload-plugin-translator";
+import { translatorPlugin, createOpenAIProvider, createPayloadJobsRunner } from "@focus-reactive/payload-plugin-translator";
 import { Posts } from "./collections/Posts";
 import { Pages } from "./collections/Pages";
 
@@ -65,13 +62,14 @@ export default buildConfig({
 
 Configuration for `translatorPlugin()`.
 
-| Property              | Type                  | Required | Default        | Description                                                                                                         |
-| --------------------- | --------------------- | -------- | -------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `collections`         | `CollectionConfig[]`  | Yes      | —              | Original collection configs to enable translation for. Must be the same objects passed to `buildConfig`, not slugs. |
-| `translationProvider` | `TranslationProvider` | Yes      | —              | Translation provider instance (e.g., `createOpenAIProvider(...)`)                                                   |
-| `runner`              | `TaskRunnerProvider`  | Yes      | —              | Task runner provider for background processing (e.g., `createPayloadJobsRunner()`)                                  |
-| `access`              | `AccessGuard`         | No       | `undefined`    | Access control function for translation endpoints                                                                   |
-| `basePath`            | `string`              | No       | `'/translate'` | Base path for all API endpoints                                                                                     |
+| Property              | Type                  | Required | Default                                | Description                                                                                                         |
+| --------------------- | --------------------- | -------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `collections`         | `CollectionConfig[]`  | Yes      | —                                      | Original collection configs to enable translation for. Must be the same objects passed to `buildConfig`, not slugs. |
+| `translationProvider` | `TranslationProvider` | Yes      | —                                      | Translation provider instance (e.g., `createOpenAIProvider(...)`)                                                   |
+| `runner`              | `TaskRunnerProvider`  | Yes      | —                                      | Task runner provider for background processing (e.g., `createPayloadJobsRunner()`)                                  |
+| `access`              | `AccessGuard`         | No       | `undefined`                            | Access guard (`{ check }`) for the translation endpoints; omit to leave them open                                   |
+| `basePath`            | `string`              | No       | `'/translate'`                         | Base path for all API endpoints                                                                                     |
+| `levels`              | `TranslationLevel[]`  | No       | `[documentLevel(), collectionLevel()]` | Which translation surfaces to enable. See [Translation Levels](#translation-levels)                                 |
 
 ```typescript
 translatorPlugin({
@@ -80,10 +78,36 @@ translatorPlugin({
     apiKey: process.env.OPENAI_API_KEY,
   }),
   runner: createPayloadJobsRunner(),
-  access: async ({ req }) => req.user?.role === "admin",
+  access: { check: ({ req }) => req.user?.role === "admin" },
   basePath: "/translate",
 });
 ```
+
+### Translation Levels
+
+_Since v0.5.0._
+
+The `levels` option controls which translation surfaces the plugin exposes. Each entry is a factory you import and list:
+
+- `documentLevel()` — a **Translate** popup on the document edit view (translate one document).
+- `collectionLevel()` — a **bulk dashboard** on the collection list view (translate many at once).
+
+Both run through the configured `runner` (async Payload Jobs by default, or synchronous via `createSyncRunner()`) and share the same translation REST API.
+
+```typescript
+import { translatorPlugin, documentLevel, collectionLevel, createOpenAIProvider, createPayloadJobsRunner } from "@focus-reactive/payload-plugin-translator";
+
+translatorPlugin({
+  collections: [Posts],
+  translationProvider: createOpenAIProvider({
+    apiKey: process.env.OPENAI_API_KEY,
+  }),
+  runner: createPayloadJobsRunner(),
+  levels: [collectionLevel()], // bulk dashboard only — no per-document popup
+});
+```
+
+Omit `levels` for the default `[documentLevel(), collectionLevel()]`, which is identical to the previous behaviour — so adopting this option is non-breaking. A synchronous `fieldLevel()` (in-place field translation) is planned for a later release.
 
 ### OpenAIProviderConfig
 
@@ -100,8 +124,7 @@ Configuration for `createOpenAIProvider()`.
 createOpenAIProvider({
   apiKey: process.env.OPENAI_API_KEY,
   model: "gpt-4o-mini",
-  systemPrompt: ({ sourceLang, targetLang, defaultPrompt }) =>
-    `${defaultPrompt}\nUse formal language. Keep brand names unchanged.`,
+  systemPrompt: ({ sourceLang, targetLang, defaultPrompt }) => `${defaultPrompt}\nUse formal language. Keep brand names unchanged.`,
   dryRun: false,
 });
 ```
@@ -165,10 +188,7 @@ Configuration for `withFieldTranslation()` helper or `field.custom.translateKit`
 ```typescript
 import { withFieldTranslation } from "@focus-reactive/payload-plugin-translator";
 
-withFieldTranslation(
-  { name: "sku", type: "text", localized: true },
-  { exclude: true },
-);
+withFieldTranslation({ name: "sku", type: "text", localized: true }, { exclude: true });
 ```
 
 ## Translation Strategies
@@ -310,20 +330,12 @@ type TranslationOutput = Record<TranslationIndex, string>;
 #### Example Implementation
 
 ```typescript
-import type {
-  TranslationProvider,
-  TranslationInput,
-  TranslationOutput,
-} from "@focus-reactive/payload-plugin-translator";
+import type { TranslationProvider, TranslationInput, TranslationOutput } from "@focus-reactive/payload-plugin-translator";
 
 class DeepLProvider implements TranslationProvider {
   constructor(private apiKey: string) {}
 
-  async translate(
-    content: TranslationInput,
-    sourceLng: string,
-    targetLng: string,
-  ): Promise<TranslationOutput | null> {
+  async translate(content: TranslationInput, sourceLng: string, targetLng: string): Promise<TranslationOutput | null> {
     try {
       // content example: { "0": "Hello", "1": "World" }
       const texts = Object.values(content);
@@ -401,6 +413,9 @@ import type {
 
   // Field config
   FieldTranslationConfig,
+
+  // Translation levels
+  TranslationLevel,
 } from "@focus-reactive/payload-plugin-translator";
 ```
 

--- a/packages/payload-plugin-translator/docs/plans/2026-06-09-translation-levels-phase1-design.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-09-translation-levels-phase1-design.md
@@ -42,9 +42,7 @@ export interface TranslationLevel {
 }
 
 export function documentLevel(options?: DocumentLevelOptions): TranslationLevel;
-export function collectionLevel(
-  options?: CollectionLevelOptions,
-): TranslationLevel;
+export function collectionLevel(options?: CollectionLevelOptions): TranslationLevel;
 export function fieldLevel(options: FieldLevelOptions): TranslationLevel; // Phase 2
 
 // Config (added to TranslatorPluginConfig)
@@ -95,10 +93,7 @@ interface LevelContext {
    *  adding the same bundle collapse to one set. */
   addEndpoints(endpoints: Endpoint[]): void;
   /** Attach an admin component to a slot on every managed collection. */
-  addCollectionComponent(
-    slot: CollectionAdminSlot,
-    make: (collection: CollectionConfig) => RawPayloadComponentExport,
-  ): void;
+  addCollectionComponent(slot: CollectionAdminSlot, make: (collection: CollectionConfig) => RawPayloadComponentExport): void;
 }
 
 type CollectionAdminSlot = "beforeDocumentControls" | "beforeListTable";
@@ -132,7 +127,7 @@ function useDocTranslationApi(ctx: LevelContext) {
       },
       access: ctx.access,
       basePath: ctx.basePath,
-    }),
+    })
   );
 }
 
@@ -141,10 +136,7 @@ function documentLevel(): TranslationLevel {
   return {
     extend(ctx) {
       useDocTranslationApi(ctx);
-      ctx.addCollectionComponent(
-        "beforeDocumentControls",
-        (collection) => new TranslateDocumentExport(collection, ctx.access),
-      );
+      ctx.addCollectionComponent("beforeDocumentControls", (collection) => new TranslateDocumentExport(collection, ctx.access));
     },
   };
 }
@@ -154,10 +146,7 @@ function collectionLevel(): TranslationLevel {
   return {
     extend(ctx) {
       useDocTranslationApi(ctx);
-      ctx.addCollectionComponent(
-        "beforeListTable",
-        () => new BulkDocumentTranslationDashboard(ctx.access),
-      );
+      ctx.addCollectionComponent("beforeListTable", () => new BulkDocumentTranslationDashboard(ctx.access));
     },
   };
 }
@@ -167,14 +156,7 @@ function collectionLevel(): TranslationLevel {
 function fieldLevel(options: FieldLevelOptions): TranslationLevel {
   return {
     extend(ctx) {
-      ctx.addEndpoints([
-        createFieldRoute(
-          ctx.schemaMap,
-          ctx.translationProvider,
-          ctx.access,
-          ctx.basePath,
-        ),
-      ]);
+      ctx.addEndpoints([createFieldRoute(ctx.schemaMap, ctx.translationProvider, ctx.access, ctx.basePath)]);
       // The per-field control UI is wired separately, at field-declaration time,
       // via withFieldTranslation(field, { control: true }) — NOT here. (Phase 3)
     },
@@ -192,6 +174,11 @@ per-collection. The generic primitives accommodate it with no special-casing.
 `plugin.init()` collapses from the hard-coded 4-step `pipe` into: build context → run
 each level's `extend` → build config.
 
+`plugin.init()` never touches `config` directly. A single `PluginConfigBuilder` is the
+**only config-writer**: levels (via the narrow `LevelContext`) and the plugin (via the
+builder-only `addAdminProvider` / `addConfigModifier`) all _describe_ contributions;
+`builder.applyTo(config)` is the one sink that mutates.
+
 ```
 init(config):
   schemaMap, collectionSlugs, basePath, translateHandler   // unchanged
@@ -199,23 +186,26 @@ init(config):
 
   levels = config.levels ?? [documentLevel(), collectionLevel()]
 
-  ctx = makeLevelContext({ collections, schemaMap, basePath, access,
-                           translationProvider, taskRunnerFactory })
-  for (const level of levels) level.extend(ctx)            // accumulate contributions
+  builder = new PluginConfigBuilder({ collections, basePath, access, taskRunnerFactory })
+  for (const level of levels) level.extend(builder)        // levels describe (endpoints, components)
 
-  // plugin-level infra (not a level concern) — added straight to the config:
-  config.admin.components.providers.push(new CacheProviderExport(basePath)) // client cache — always, once
-  runnerConfigModifier = runner.configure(runnerContext)                    // root runner configured once
+  // plugin-level contributions, routed through the same single writer:
+  builder.addConfigModifier(runner.configure(runnerContext))   // root runner: jobs/autorun/onInit
+  builder.addAdminProvider(new CacheProviderExport(basePath))  // client cache — always, once
 
-  return ctx.applyTo(config, runnerConfigModifier)         // dedup endpoints (method+path) → pipe
+  return builder.applyTo(config)   // THE ONLY place config is mutated
 ```
 
-`ctx.applyTo` deduplicates the accumulated endpoints by content (method + path) before
-composing them, so two doc-levels each contributing the 6-route bundle collapse to one
-set. The `CacheProvider` is **plugin-level** — always needed for requests/caching, so
-the plugin adds it directly to `config.admin.components.providers` (once, regardless of
-which levels are active). It is **not** a `LevelContext` primitive: no level
-contributes it, so `addAdminProvider` would be dead surface.
+`applyTo` writes everything in one place, in order: **config modifiers first** (a runner
+modifier may return a fresh config object, so later writes must land on its result) →
+admin providers → collection components → endpoints (deduplicated by method + path, so
+two doc-levels each contributing the 6-route bundle collapse to one set).
+
+The `CacheProvider` is **plugin-level** — always needed for requests/caching — and the
+runner config is **runner-level**; both are contributed through the builder rather than
+mutating `config` in `plugin.ts`, so the in-place-mutation style stays confined to the
+one writer. Neither is on the level-facing `LevelContext`: levels see only `addEndpoints`
+/ `addCollectionComponent`; `addAdminProvider` / `addConfigModifier` are builder-only.
 
 ## Runners — one shared doc-translation runner + two backends by request shape
 
@@ -288,10 +278,17 @@ infrastructure — levels are effectively "sub-plugins coordinated inside one pl
   - `translateContent` (field, sync). The runner is not generalized.
 - **One shared doc-translation runner**; per-level runners deferred to the planned major
   (they need a breaking route split).
-- **`CacheProvider` is plugin-level** — always needed for requests/caching, added
-  directly to the config by the plugin. Not a `LevelContext` primitive (no level
-  contributes it), so `addAdminProvider` stays out of the interface. Its own QueryClient
-  is isolated and nests safely under any host-app react-query provider.
+- **Single config-writer (`PluginConfigBuilder`)** — the one place that mutates `config`.
+  `plugin.ts` and the levels never touch `config` directly; they describe contributions
+  and `applyTo(config)` writes them (modifiers → providers → components → endpoints). This
+  confines Payload's in-place-mutation style (and the lazy nested-config init) to one
+  tested class.
+- **`CacheProvider` is plugin-level** — always needed for requests/caching, contributed
+  through the builder-only `addAdminProvider` (the runner config likewise via
+  `addConfigModifier`). Neither is on the level-facing `LevelContext` (levels see only
+  `addEndpoints` / `addCollectionComponent`), so the interface stays minimal while the
+  plugin still routes its infra through the single writer instead of poking `config`.
+  The cache's own QueryClient is isolated and nests safely under any host react-query provider.
 
 ## Exit criteria
 

--- a/packages/payload-plugin-translator/src/index.ts
+++ b/packages/payload-plugin-translator/src/index.ts
@@ -1,31 +1,29 @@
 // Main plugin
-export { translatorPlugin } from './plugin'
-export type { TranslatorPluginConfig } from './plugin'
+export { translatorPlugin } from "./plugin";
+export type { TranslatorPluginConfig } from "./plugin";
 
 // Access control
-export type { AccessGuard, AccessGuardRequest } from './types/AccessGuard'
+export type { AccessGuard, AccessGuardRequest } from "./types/AccessGuard";
 
 // Translation providers
-export { createOpenAIProvider } from './server/modules/translation-providers'
-export type {
-  TranslationProvider,
-  TranslationInput,
-  TranslationOutput,
-  OpenAIProviderConfig,
-  DryRunConfig,
-} from './server/modules/translation-providers'
+export { createOpenAIProvider } from "./server/modules/translation-providers";
+export type { TranslationProvider, TranslationInput, TranslationOutput, OpenAIProviderConfig, DryRunConfig } from "./server/modules/translation-providers";
 
 // Task runners
-export { createPayloadJobsRunner, createSyncRunner } from './server/modules/task-runner'
-export type { TaskRunnerProvider, PayloadJobsRunnerOptions } from './server/modules/task-runner'
+export { createPayloadJobsRunner, createSyncRunner } from "./server/modules/task-runner";
+export type { TaskRunnerProvider, PayloadJobsRunnerOptions } from "./server/modules/task-runner";
+
+// Translation levels
+export { documentLevel, collectionLevel } from "./server/modules/translation-levels";
+export type { TranslationLevel } from "./server/modules/translation-levels";
 
 // Field config
-export { withFieldTranslation } from './field-config'
-export type { FieldTranslationConfig } from './field-config'
+export { withFieldTranslation } from "./field-config";
+export type { FieldTranslationConfig } from "./field-config";
 
 // Deprecated exports (for backwards compatibility)
-export { createTranslatePlugin, TranslateCollectionPlugin } from './plugin'
-export type { TranslateCollectionPluginConfig } from './plugin'
-export { OpenAITranslationProvider } from './server/modules/translation-providers'
-export { translateKitField } from './field-config'
-export type { TranslateKitFieldConfig } from './field-config'
+export { createTranslatePlugin, TranslateCollectionPlugin } from "./plugin";
+export type { TranslateCollectionPluginConfig } from "./plugin";
+export { OpenAITranslationProvider } from "./server/modules/translation-providers";
+export { translateKitField } from "./field-config";
+export type { TranslateKitFieldConfig } from "./field-config";

--- a/packages/payload-plugin-translator/src/plugin.test.ts
+++ b/packages/payload-plugin-translator/src/plugin.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Config } from "payload";
+
+import { translatorPlugin } from "./plugin";
+import type { TranslatorPluginConfig } from "./plugin";
+import { documentLevel } from "./server/modules/translation-levels";
+import { TranslateDocumentExport } from "./client/widgets/translate-document";
+import { BulkDocumentTranslationDashboard } from "./client/widgets/bulk-translation-dashboard/ui/BulkTranslationDashboard.export";
+
+// End-to-end behaviour guard for the levels refactor: the default levels must
+// reproduce today's wiring (6-route bundle, cache provider, doc popup + bulk
+// dashboard on managed collections, runner configured once), and an explicit
+// `levels` list must scope the surfaces accordingly.
+
+const makeCollection = () => ({
+  slug: "posts",
+  fields: [{ name: "title", type: "text", localized: true }],
+});
+const makeRunner = () => ({
+  create: vi.fn(),
+  configure: vi.fn().mockReturnValue((c: Config) => c),
+});
+
+async function build(overrides: Partial<TranslatorPluginConfig> = {}) {
+  const runner = overrides.runner ?? makeRunner();
+  const collection = makeCollection();
+  const incoming = { collections: [collection] } as unknown as Config;
+  const pluginConfig = {
+    collections: [collection],
+    translationProvider: { translate: vi.fn() },
+    runner,
+    ...overrides,
+  } as unknown as TranslatorPluginConfig;
+
+  const result = await translatorPlugin(pluginConfig)(incoming);
+  return {
+    result,
+    runner: runner as ReturnType<typeof makeRunner>,
+    posts: result.collections?.[0] as Record<string, any>,
+  };
+}
+
+describe("translatorPlugin — default levels (behaviour-preserving)", () => {
+  it("registers the 6-route bundle once (document + collection share it)", async () => {
+    const { result } = await build();
+    expect(result.endpoints).toHaveLength(6); // not 12 — deduped across the two doc levels
+    expect(result.endpoints?.map((e) => e.path)).toContain("/translate/enqueue");
+  });
+
+  it("does not duplicate endpoints when the same config is run through the plugin twice", async () => {
+    const collection = makeCollection();
+    const pluginConfig = {
+      collections: [collection],
+      translationProvider: { translate: vi.fn() },
+      runner: makeRunner(),
+    } as unknown as TranslatorPluginConfig;
+
+    const once = await translatorPlugin(pluginConfig)({
+      collections: [collection],
+    } as unknown as Config);
+    const twice = await translatorPlugin(pluginConfig)(once);
+
+    // Endpoint seeding dedups against routes already on the config, so a second
+    // registration on the same config doesn't double the 6-route bundle.
+    expect(twice.endpoints).toHaveLength(6);
+  });
+
+  it("adds the cache provider and configures the runner once", async () => {
+    const { result, runner } = await build();
+    expect(result.admin?.components?.providers).toHaveLength(1);
+    expect(runner.configure).toHaveBeenCalledTimes(1);
+  });
+
+  it("attaches the doc popup and bulk dashboard to the managed collection (right component on right slot)", async () => {
+    const { posts } = await build();
+    expect(posts.admin.components.edit.beforeDocumentControls).toHaveLength(1);
+    expect(posts.admin.components.edit.beforeDocumentControls[0]).toBeInstanceOf(TranslateDocumentExport);
+    expect(posts.admin.components.beforeListTable).toHaveLength(1);
+    expect(posts.admin.components.beforeListTable[0]).toBeInstanceOf(BulkDocumentTranslationDashboard);
+  });
+
+  it("threads a custom basePath into every endpoint", async () => {
+    const { result } = await build({ basePath: "/i18n" });
+    expect(result.endpoints?.every((e) => e.path.startsWith("/i18n/"))).toBe(true);
+  });
+});
+
+describe("translatorPlugin — explicit levels", () => {
+  it("documentLevel only → bundle present, doc popup yes, bulk dashboard no", async () => {
+    const { result, posts } = await build({ levels: [documentLevel()] });
+    expect(result.endpoints).toHaveLength(6);
+    expect(posts.admin.components.edit.beforeDocumentControls).toHaveLength(1);
+    expect(posts.admin.components.beforeListTable).toBeUndefined();
+  });
+
+  it("empty levels → no endpoints/components, but cache provider + runner config still happen", async () => {
+    const { result, runner } = await build({ levels: [] });
+    expect(result.endpoints ?? []).toHaveLength(0);
+    expect(result.collections?.[0] as Record<string, any>).not.toHaveProperty("admin");
+    expect(result.admin?.components?.providers).toHaveLength(1);
+    expect(runner.configure).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/payload-plugin-translator/src/plugin.ts
+++ b/packages/payload-plugin-translator/src/plugin.ts
@@ -1,14 +1,14 @@
 import type { CollectionConfig, Config } from "payload";
 
 import { CacheProviderExport } from "./client/app/cache/CacheProvider.export";
-import { BulkDocumentTranslationDashboard } from "./client/widgets/bulk-translation-dashboard/ui/BulkTranslationDashboard.export";
-import { TranslateDocumentExport } from "./client/widgets/translate-document";
 import type { AccessGuard } from "./types/AccessGuard";
 import type { TranslationProvider } from "./server/modules/translation-providers";
 import type { TaskRunnerProvider, TaskRunnerContext, TaskRunnerFactory } from "./server/modules/task-runner";
 import { TranslateDocumentHandler } from "./server/features/translate-document";
-import { createTranslationRoutes } from "./server/features/createTranslationRoutes";
-import { normalizePath, pipe } from "./server/shared";
+import { documentLevel, collectionLevel } from "./server/modules/translation-levels";
+import type { TranslationLevel } from "./server/modules/translation-levels";
+import { PluginConfigBuilder } from "./server/modules/translation-levels/PluginConfigBuilder";
+import { normalizePath } from "./server/shared";
 
 export type TranslatorPluginConfig = {
   /**
@@ -40,6 +40,16 @@ export type TranslatorPluginConfig = {
    * @default '/translate'
    */
   basePath?: string;
+  /**
+   * Which translation surfaces to enable, as level factories — `documentLevel()`,
+   * `collectionLevel()` (and, from a later phase, `fieldLevel()`). Omit for the
+   * default `[documentLevel(), collectionLevel()]`, which is exactly today's behaviour.
+   * Each level should appear at most once: endpoints are deduplicated, but admin
+   * components are not, so a duplicated level renders a duplicated control.
+   * @default [documentLevel(), collectionLevel()]
+   * @since 0.5.0
+   */
+  levels?: TranslationLevel[];
 };
 
 /** @deprecated Use `TranslatorPluginConfig` instead */
@@ -47,11 +57,15 @@ export type TranslateCollectionPluginConfig = TranslatorPluginConfig;
 
 /** @deprecated Use `translatorPlugin` function instead */
 export class TranslateCollectionPlugin {
-  constructor(private readonly pluginConfig: TranslatorPluginConfig) {}
+  private readonly pluginConfig: TranslatorPluginConfig;
+
+  constructor(pluginConfig: TranslatorPluginConfig) {
+    this.pluginConfig = pluginConfig;
+  }
 
   init(): (config: Config) => Promise<Config> {
     return async (config) => {
-      const { access, translationProvider, basePath: rawBasePath = "/translate" } = this.pluginConfig;
+      const { access, translationProvider, runner, collections, levels, basePath: rawBasePath = "/translate" } = this.pluginConfig;
 
       // Build schema map from deep-cloned collections
       // Deep clone is required because Payload mutates the original collection objects,
@@ -61,7 +75,7 @@ export class TranslateCollectionPlugin {
       // TODO: Consider introducing a FieldLike interface with only the properties
       // used by the pipeline (name, type, localized, fields, blocks, tabs, custom)
       // to make the contract explicit and avoid reliance on JSON round-trip.
-      const schemaMap = new Map(this.pluginConfig.collections.map((col) => [col.slug, JSON.parse(JSON.stringify(col.fields))]));
+      const schemaMap = new Map(collections.map((col) => [col.slug, JSON.parse(JSON.stringify(col.fields))]));
       const collectionSlugs = new Set(schemaMap.keys());
       const basePath = normalizePath(rawBasePath);
       const translateHandler = new TranslateDocumentHandler(translationProvider, schemaMap);
@@ -79,67 +93,33 @@ export class TranslateCollectionPlugin {
         },
         collections: Array.from(collectionSlugs),
       };
-      const runnerConfigModifier = this.pluginConfig.runner.configure(runnerContext);
+      const runnerConfigModifier = runner.configure(runnerContext);
 
       // Bind the context once so routes receive a self-sufficient factory: the
       // runner needs no mutable per-instance handler state and create() has no
       // "configure() must run first" ordering coupling (translator plan, 0c).
       const taskRunnerFactory: TaskRunnerFactory = {
-        create: (payload) => this.pluginConfig.runner.create(payload, runnerContext.handler),
+        create: (payload) => runner.create(payload, runnerContext.handler),
       };
 
-      return pipe<Config>(
-        // 1. Set up UI component provider import
-        (cfg) => {
-          if (!cfg.admin) cfg.admin = {};
-          if (!cfg.admin.components) cfg.admin.components = {};
-          if (!cfg.admin.components.providers) cfg.admin.components.providers = [];
+      const activeLevels = levels ?? [documentLevel(), collectionLevel()];
+      const builder = new PluginConfigBuilder({
+        collections,
+        basePath,
+        access,
+        taskRunnerFactory,
+      });
+      for (const level of activeLevels) level.extend(builder);
 
-          cfg.admin.components.providers.push(new CacheProviderExport(basePath));
-          return cfg;
-        },
+      // Plugin-level contributions, routed through the same single config-writer:
+      //  - the runner's jobs/autorun/onInit modifier (the builder applies it first,
+      //    so a modifier returning a fresh config object doesn't drop later writes),
+      //  - the always-on client cache provider.
+      builder.addConfigModifier(runnerConfigModifier);
+      builder.addAdminProvider(new CacheProviderExport(basePath));
 
-        // 2. Set up UI component import
-        (cfg) => {
-          cfg.collections?.forEach((collection) => {
-            if (!collectionSlugs.has(collection.slug)) {
-              return;
-            }
-
-            if (!collection.admin) collection.admin = {};
-            if (!collection.admin.components) collection.admin.components = {};
-            if (!collection.admin.components.edit) collection.admin.components.edit = {};
-            if (!collection.admin.components.edit.beforeDocumentControls) {
-              collection.admin.components.edit.beforeDocumentControls = [];
-            }
-            if (!collection.admin.components.beforeListTable) {
-              collection.admin.components.beforeListTable = [];
-            }
-
-            collection.admin.components.edit.beforeDocumentControls.push(new TranslateDocumentExport(collection, access));
-            collection.admin.components.beforeListTable.push(new BulkDocumentTranslationDashboard(access));
-          });
-          return cfg;
-        },
-
-        // 3. Runner configures jobs/tasks/autorun
-        runnerConfigModifier,
-
-        // 4. Add global endpoints — the 6 job-API routes as one shared bundle
-        (cfg) => {
-          if (!cfg.endpoints) cfg.endpoints = [];
-          const collectionConfig = { availableCollections: collectionSlugs };
-          cfg.endpoints.push(
-            ...createTranslationRoutes({
-              taskRunnerFactory,
-              collectionConfig,
-              access,
-              basePath,
-            })
-          );
-          return cfg;
-        }
-      )(config);
+      // The single place the Payload config is mutated.
+      return builder.applyTo(config);
     };
   }
 }

--- a/packages/payload-plugin-translator/src/server/features/createTranslationRoutes.ts
+++ b/packages/payload-plugin-translator/src/server/features/createTranslationRoutes.ts
@@ -23,10 +23,10 @@ export type TranslationRoutesDeps = {
  * (enqueue / run / cancel / cancel-by-collection / document-status /
  * collection-status), all wired to the same runner factory and access guard.
  *
- * Extracted from the plugin's `init()` so registration is a single unit — Phase
- * 1 will register this bundle conditionally (only when a job-based level is
- * present) instead of unconditionally. Behaviour-preserving: same endpoints,
- * same order, same wiring as the previous inline registration.
+ * Extracted from the plugin's `init()` so registration is a single unit. The
+ * document and collection levels each contribute this bundle via the level
+ * context; the plugin deduplicates by method + path, so it registers exactly
+ * once. Behaviour-preserving: same endpoints, same order, same wiring.
  */
 export function createTranslationRoutes({ taskRunnerFactory, collectionConfig, access, basePath }: TranslationRoutesDeps): Endpoint[] {
   return [

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsRunnerProvider.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsRunnerProvider.ts
@@ -199,7 +199,22 @@ export class PayloadJobsRunnerProvider implements TaskRunnerProvider {
 }
 
 /**
- * Creates a TaskRunnerProvider that uses Payload Jobs for task execution.
+ * Creates the **recommended** task runner: translations run as Payload Jobs
+ * (queued, executed by autoRun cron or a manual run, with stale-lock recovery).
+ * Durable across restarts and suited to production/serverless. Pass the result
+ * as `translatorPlugin({ runner })`.
+ *
+ * @param options - Queue/task names, `autoRun` cron (or `false` to disable),
+ *   `staleJobTimeoutMs`, and retry policy. See {@link PayloadJobsRunnerOptions}.
+ * @returns A {@link TaskRunnerProvider} for the plugin's `runner` option.
+ * @example
+ * ```ts
+ * translatorPlugin({
+ *   collections: [Posts],
+ *   translationProvider: createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY! }),
+ *   runner: createPayloadJobsRunner({ autoRun: { cron: '* * * * *' } }),
+ * })
+ * ```
  */
 export function createPayloadJobsRunner(options?: PayloadJobsRunnerOptions): TaskRunnerProvider {
   return new PayloadJobsRunnerProvider(options);

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncRunnerProvider.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncRunnerProvider.ts
@@ -46,10 +46,19 @@ export class SyncRunnerProvider implements TaskRunnerProvider {
 }
 
 /**
- * Creates a synchronous TaskRunnerProvider.
+ * Creates a synchronous task runner: translations execute inline on enqueue,
+ * with no Payload Jobs queue. Status is kept in an in-memory map (bounded by
+ * `maxSize`/`ttlMs`) and is **lost on server restart**, so this is best for
+ * development, tests, or simple single-process setups — not serverless. Pass the
+ * result as `translatorPlugin({ runner })`.
  *
- * Executes translations immediately without queuing.
- * Results are stored in memory and lost on server restart.
+ * @param options - In-memory store bounds: `maxSize` (default 100) and `ttlMs`
+ *   (default 1h) for completed/failed task records.
+ * @returns A {@link TaskRunnerProvider} for the plugin's `runner` option.
+ * @example
+ * ```ts
+ * translatorPlugin({ collections, translationProvider, runner: createSyncRunner() })
+ * ```
  */
 export function createSyncRunner(options?: SyncRunnerOptions): TaskRunnerProvider {
   return new SyncRunnerProvider(options);

--- a/packages/payload-plugin-translator/src/server/modules/translation-levels/PluginConfigBuilder.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-levels/PluginConfigBuilder.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import type { CollectionConfig, Config, Endpoint } from "payload";
+
+import type { RawPayloadComponentExport } from "../../../client/shared/types/PayloadComponentExport";
+
+import { PluginConfigBuilder } from "./PluginConfigBuilder";
+
+const deps = (collections: Array<{ slug: string }> = []) => ({
+  collections: collections as unknown as CollectionConfig[],
+  basePath: "/translate",
+  taskRunnerFactory: { create: vi.fn() },
+});
+
+const ep = (method: string, path: string): Endpoint => ({ method, path, handler: vi.fn() }) as unknown as Endpoint;
+
+const component = (path: string) => ({ path }) as unknown as RawPayloadComponentExport;
+
+describe("PluginConfigBuilder", () => {
+  it("deduplicates endpoints by method + path", () => {
+    const builder = new PluginConfigBuilder(deps());
+    builder.addEndpoints([ep("post", "/translate/enqueue"), ep("post", "/translate/run/:id")]);
+    builder.addEndpoints([ep("post", "/translate/enqueue")]); // same method+path → dropped
+
+    const config = {} as Config;
+    builder.applyTo(config);
+
+    expect(config.endpoints?.map((e) => `${e.method} ${e.path}`)).toEqual(["post /translate/enqueue", "post /translate/run/:id"]);
+  });
+
+  it("keeps endpoints that differ in method or path", () => {
+    const builder = new PluginConfigBuilder(deps());
+    builder.addEndpoints([ep("post", "/translate/cancel"), ep("delete", "/translate/cancel")]);
+
+    const config = {} as Config;
+    builder.applyTo(config);
+
+    expect(config.endpoints).toHaveLength(2);
+  });
+
+  it("attaches components only to managed collections, on the right slot", () => {
+    const builder = new PluginConfigBuilder(deps([{ slug: "posts" }]));
+    const doc = component("doc");
+    const bulk = component("bulk");
+    builder.addCollectionComponent("beforeDocumentControls", () => doc);
+    builder.addCollectionComponent("beforeListTable", () => bulk);
+
+    const config = {
+      collections: [{ slug: "posts" }, { slug: "other" }],
+    } as unknown as Config;
+    builder.applyTo(config);
+
+    const posts = config.collections![0] as Record<string, any>;
+    const other = config.collections![1] as Record<string, any>;
+    expect(posts.admin.components.edit.beforeDocumentControls).toEqual([doc]);
+    expect(posts.admin.components.beforeListTable).toEqual([bulk]);
+    expect(other.admin).toBeUndefined(); // unmanaged collection untouched
+  });
+
+  it("registers admin providers into config.admin.components.providers", () => {
+    const builder = new PluginConfigBuilder(deps());
+    const provider = component("cache");
+    builder.addAdminProvider(provider);
+
+    const config = {} as Config;
+    builder.applyTo(config);
+
+    expect(config.admin?.components?.providers).toEqual([provider]);
+  });
+
+  it("applies config modifiers in registration order", () => {
+    const builder = new PluginConfigBuilder(deps());
+    const order: string[] = [];
+    builder.addConfigModifier((c) => {
+      order.push("first");
+      return c;
+    });
+    builder.addConfigModifier((c) => {
+      order.push("second");
+      return c;
+    });
+
+    builder.applyTo({} as Config);
+
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  it("does not re-add an endpoint already present in config.endpoints (keeps the existing one)", () => {
+    const builder = new PluginConfigBuilder(deps());
+    builder.addEndpoints([ep("post", "/translate/enqueue")]);
+
+    const original = ep("post", "/translate/enqueue");
+    const config = { endpoints: [original] } as unknown as Config;
+    builder.applyTo(config);
+
+    expect(config.endpoints).toHaveLength(1); // not duplicated
+    expect(config.endpoints?.[0]).toBe(original); // the pre-existing route is kept, ours skipped
+  });
+
+  it("threads a fresh config returned by a modifier through every later write", () => {
+    const builder = new PluginConfigBuilder(deps());
+    const fresh = {} as Config;
+    builder.addConfigModifier(() => fresh); // runner-style: returns a brand-new object
+    builder.addAdminProvider(component("cache"));
+
+    const original = {} as Config;
+    const result = builder.applyTo(original);
+
+    expect(result).toBe(fresh);
+    expect(fresh.admin?.components?.providers).toHaveLength(1); // landed on the fresh config
+    expect(original.admin).toBeUndefined(); // not on the original
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/translation-levels/PluginConfigBuilder.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-levels/PluginConfigBuilder.ts
@@ -1,0 +1,145 @@
+import type { CollectionConfig, Config, Endpoint } from "payload";
+
+import type { AccessGuard } from "../../../types/AccessGuard";
+import type { RawPayloadComponentExport } from "../../../client/shared/types/PayloadComponentExport";
+import type { TaskRunnerFactory } from "../task-runner";
+
+import type { CollectionAdminSlot, LevelContext } from "./types";
+
+type CollectionComponent = {
+  slot: CollectionAdminSlot;
+  make: (collection: CollectionConfig) => RawPayloadComponentExport;
+};
+
+type ConfigModifier = (config: Config) => Config;
+
+export type PluginConfigBuilderDeps = {
+  collections: CollectionConfig[];
+  basePath: string;
+  access?: AccessGuard;
+  taskRunnerFactory: TaskRunnerFactory;
+};
+
+const endpointKey = (endpoint: Endpoint): string => `${endpoint.method} ${endpoint.path}`;
+
+function attachToSlot(collection: CollectionConfig, slot: CollectionAdminSlot, component: RawPayloadComponentExport): void {
+  if (!collection.admin) collection.admin = {};
+  if (!collection.admin.components) collection.admin.components = {};
+  const components = collection.admin.components;
+
+  if (slot === "beforeDocumentControls") {
+    if (!components.edit) components.edit = {};
+    if (!components.edit.beforeDocumentControls) components.edit.beforeDocumentControls = [];
+    components.edit.beforeDocumentControls.push(component);
+    return;
+  }
+
+  if (slot === "beforeListTable") {
+    if (!components.beforeListTable) components.beforeListTable = [];
+    components.beforeListTable.push(component);
+    return;
+  }
+
+  // Exhaustiveness: a new CollectionAdminSlot must be handled above, not fall through.
+  slot satisfies never;
+}
+
+/**
+ * The single place that mutates the Payload `config`. Levels (through the narrow
+ * {@link LevelContext}) and the plugin (through `addAdminProvider` /
+ * `addConfigModifier`) only *describe* their contributions; `applyTo(config)` is
+ * the one sink that writes them in. This keeps Payload's in-place-mutation style
+ * — including the lazy nested-config init — confined here, so `plugin.ts` and the
+ * levels stay free of direct config mutation.
+ *
+ * It implements {@link LevelContext}, so the same instance is what levels receive
+ * as their context (they see only `addEndpoints` / `addCollectionComponent`).
+ */
+export class PluginConfigBuilder implements LevelContext {
+  readonly collections: CollectionConfig[];
+  readonly basePath: string;
+  readonly access?: AccessGuard;
+  readonly taskRunnerFactory: TaskRunnerFactory;
+
+  private readonly endpoints: Endpoint[] = [];
+  private readonly collectionComponents: CollectionComponent[] = [];
+  private readonly adminProviders: RawPayloadComponentExport[] = [];
+  private readonly configModifiers: ConfigModifier[] = [];
+
+  constructor(deps: PluginConfigBuilderDeps) {
+    this.collections = deps.collections;
+    this.basePath = deps.basePath;
+    this.access = deps.access;
+    this.taskRunnerFactory = deps.taskRunnerFactory;
+  }
+
+  addEndpoints(endpoints: Endpoint[]): void {
+    this.endpoints.push(...endpoints);
+  }
+
+  addCollectionComponent(slot: CollectionAdminSlot, make: (collection: CollectionConfig) => RawPayloadComponentExport): void {
+    this.collectionComponents.push({ slot, make });
+  }
+
+  /** Register a global admin provider (e.g. the client cache provider). */
+  addAdminProvider(provider: RawPayloadComponentExport): void {
+    this.adminProviders.push(provider);
+  }
+
+  /** Register a config modifier (e.g. the runner's jobs/autorun/onInit setup). */
+  addConfigModifier(modifier: ConfigModifier): void {
+    this.configModifiers.push(modifier);
+  }
+
+  /** The one sink that writes every accumulated contribution into `config`. */
+  applyTo(config: Config): Config {
+    // Config modifiers first — a runner's modifier may return a fresh config
+    // object, so everything else must be applied to its result.
+    let result = config;
+    for (const modify of this.configModifiers) result = modify(result);
+
+    this.attachAdminProviders(result);
+    this.attachCollectionComponents(result);
+    this.registerEndpoints(result);
+    return result;
+  }
+
+  private attachAdminProviders(config: Config): void {
+    if (this.adminProviders.length === 0) return;
+    if (!config.admin) config.admin = {};
+    if (!config.admin.components) config.admin.components = {};
+    if (!config.admin.components.providers) config.admin.components.providers = [];
+    // Not deduplicated. Unlike a duplicate endpoint (a route conflict), a
+    // duplicate admin provider is harmless, and providers have no reliable
+    // identity key across their shapes (`string | { path } | false`, with
+    // distinguishing `serverProps`). The single CacheProvider is added once per
+    // plugin instance.
+    config.admin.components.providers.push(...this.adminProviders);
+  }
+
+  private attachCollectionComponents(config: Config): void {
+    if (this.collectionComponents.length === 0) return;
+    const managed = new Set(this.collections.map((collection) => collection.slug));
+    config.collections?.forEach((collection) => {
+      if (!managed.has(collection.slug)) return;
+      for (const { slot, make } of this.collectionComponents) {
+        attachToSlot(collection, slot, make(collection));
+      }
+    });
+  }
+
+  private registerEndpoints(config: Config): void {
+    if (this.endpoints.length === 0) return;
+    if (!config.endpoints) config.endpoints = [];
+    // Seed from endpoints already on the config so each (method, path) registers
+    // once — across the levels' contributions AND anything already present (e.g.
+    // the plugin registered twice, or a host route at the same path).
+    const seen = new Set(config.endpoints.map(endpointKey));
+    for (const endpoint of this.endpoints) {
+      const key = endpointKey(endpoint);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      config.endpoints.push(endpoint);
+    }
+  }
+}

--- a/packages/payload-plugin-translator/src/server/modules/translation-levels/collectionLevel.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-levels/collectionLevel.ts
@@ -1,0 +1,26 @@
+import { BulkDocumentTranslationDashboard } from "../../../client/widgets/bulk-translation-dashboard/ui/BulkTranslationDashboard.export";
+
+import type { TranslationLevel } from "./types";
+import { useDocTranslationApi } from "./useDocTranslationApi";
+
+/**
+ * Bulk collection translation: a dashboard on the list view (translate many
+ * documents at once), backed by the same shared document-translation API as
+ * {@link documentLevel}.
+ *
+ * @since 0.5.0
+ * @returns An opaque {@link TranslationLevel} to list in `translatorPlugin({ levels })`.
+ * @example
+ * ```ts
+ * // Enable only bulk collection translation (no per-document popup):
+ * translatorPlugin({ collections: [Posts], translationProvider, runner, levels: [collectionLevel()] })
+ * ```
+ */
+export function collectionLevel(): TranslationLevel {
+  return {
+    extend(ctx) {
+      useDocTranslationApi(ctx);
+      ctx.addCollectionComponent("beforeListTable", () => new BulkDocumentTranslationDashboard(ctx.access));
+    },
+  };
+}

--- a/packages/payload-plugin-translator/src/server/modules/translation-levels/documentLevel.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-levels/documentLevel.ts
@@ -1,0 +1,30 @@
+import { TranslateDocumentExport } from "../../../client/widgets/translate-document";
+
+import type { TranslationLevel } from "./types";
+import { useDocTranslationApi } from "./useDocTranslationApi";
+
+/**
+ * Per-document translation: a popup control on the document edit view, backed by
+ * the shared document-translation API (async/job by default; synchronous if the
+ * configured `runner` is a sync runner).
+ *
+ * @since 0.5.0
+ * @returns An opaque {@link TranslationLevel} to list in `translatorPlugin({ levels })`.
+ * @example
+ * ```ts
+ * translatorPlugin({
+ *   collections: [Posts],
+ *   translationProvider,
+ *   runner: createPayloadJobsRunner(),
+ *   levels: [documentLevel(), collectionLevel()], // this is the default — omit for the same result
+ * })
+ * ```
+ */
+export function documentLevel(): TranslationLevel {
+  return {
+    extend(ctx) {
+      useDocTranslationApi(ctx);
+      ctx.addCollectionComponent("beforeDocumentControls", (collection) => new TranslateDocumentExport(collection, ctx.access));
+    },
+  };
+}

--- a/packages/payload-plugin-translator/src/server/modules/translation-levels/index.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-levels/index.ts
@@ -1,0 +1,3 @@
+export type { TranslationLevel } from "./types";
+export { documentLevel } from "./documentLevel";
+export { collectionLevel } from "./collectionLevel";

--- a/packages/payload-plugin-translator/src/server/modules/translation-levels/levels.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-levels/levels.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import type { CollectionConfig } from "payload";
+
+import { TranslateDocumentExport } from "../../../client/widgets/translate-document";
+import { BulkDocumentTranslationDashboard } from "../../../client/widgets/bulk-translation-dashboard/ui/BulkTranslationDashboard.export";
+
+import { documentLevel } from "./documentLevel";
+import { collectionLevel } from "./collectionLevel";
+import type { CollectionAdminSlot, LevelContext } from "./types";
+
+const fakeCollection = {
+  slug: "posts",
+  fields: [],
+} as unknown as CollectionConfig;
+
+// Pull the make() callback handed to addCollectionComponent for the given slot.
+const componentFor = (ctx: LevelContext, slot: CollectionAdminSlot) => {
+  const call = (ctx.addCollectionComponent as ReturnType<typeof vi.fn>).mock.calls.find((c) => c[0] === slot);
+  return call?.[1](fakeCollection);
+};
+
+// Unit-level: a level's extend() should call the expected context primitives.
+// The shared route bundle + component construction are covered elsewhere; here
+// we only assert the wiring (which primitive, which slot).
+const makeCtx = (): LevelContext => ({
+  collections: [{ slug: "posts", fields: [] } as unknown as CollectionConfig],
+  basePath: "/translate",
+  access: undefined,
+  taskRunnerFactory: { create: vi.fn() },
+  addEndpoints: vi.fn(),
+  addCollectionComponent: vi.fn(),
+});
+
+describe("documentLevel", () => {
+  it("contributes the document-translation bundle + a beforeDocumentControls component", () => {
+    const ctx = makeCtx();
+
+    documentLevel().extend(ctx);
+
+    expect(ctx.addEndpoints).toHaveBeenCalledTimes(1);
+    expect((ctx.addEndpoints as ReturnType<typeof vi.fn>).mock.calls[0][0]).toHaveLength(6);
+    expect(ctx.addCollectionComponent).toHaveBeenCalledWith("beforeDocumentControls", expect.any(Function));
+    expect(componentFor(ctx, "beforeDocumentControls")).toBeInstanceOf(TranslateDocumentExport);
+  });
+});
+
+describe("collectionLevel", () => {
+  it("contributes the document-translation bundle + a beforeListTable component", () => {
+    const ctx = makeCtx();
+
+    collectionLevel().extend(ctx);
+
+    expect(ctx.addEndpoints).toHaveBeenCalledTimes(1);
+    expect((ctx.addEndpoints as ReturnType<typeof vi.fn>).mock.calls[0][0]).toHaveLength(6);
+    expect(ctx.addCollectionComponent).toHaveBeenCalledWith("beforeListTable", expect.any(Function));
+    expect(componentFor(ctx, "beforeListTable")).toBeInstanceOf(BulkDocumentTranslationDashboard);
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/translation-levels/types.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-levels/types.ts
@@ -1,0 +1,47 @@
+import type { CollectionConfig, Endpoint } from "payload";
+
+import type { AccessGuard } from "../../../types/AccessGuard";
+import type { RawPayloadComponentExport } from "../../../client/shared/types/PayloadComponentExport";
+import type { TaskRunnerFactory } from "../task-runner";
+
+export type CollectionAdminSlot = "beforeDocumentControls" | "beforeListTable";
+
+/**
+ * A composable translation surface (document / collection / field).
+ *
+ * Treat it as an **opaque value**: create one with `documentLevel()` /
+ * `collectionLevel()` (and, later, `fieldLevel()`) and list it in
+ * `translatorPlugin({ levels })`. It is produced only by those built-in
+ * factories — not externally implementable yet, since {@link LevelContext} is
+ * intentionally not exported. Opening it later (export `LevelContext`, drop the
+ * `@internal` tag) is additive and non-breaking.
+ *
+ * @since 0.5.0
+ */
+export interface TranslationLevel {
+  /**
+   * Not a stable contract yet — produce via the level factories.
+   * @internal
+   */
+  extend(ctx: LevelContext): void;
+}
+
+/**
+ * Public-ready shape, kept internal until external levels are needed.
+ *
+ * A level contributes via these generic primitives; it never mutates the raw
+ * Payload config. The plugin deduplicates endpoints by method + path on apply.
+ * (fieldLevel — Phase 2 — will also read `schemaMap` + `translationProvider`.)
+ * @internal
+ */
+export interface LevelContext {
+  readonly collections: CollectionConfig[];
+  readonly basePath: string;
+  readonly access?: AccessGuard;
+  readonly taskRunnerFactory: TaskRunnerFactory;
+
+  /** Register endpoints. Deduplicated by method + path when applied. */
+  addEndpoints(endpoints: Endpoint[]): void;
+  /** Attach an admin component to a slot on every managed collection. */
+  addCollectionComponent(slot: CollectionAdminSlot, make: (collection: CollectionConfig) => RawPayloadComponentExport): void;
+}

--- a/packages/payload-plugin-translator/src/server/modules/translation-levels/useDocTranslationApi.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-levels/useDocTranslationApi.ts
@@ -1,0 +1,22 @@
+import { createTranslationRoutes } from "../../features/createTranslationRoutes";
+
+import type { LevelContext } from "./types";
+
+/**
+ * Contribute the runner-agnostic document-translation API — the shared 6-route
+ * bundle, bound to the level context's runner. Both `documentLevel` and
+ * `collectionLevel` call this; the plugin deduplicates the endpoints by method +
+ * path, so the bundle registers exactly once.
+ */
+export function useDocTranslationApi(ctx: LevelContext): void {
+  ctx.addEndpoints(
+    createTranslationRoutes({
+      taskRunnerFactory: ctx.taskRunnerFactory,
+      collectionConfig: {
+        availableCollections: new Set(ctx.collections.map((collection) => collection.slug)),
+      },
+      access: ctx.access,
+      basePath: ctx.basePath,
+    })
+  );
+}

--- a/packages/payload-plugin-translator/src/server/modules/translation-providers/OpenAITranslation.provider.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-providers/OpenAITranslation.provider.ts
@@ -1,44 +1,45 @@
-import OpenAI from 'openai'
+import OpenAI from "openai";
 
-import type { TranslationProvider, TranslationInput, TranslationOutput } from './TranslationProvider.interface'
-import { isObject } from '../../shared'
-import type { ChatModel } from 'openai/resources/index.mjs'
+import type { TranslationProvider, TranslationInput, TranslationOutput } from "./TranslationProvider.interface";
+import { isObject } from "../../shared";
+import type { ChatModel } from "openai/resources/index.mjs";
 
 /**
  * Function to transform text in dry run mode.
  * Receives the original text and returns the transformed text.
  */
-type DryRunTransformer = (text: string) => string | Promise<string>
+type DryRunTransformer = (text: string) => string | Promise<string>;
 
 /**
  * Configuration for dry run mode with custom transformer.
  */
 export type DryRunConfig = {
   /** Custom transformer function for text */
-  transform: DryRunTransformer
+  transform: DryRunTransformer;
   /** Delay in milliseconds before returning mock translation (simulates API latency) */
-  timeout?: number
-}
+  timeout?: number;
+};
 
 /**
  * Context passed to the system prompt builder function.
  */
 export type SystemPromptContext = {
   /** Source language code (e.g., 'en', 'de') */
-  sourceLang: string
+  sourceLang: string;
   /** Target language code (e.g., 'fr', 'es') */
-  targetLang: string
+  targetLang: string;
   /** Default system prompt that can be extended or replaced */
-  defaultPrompt: string
-}
+  defaultPrompt: string;
+};
 
 /**
  * Function to build a custom system prompt for translation.
  */
-type SystemPromptBuilder = (context: SystemPromptContext) => string
+type SystemPromptBuilder = (context: SystemPromptContext) => string;
 
 export type OpenAIProviderConfig = {
-  apiKey: string
+  /** OpenAI API key (required). Read it from an env var — never hard-code it. */
+  apiKey: string;
   /**
    * OpenAI model to use for translation.
    *
@@ -47,7 +48,7 @@ export type OpenAIProviderConfig = {
    * @example
    * model: 'gpt-4o-mini'
    */
-  model?: (string & {}) | ChatModel
+  model?: (string & {}) | ChatModel;
   /**
    * Custom system prompt builder for translation.
    * Receives context with source/target languages and the default prompt.
@@ -62,7 +63,7 @@ export type OpenAIProviderConfig = {
    * systemPrompt: ({ sourceLang, targetLang }) =>
    *   `Translate JSON values from ${sourceLang} to ${targetLang}. Be concise.`
    */
-  systemPrompt?: SystemPromptBuilder
+  systemPrompt?: SystemPromptBuilder;
   /**
    * When enabled, simulates translations without making actual API calls to OpenAI.
    *
@@ -82,55 +83,57 @@ export type OpenAIProviderConfig = {
    *
    * @default false
    */
-  dryRun?: boolean | DryRunConfig
-}
+  dryRun?: boolean | DryRunConfig;
+};
 
 /** @deprecated Use `createOpenAIProvider` function instead */
 export class OpenAITranslationProvider implements TranslationProvider {
-  private openAiClient: OpenAI
+  private openAiClient: OpenAI;
+  private readonly config: OpenAIProviderConfig;
 
-  constructor(private readonly config: OpenAIProviderConfig) {
-    this.openAiClient = new OpenAI({ apiKey: config.apiKey })
+  constructor(config: OpenAIProviderConfig) {
+    this.openAiClient = new OpenAI({ apiKey: config.apiKey });
+    this.config = config;
   }
 
   async translate(content: TranslationInput, souceLng: string, targetLng: string): Promise<TranslationOutput | null> {
     if (this.config.dryRun) {
-      console.info('[DRY RUN] Translation simulation:', {
+      console.info("[DRY RUN] Translation simulation:", {
         content,
         sourceLang: souceLng,
         targetLang: targetLng,
-        provider: 'OpenAI',
-      })
+        provider: "OpenAI",
+      });
 
-      const timeout = this.getDryRunTimeout()
-      if (timeout > 0) await new Promise((resolve) => setTimeout(resolve, timeout))
+      const timeout = this.getDryRunTimeout();
+      if (timeout > 0) await new Promise((resolve) => setTimeout(resolve, timeout));
 
-      const transformer = this.getDryRunTransformer()
-      return this.createMockTranslation(content, transformer)
+      const transformer = this.getDryRunTransformer();
+      return this.createMockTranslation(content, transformer);
     }
 
-    const systemPrompt = this.buildSystemPrompt(souceLng, targetLng)
+    const systemPrompt = this.buildSystemPrompt(souceLng, targetLng);
 
     const chatCompletion = await this.openAiClient.chat.completions.create({
       messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: JSON.stringify(content) },
+        { role: "system", content: systemPrompt },
+        { role: "user", content: JSON.stringify(content) },
       ],
-      model: this.config.model ?? 'gpt-4o',
+      model: this.config.model ?? "gpt-4o",
       temperature: 0,
       top_p: 1,
       frequency_penalty: 0,
       presence_penalty: 0,
-      response_format: { type: 'json_object' },
-    })
+      response_format: { type: "json_object" },
+    });
 
-    const translatedContent = chatCompletion.choices[0].message.content
-    if (!translatedContent) return null
+    const translatedContent = chatCompletion.choices[0].message.content;
+    if (!translatedContent) return null;
 
     try {
-      return JSON.parse(translatedContent)
+      return JSON.parse(translatedContent);
     } catch {
-      return null
+      return null;
     }
   }
 
@@ -138,15 +141,21 @@ export class OpenAITranslationProvider implements TranslationProvider {
    * Builds the system prompt for translation.
    */
   private buildSystemPrompt(sourceLang: string, targetLang: string): string {
-    const defaultPrompt = `Translate the values from the JSON that the user will send you${sourceLang ? ` from ${sourceLang}` : ''} into ${targetLang}. Keep all JSON keys exactly as they are, only translate the values.
+    const defaultPrompt = `Translate the values from the JSON that the user will send you${
+      sourceLang ? ` from ${sourceLang}` : ""
+    } into ${targetLang}. Keep all JSON keys exactly as they are, only translate the values.
 The response should be a valid JSON object with the same structure and keys as the input, but with translated values.
-Maintain any special formatting, placeholders, or variables within the values if they exist.`
+Maintain any special formatting, placeholders, or variables within the values if they exist.`;
 
     if (this.config.systemPrompt) {
-      return this.config.systemPrompt({ sourceLang, targetLang, defaultPrompt })
+      return this.config.systemPrompt({
+        sourceLang,
+        targetLang,
+        defaultPrompt,
+      });
     }
 
-    return defaultPrompt
+    return defaultPrompt;
   }
 
   /**
@@ -155,10 +164,10 @@ Maintain any special formatting, placeholders, or variables within the values if
    * If dryRun is true, returns the default transformer that reverses text.
    */
   private getDryRunTransformer(): DryRunTransformer {
-    if (typeof this.config.dryRun === 'object' && this.config.dryRun.transform) {
-      return this.config.dryRun.transform
+    if (typeof this.config.dryRun === "object" && this.config.dryRun.transform) {
+      return this.config.dryRun.transform;
     }
-    return (text: string) => text.split('').reverse().join('')
+    return (text: string) => text.split("").reverse().join("");
   }
 
   /**
@@ -167,25 +176,22 @@ Maintain any special formatting, placeholders, or variables within the values if
    * Otherwise returns 0 (no delay).
    */
   private getDryRunTimeout(): number {
-    if (typeof this.config.dryRun === 'object' && this.config.dryRun.timeout) {
-      return this.config.dryRun.timeout
+    if (typeof this.config.dryRun === "object" && this.config.dryRun.timeout) {
+      return this.config.dryRun.timeout;
     }
-    return 0
+    return 0;
   }
 
-  private async createMockTranslation(
-    content: TranslationInput,
-    transformer: DryRunTransformer,
-  ): Promise<TranslationOutput | null> {
+  private async createMockTranslation(content: TranslationInput, transformer: DryRunTransformer): Promise<TranslationOutput | null> {
     try {
       const mockTranslation = await this.transformObjectValues(content, async (value) => {
-        if (typeof value === 'string' && value.trim()) return transformer(value)
-        return value
-      })
+        if (typeof value === "string" && value.trim()) return transformer(value);
+        return value;
+      });
 
-      return mockTranslation as TranslationOutput
+      return mockTranslation as TranslationOutput;
     } catch {
-      return null
+      return null;
     }
   }
 
@@ -195,23 +201,20 @@ Maintain any special formatting, placeholders, or variables within the values if
    * @param transformer The function to apply to each value.
    * @returns The transformed object, array, or value.
    */
-  private async transformObjectValues(
-    obj: unknown,
-    transformer: (value: unknown) => unknown | Promise<unknown>,
-  ): Promise<unknown> {
+  private async transformObjectValues(obj: unknown, transformer: (value: unknown) => unknown | Promise<unknown>): Promise<unknown> {
     if (Array.isArray(obj)) {
-      return Promise.all(obj.map((item) => this.transformObjectValues(item, transformer)))
+      return Promise.all(obj.map((item) => this.transformObjectValues(item, transformer)));
     }
 
     if (isObject(obj)) {
-      const result: Record<string, unknown> = {}
+      const result: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(obj)) {
-        result[key] = await this.transformObjectValues(value, transformer)
+        result[key] = await this.transformObjectValues(value, transformer);
       }
-      return result
+      return result;
     }
 
-    return transformer(obj)
+    return transformer(obj);
   }
 }
 
@@ -232,5 +235,5 @@ Maintain any special formatting, placeholders, or variables within the values if
  * ```
  */
 export function createOpenAIProvider(config: OpenAIProviderConfig): OpenAITranslationProvider {
-  return new OpenAITranslationProvider(config)
+  return new OpenAITranslationProvider(config);
 }

--- a/packages/payload-plugin-translator/src/types/AccessGuard.ts
+++ b/packages/payload-plugin-translator/src/types/AccessGuard.ts
@@ -1,11 +1,34 @@
-import type { BasePayload, TypedUser } from 'payload'
+import type { BasePayload, TypedUser } from "payload";
 
+/**
+ * The request context an {@link AccessGuard} receives when deciding whether to
+ * allow a translation API call.
+ */
 export type AccessGuardRequest = {
-  headers: Headers
-  user?: TypedUser | null
-  payload: BasePayload
-}
+  /** Incoming request headers (e.g. for token/cookie checks). */
+  headers: Headers;
+  /** The authenticated user, or `null`/`undefined` if the request is anonymous. */
+  user?: TypedUser | null;
+  /** The Payload instance, for any DB/permission lookups the guard needs. */
+  payload: BasePayload;
+};
 
+/**
+ * Gate for the translation API endpoints. Provide one via `translatorPlugin({ access })`
+ * to control who may trigger translations; omit it to leave the endpoints open.
+ *
+ * @example
+ * ```ts
+ * const adminsOnly: AccessGuard = {
+ *   check: ({ req }) => req.user?.role === 'admin',
+ * }
+ * translatorPlugin({ collections, translationProvider, runner, access: adminsOnly })
+ * ```
+ */
 export interface AccessGuard {
-  check<R extends AccessGuardRequest>({ req }: { req: R }): Promise<boolean> | boolean
+  /**
+   * Return `true` to allow the request, `false` to reject it with `403 Forbidden`.
+   * May be async (e.g. to query permissions).
+   */
+  check<R extends AccessGuardRequest>({ req }: { req: R }): Promise<boolean> | boolean;
 }


### PR DESCRIPTION
## What

Adds a `levels` option to `translatorPlugin` so the **per-document popup** and the **bulk-collection dashboard** can be enabled independently, via the `documentLevel()` / `collectionLevel()` factories.

```ts
translatorPlugin({
  collections: [Posts],
  translationProvider: createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY }),
  runner: createPayloadJobsRunner(),
  levels: [collectionLevel()], // bulk dashboard only — no per-document popup
})
```

Omitting `levels` keeps today's behaviour (`[documentLevel(), collectionLevel()]`), so the option is **non-breaking**.

## How

- **Single config-writer (`PluginConfigBuilder`)** — all Payload `config` mutation is now confined to one sink. Levels and the plugin only *describe* their contributions (endpoints, collection components, admin providers, config modifiers); `applyTo(config)` is the one place they're written in. This keeps `plugin.ts` and the levels free of direct config mutation.
- **Endpoint dedup by method+path** — both levels contribute the shared 6-route bundle, so it registers exactly once (also guards against a second plugin pass / a host route at the same path).
- **Levels are a closed-but-openable set** — `TranslationLevel` is an opaque value created by the factories; the `extend(ctx)` / `LevelContext` surface is `@internal`, leaving room to open it later without a breaking change.

## Public API (new, `@since 0.5.0`)

- `levels?: TranslationLevel[]` on `TranslatorPluginConfig`
- `documentLevel()`, `collectionLevel()` factories + the `TranslationLevel` type

## Docs

- README: Features bullet, `levels` config row, **Translation Levels** section (all marked _Since v0.5.0_).
- New package-scoped `CLAUDE.md` documenting the `@since` / "Since vX" versioning practice.
- Comprehensive JSDoc across the public API.

## Verification

- `check-types` ✓ · **602 tests** ✓ · lint 0 errors.
- Behaviour-preserving e2e guard: default levels reproduce today's wiring (6-route bundle, cache provider, doc popup + bulk dashboard on managed collections, runner configured once); double-apply on the same config stays at 6 endpoints.

## Release

`feat` on top of `0.4.0` → **minor → 0.5.0** once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)