### PR TITLE
chore(dev): wire translation levels into sandbox config

### DIFF
--- a/apps/dev/src/payload-types.ts
+++ b/apps/dev/src/payload-types.ts
@@ -830,10 +830,15 @@ export interface CollectionsWidget {
  */
 export interface TaskTranslateDocument {
   input: {
-    collection: {
+    collection_slug: string;
+    collection_id: string;
+    /**
+     * Deprecated. See docs/DEPRECATIONS.md#jobs-input-collection-field
+     */
+    collection?: {
       relationTo: "pages";
       value: number | Page;
-    };
+    } | null;
     source_lng: string;
     target_lng: string;
     strategy: string;

--- a/apps/dev/src/payload.config.ts
+++ b/apps/dev/src/payload.config.ts
@@ -5,7 +5,7 @@ import { abTestingPlugin } from "@focus-reactive/payload-plugin-ab";
 import { commentsPlugin } from "@focus-reactive/payload-plugin-comments";
 import { presetsPlugin } from "@focus-reactive/payload-plugin-presets";
 import { schedulePublicationPlugin } from "@focus-reactive/payload-plugin-scheduling";
-import { translatorPlugin, createOpenAIProvider, createPayloadJobsRunner } from "@focus-reactive/payload-plugin-translator";
+import { translatorPlugin, createOpenAIProvider, createPayloadJobsRunner, documentLevel, collectionLevel } from "@focus-reactive/payload-plugin-translator";
 import { analyticsPlugin } from "@focus-reactive/payload-plugin-analytics";
 import { sqliteAdapter } from "@payloadcms/db-sqlite";
 import { lexicalEditor } from "@payloadcms/richtext-lexical";
@@ -87,6 +87,7 @@ export default buildConfig({
         apiKey: process.env.OPENAI_API_KEY ?? "",
         dryRun: !process.env.OPENAI_API_KEY,
       }),
+      levels: [documentLevel(), collectionLevel()],
     }),
     analyticsPlugin({
       ga4: {


### PR DESCRIPTION
Wires `levels: [documentLevel(), collectionLevel()]` into the dev sandbox (`apps/dev/src/payload.config.ts`) to exercise the translation-levels feature already in `main`, and regenerates `apps/dev/src/payload-types.ts` accordingly.

**Scope:** `apps/dev` only — the private dev sandbox. No published-package files change, so this triggers **no release / no version bump** (`apps/dev` is excluded via `--ignore-private-packages`).

Commit: `ebebaa9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)