### PR TITLE
chore(translator): add internal field-traversal engine

### DIFF
--- a/packages/payload-plugin-translator/docs/plans/2026-06-11-field-traversal-utility-design.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-11-field-traversal-utility-design.md
@@ -1,0 +1,305 @@
+# Field Traversal Utility — design
+
+**Date:** 2026-06-11
+**Status:** Engine implemented (Steps 1–2 done) — `kernel.ts` + `walkFields.ts` green, sites not yet migrated (Step 3 pending). Approach: **B+** (one engine, see "Decision & interface" below).
+**Scope:** Internal (`server/shared`) — not public API, no `@since` needed.
+
+We hand-roll the same Payload field-schema recursion in **four** places. Each one
+re-derives "how Payload containers nest and map onto data" (tabs → unnamed containers →
+group → array → blocks, plus block-slug lookup). That structural knowledge is the
+drift-prone, bug-prone part, and it is copy-pasted. This doc designs a single source of
+truth for it.
+
+## The four call sites
+
+| File | Data trees | Output mode | Site-specific rules |
+| --- | --- | --- | --- |
+| `server/features/translate-field/resolveFieldSubtree.ts` *(new, uncommitted)* | 0 — navigates a `path` | locate one node, early-exit | statuses `inside-blocks` / `not-translatable` / `not-found`; drops numeric path segments |
+| `server/shared/utils/filterLocalizedFields.ts` | 1 (`data`) | build a new pruned tree | keeps `id` on array items, `blockType`+`id` on blocks; drops empty containers; keeps only `isTranslatableField && isLocalizedField` leaves |
+| `server/modules/translation-pipeline/stages/data-reconciler/DataReconciler.ts` | 2 (`source`, `target`) | build a new merged tree | **strips** `id` (Postgres rejects it), keeps `blockType`; emits **all** fields; target-priority merge at leaves |
+| `server/modules/translation-pipeline/stages/field-collector/FieldChunkCollector.ts` | 3 (`filtered`, `source`, `target`) | flat `FieldChunk[]` + mutates `data` | tracks `path: string[]` incl. array indices; leaf kept if translatable && localized && `!excluded` && `strategy.shouldTranslate` |
+
+### What is identical across all four (the duplication)
+
+The structural dispatch, in this exact order:
+
+1. **tabs** — `for (const tab of field.tabs)`; guard `hasFields(tab)`; if `tabHasName(tab)`
+   → descend into `data[tab.name]` (a data boundary, group-like); else (unnamed) → descend
+   in the **same** data scope.
+2. **presentational container** — `!fieldAffectsData(field)` (row, collapsible) → if
+   `hasFields(field)` descend in the **same** scope; UI leaves are ignored.
+3. **group** — `fieldIsGroupType` → descend into `value` (object boundary).
+4. **array** — `fieldIsArrayType` → iterate items (`isObject` guard), descend per item.
+5. **blocks** — `fieldIsBlockType` → iterate items (`isBlockItem` guard), resolve
+   `field.blocks.find(b => b.slug === item.blockType)`, descend into `block.fields`.
+6. **leaf** — `fieldAffectsData`, no subfields → site-specific decision.
+
+Every site already correctly imports the predicates from `payload/shared`
+(`fieldAffectsData`, `fieldIsArrayType/BlockType/GroupType`, `tabHasName`). We are **not**
+re-implementing predicates — we are re-implementing the *control flow that strings them
+together*.
+
+### What genuinely differs (must stay caller-controlled)
+
+- **Arity** — 0/1/2/3 parallel data trees.
+- **Output mode** — locate-and-stop vs build-tree vs collect-flat-list.
+- **Leaf decision** — classify / keep-if-localized / always-emit / keep-if-strategy.
+- **Container assembly** — keep `id` vs strip `id`; keep `blockType`; drop-empty vs keep;
+  pass non-object array items through unchanged (reconcile only).
+
+## Why not Payload's `traverseFields` / `getFieldByPath`
+
+(Established in prior investigation — recorded here so we don't re-litigate.)
+
+- `traverseFields` carries a **single** mutable `ref` (one data tree). Reconcile needs 2,
+  the collector needs 3. No clean fit.
+- `getFieldByPath` / `flatten*` want **sanitized/flattened** schema and resolve block
+  references via `config.blocks`. Our pipeline deliberately runs on the **original,
+  un-sanitized** schema (it preserves `localized: true` on nested fields and inlines
+  `field.blocks`). Mismatch.
+- `traverseFields` defaults `fillEmpty: true` and mutates `ref`.
+
+So we build our own — but **one** of our own, not four.
+
+## The kernel: a single classification of Payload field structure
+
+The non-negotiable shared piece. One function encodes the dispatch order above:
+
+```ts
+// server/shared/field-structure/classifyField.ts
+export type FieldStructure =
+  | { kind: 'tabs'; field: TabsField }
+  | { kind: 'transparent'; fields: Field[] }   // row / collapsible / unnamed presentational
+  | { kind: 'presentational' }                  // UI leaf — no data, no subfields
+  | { kind: 'group'; name: string; fields: Field[] }
+  | { kind: 'array'; name: string; fields: Field[] }
+  | { kind: 'blocks'; name: string; field: BlocksField }
+  | { kind: 'leaf'; field: FieldAffectingData; name: string }
+
+export function classifyField(field: Field): FieldStructure
+```
+
+Plus two helpers that absorb the other two duplicated details:
+
+```ts
+// Normalizes the named/unnamed + hasFields tab dance into a flat list.
+export function tabScopes(field: TabsField):
+  Array<{ named: true; name: string; fields: Field[] } | { named: false; fields: Field[] }>
+
+// The block-slug lookup, in one place. Returns null for unknown/!block items.
+export function resolveBlockFields(field: BlocksField, item: unknown): Field[] | null
+```
+
+This kernel is the floor: **every option below builds on it.** It alone kills the
+drift-prone duplication (a new container type, or a `tab.localized` rule, is then a
+one-file change). Each call site keeps its own recursion but `switch`es on
+`classifyField` instead of re-deriving the dispatch.
+
+The question is how much *further* to go.
+
+## Options for the traversal layer on top of the kernel
+
+### Option A — kernel only; each site keeps its recursion
+
+Sites stay 4 separate recursive functions, but each one is a `switch (classifyField(f).kind)`
+and uses `tabScopes` / `resolveBlockFields`.
+
+- **Pros:** smallest abstraction; each site's data/leaf/assembly logic stays explicit and
+  local (matches the codebase's hand-written, readable style); refactor one site at a time,
+  behavior-preserving, under existing tests; zero new generic typing to fight.
+- **Cons:** the recursion boilerplate (the `for` loop + recurse calls) is still written 4×,
+  even if the *decisions* inside it are now centralized.
+- **De-dup achieved:** the bug-prone ~80% (dispatch, tabs, block lookup). Leaves the benign
+  ~20% (loop scaffolding).
+
+### Option B — generic visitor `walkFields<Scope, R>`
+
+The kernel drives a single recursive walker; callers supply a visitor. `Scope` is the
+caller's opaque bundle of parallel data cursors (1/2/3 trees + path) — the walker never
+reads data itself, it only asks the visitor to descend.
+
+```ts
+interface WalkVisitor<Scope, R> {
+  enterObject(scope: Scope, name: string): Scope | null          // group / named tab
+  enterList(scope: Scope, s: FieldStructure): ListEntry<Scope>[] | null  // array / blocks
+  leaf(field: Field, scope: Scope, path: Path): R | undefined
+  assemble(node: ContainerNode<Scope>, children: ChildResult<R>[]): R | undefined
+}
+function walkFields<Scope, R>(fields: Field[], root: Scope, v: WalkVisitor<Scope, R>): R
+```
+
+- Filter → `R = unknown`, `assemble` rebuilds objects/arrays (keeps id/blockType, drops empty).
+- Reconcile → `Scope = {source,target}`, `assemble` strips id, target-priority at leaves.
+- Collector → `R = void`, `leaf` pushes chunks + mutates; `assemble` is a no-op (accumulates in a closure).
+- resolveFieldSubtree → **does not fit** — it is a targeted descent with early-exit, not a
+  full-tree fold. Keep it on the kernel (Option A style) via a small `findFieldByPath`.
+
+- **Pros:** removes the recursion boilerplate too; one tested traversal engine.
+- **Cons:** 4-method visitor + generic `Scope`/`R` is a real cognitive and typing load; the
+  "primary tree drives list iteration, others looked up by index" rule has to be encoded in
+  `enterList`; heavier review surface; one of the four still can't use it.
+
+### Option C — leaf generator + `setByPath`
+
+`function* walkLeaves(fields, data): Generator<{ field, path, value }>`, and rebuild via the
+existing `setByPath`/`getByPath` utils.
+
+- **Pros:** elegant for collector (just `for…of` + `break`) and navigation.
+- **Cons:** **build-tree sites lose container metadata** — `id` (array items) and `blockType`
+  (blocks) are not schema fields, so a leaf-only stream can't reconstruct them; reconcile's
+  "emit all fields, strip id, pass non-objects through" rule is unreachable. Fails 2 of 4.
+  Rejected as a *unifier* (still fine as an internal detail of one site).
+
+## Recommendation
+
+**Adopt the kernel (`classifyField` + `tabScopes` + `resolveBlockFields`) now, and land
+Option A.** Rationale:
+
+1. It eliminates the genuinely dangerous duplication — the structural dispatch and block
+   lookup — in one well-tested module, which is the actual source of drift risk.
+2. It keeps each site's *different* logic (arity, assembly, leaf rules) explicit and local,
+   matching how this codebase is written and keeping each refactor a small, behavior-
+   preserving, independently-reviewable diff guarded by existing tests.
+3. It is **forward-compatible with Option B**: the visitor walker, if we later want to kill
+   the loop boilerplate too, is just a function that consumes the same kernel. We are not
+   painting ourselves into a corner by starting with A.
+4. Option B's full generic visitor is the kind of abstraction we should earn with a second
+   concrete need, not front-load — and it still leaves resolveFieldSubtree on the kernel
+   anyway.
+
+**Sequencing:** build the kernel + its unit tests → migrate `resolveFieldSubtree` (new,
+uncommitted, smallest blast radius) → then `filterLocalizedFields` → `DataReconciler` →
+`FieldChunkCollector`, each as its own commit, each leaving the existing test suite green.
+
+## Decision & interface (agreed 2026-06-11)
+
+We chose **one engine** — Option B refined with a `stop` signal so it also absorbs the
+exhaustive cases without losing early-exit (call it **B+**). It is the same pattern Payload
+itself uses for `traverseFields` (callback + `next()`-skip + return-truthy-stop + a `ref`
+data cursor), generalized with the two properties Payload's lacks and we need:
+**a multi-tree opaque cursor** (1..n data trees instead of one `ref`) and **block resolution
+from inline `field.blocks`** (original, un-sanitized schema).
+
+**Module layout** — one module, `server/shared/field-traversal/`:
+
+| File | Role |
+| --- | --- |
+| `types.ts` | the contract (`FieldStructure`, `WalkSignal`, `ChildCursor`, `ContainerInfo`, `ChildOutput`, `FieldWalker<Cursor, Out>`, `TabScope`) — pure types, erase to nothing |
+| `kernel.ts` | `classifyField` / `tabScopes` / `resolveBlockFields` — the shared structural dispatch |
+| `walkFields.ts` | the engine: DFS over the schema, drives `FieldWalker`, assembles containers bottom-up |
+| `index.ts` | barrel |
+| `*.test.ts` | behavioural specs (vitest) |
+
+Plus a package-level `tsconfig.check.json` (extends `tsconfig.json`, re-includes tests) wired
+into the `check-types` script — see "Type-safety" below.
+
+**Leaf typing — `field.name` is not free.** `leaf` must NOT receive the raw `Field` union:
+its presentational members (`row`, `collapsible`, `ui`, `tabs`, unnamed `group`) have no
+`name`. Even `FieldAffectingData` is insufficient — it includes `TabAsField`, whose `name`
+is optional, so `field.name` widens to `string | undefined`. The contract therefore exposes:
+
+```ts
+export type LeafField = Exclude<FieldAffectingData, ArrayField | BlocksField | NamedGroupField | TabAsField>
+```
+
+The engine resolves the union via the `fieldAffectsData` guard inside `classifyField`, so
+`leaf` always gets a `LeafField` with a guaranteed `name`; callers never touch the raw union.
+
+**Why types in `.ts`, not a hand-authored `.d.ts`** (the question that prompted this):
+a `.d.ts` is the wrong tool here. (1) Our tests are **behavioural** (vitest imports and
+*calls* the module) — a `.d.ts` has no runtime, so the tests can't run. (2) Once the impl
+`.ts` lands, the `.ts` shadows a same-named `.d.ts` and the build emits its own `.d.ts`
+from it anyway. `.d.ts` stays reserved for *ambient* declarations (`scss.d.ts`,
+`vitest-env.d.ts`). The safe equivalent of "interface first" is `types.ts` (compiles to
+empty JS) + throwing stubs so the contract type-checks and the red tests import cleanly.
+
+**How the engine subsumes the shapes** (the cursor carries the data; the engine never reads it):
+
+| Caller | `Cursor` | `enterObject` / `enterList` | `leaf` | `combine` |
+| --- | --- | --- | --- | --- |
+| filter | `{ data }` | descend if value present, else `'skip'` | keep if localized | rebuild object/array, drop empty, keep `id`/`blockType` |
+| reconcile | `{ source, target }` | descend if `source` present | `target ?? source` | rebuild, **strip** `id`, keep `blockType` |
+| collector | `{ data, source, target, path }` | descend if value present | push chunk + mutate | no-op (`undefined`) |
+
+**Navigation stays on the kernel.** `resolveFieldSubtree` is targeted descent with early-exit,
+not a full fold; it gets a small `findFieldByPath` built on `classifyField`, not `walkFields`.
+This is the one honest seam in "one engine for all four" — recorded, not hidden.
+
+**Type-safety: tests are now type-checked.** Previously `tsconfig.json` excluded `*.test.ts`,
+and vitest runs through esbuild (strips types, no checking) — so type errors in tests went
+undetected (it was exactly this gap that hid the `field.name`/`TabAsField` bug above). Fix:
+a `tsconfig.check.json` that extends the build config but re-includes tests, wired into
+`check-types` (`tsgo --noEmit -p tsconfig.check.json`). The build config (`tsconfig.json`,
+used by `build:types`) still excludes tests, so no test `.d.ts` is emitted into `dist`.
+Verified: full-package check is 0 errors with tests included.
+
+**TDD state:** `types.ts` + stubs + `kernel.test.ts` + `walkFields.test.ts` (build-tree +
+collect shapes) are in. `check-types` (incl. tests) is clean; all 14 tests are red on the
+stubs. Implementation turns them green.
+
+## Migration safety — Step 1: characterization tests (done)
+
+Before swapping any implementation, each of the four sites was locked down with
+characterization tests for the structural branches a recursion refactor is most likely to
+break — added against the CURRENT (un-migrated) code and verified **green**, so they encode
+real present behavior, not aspiration. This is the regression net: after each site delegates
+to `walkFields`/kernel, its suite must stay 100% green.
+
+| Site | Cases (before → after) | Gaps closed |
+| --- | --- | --- |
+| `resolveFieldSubtree` | 11 → 15 | path normalization (trim / empty / index-only segments), `group > array > leaf` |
+| `filterLocalizedFields` | 25 → 28 | empty blocks dropped, unknown `blockType` dropped, non-object array items dropped |
+| `DataReconciler` | 16 → 19 | non-object array items passed through, target array shorter than source, unknown `blockType` passed through verbatim (keeps `id`) |
+| `FieldChunkCollector` | 37 → 39 | non-object array items skipped, per-item source/target index fallback when arrays differ in length |
+| **Total** | **89 → 101** | |
+
+Note a deliberately-locked asymmetry surfaced while writing these: on an **unknown
+`blockType`**, `filterLocalizedFields` and `FieldChunkCollector` **drop** the item, whereas
+`DataReconciler` **passes the source item through unchanged (id included)**. The new impl
+must preserve this per-site difference — the tests now enforce it.
+
+**Open migration caveat — `filterLocalizedFields` × named tabs.** A review of the engine
+surfaced that `filterLocalizedFields` flattens **all** tabs into the parent data scope: it does
+not check `tabHasName`, so a *named* tab's fields are read at the parent level rather than nested
+under `data[tabName]`. `DataReconciler`, `FieldChunkCollector`, and the new engine instead treat a
+named tab as a data boundary. So migrating `filterLocalizedFields` onto `walkFields` would *change*
+its named-tab behavior, and the current characterization tests do **not** cover named tabs for this
+site. Before migrating it: add a named-tab characterization test to pin today's (flat) behavior,
+then decide explicitly whether to preserve it or fix the divergence.
+
+## Migration safety — Step 2: engine implemented (done)
+
+`kernel.ts` (`classifyField` / `tabScopes` / `resolveBlockFields`) and `walkFields.ts` are
+implemented; all engine tests (17: 15 kernel + 2 walkFields) are green, `check-types` (incl.
+tests) is clean, and the full package suite stays at 658 passing.
+
+- `classifyField`'s dispatch order is the one fragile spot (a field can match several
+  predicates; only the order disambiguates). Two junctions matter: the `fieldAffectsData`
+  gate runs **before** the group check (so an unnamed group → `transparent`, not a `group`
+  with `name: undefined`), and `tabs` is checked **before** the non-data-affecting branch
+  (so a `tabs` field, which has no `.fields`, isn't mislabeled `presentational`). A dedicated
+  `dispatch order (disambiguation)` test block locks both, and a mutation check (moving the
+  group check above the gate) confirms the tests are not vacuous — it reds exactly those two.
+
+- `walkFields` is a thin wrapper over an internal `FieldTreeWalker` **class**. A class (not
+  nested functions) because `level`/`object`/`list` are mutually recursive — methods reference
+  each other via `this` without tripping `noUseBeforeDefine`. Matches the codebase's
+  class style (`DataReconciler`, `FieldChunkCollector`).
+- One contract refinement landed while implementing: `TabScope`'s named variant now carries
+  the `NamedTab` itself (`{ named: true; tab }`), since the walker must hand that object to
+  `enterObject`; unnamed stays `{ named: false; fields }`.
+- `classifyField` resolves `fieldAffectsData` first, which is what makes the two `as`
+  narrowings sound (unnamed groups are already routed to `transparent`; `TabAsField` never
+  reaches the leaf branch).
+
+**Next:** Step 3 — migrate each site to delegate to `walkFields`/kernel, one commit each,
+keeping that site's suite 100% green; mind the unknown-`blockType` asymmetry noted above.
+
+## Resolved decisions
+
+- **D1 — A or B?** → **B+** (one engine), per the conversation. A's kernel survives inside B+
+  as `kernel.ts`; navigation uses the kernel directly.
+- **D2 — kernel location:** → `server/shared/field-traversal/` (new folder). It is structural
+  mapping, not a type guard.
+- **D3 — array-index path segments:** → owned by the caller via the `Cursor` (the collector
+  threads `path` in its cursor), not by the engine. Keeps the engine data-agnostic.

--- a/packages/payload-plugin-translator/package.json
+++ b/packages/payload-plugin-translator/package.json
@@ -55,7 +55,7 @@
     "lint:fix": "ultracite fix",
     "test": "vitest run",
     "test:watch": "vitest",
-    "check-types": "tsgo --noEmit"
+    "check-types": "tsgo --noEmit -p tsconfig.check.json"
   },
   "peerDependencies": {
     "@payloadcms/richtext-lexical": "^3.76.0",

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/data-reconciler/DataReconciler.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/data-reconciler/DataReconciler.test.ts
@@ -1,327 +1,366 @@
-import { describe, it, expect } from 'vitest'
-import type { Field } from 'payload'
-import { DataReconciler } from './DataReconciler'
+import { describe, it, expect } from "vitest";
+import type { Field } from "payload";
+import { DataReconciler } from "./DataReconciler";
 
-describe('DataReconciler', () => {
-  describe('deep merge with target priority', () => {
-    it('uses target value when it exists', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const sourceData = { title: 'Hello' }
-      const targetData = { title: 'Existing' }
+describe("DataReconciler", () => {
+  describe("deep merge with target priority", () => {
+    it("uses target value when it exists", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const sourceData = { title: "Hello" };
+      const targetData = { title: "Existing" };
 
-      const reconciler = new DataReconciler(schema)
-      expect(reconciler.reconcile(sourceData, targetData)).toEqual({ title: 'Existing' })
-    })
+      const reconciler = new DataReconciler(schema);
+      expect(reconciler.reconcile(sourceData, targetData)).toEqual({ title: "Existing" });
+    });
 
-    it('uses source value when target is empty', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const sourceData = { title: 'Hello' }
-      const targetData = { title: '' }
+    it("uses source value when target is empty", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const sourceData = { title: "Hello" };
+      const targetData = { title: "" };
 
-      const reconciler = new DataReconciler(schema)
-      expect(reconciler.reconcile(sourceData, targetData)).toEqual({ title: 'Hello' })
-    })
+      const reconciler = new DataReconciler(schema);
+      expect(reconciler.reconcile(sourceData, targetData)).toEqual({ title: "Hello" });
+    });
 
-    it('uses source value when target is missing', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const sourceData = { title: 'Hello' }
-      const targetData = {}
+    it("uses source value when target is missing", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const sourceData = { title: "Hello" };
+      const targetData = {};
 
-      const reconciler = new DataReconciler(schema)
-      expect(reconciler.reconcile(sourceData, targetData)).toEqual({ title: 'Hello' })
-    })
+      const reconciler = new DataReconciler(schema);
+      expect(reconciler.reconcile(sourceData, targetData)).toEqual({ title: "Hello" });
+    });
 
-    it('handles multiple fields independently', () => {
+    it("handles multiple fields independently", () => {
       const schema: Field[] = [
-        { name: 'title', type: 'text', localized: true },
-        { name: 'description', type: 'text', localized: true },
-        { name: 'slug', type: 'text', localized: false },
-      ]
-      const sourceData = { title: 'Hello', description: 'World', slug: 'hello' }
-      const targetData = { title: 'Translated Title', description: '', slug: 'other-slug' }
+        { name: "title", type: "text", localized: true },
+        { name: "description", type: "text", localized: true },
+        { name: "slug", type: "text", localized: false },
+      ];
+      const sourceData = { title: "Hello", description: "World", slug: "hello" };
+      const targetData = { title: "Translated Title", description: "", slug: "other-slug" };
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        title: 'Translated Title',
-        description: 'World',
-        slug: 'other-slug',
-      })
-    })
+        title: "Translated Title",
+        description: "World",
+        slug: "other-slug",
+      });
+    });
 
-    it('preserves full document shape', () => {
+    it("preserves full document shape", () => {
       const schema: Field[] = [
-        { name: 'title', type: 'text', localized: true },
-        { name: 'slug', type: 'text', localized: false },
-        { name: 'author', type: 'relationship', relationTo: 'users', localized: false },
-      ]
-      const sourceData = { title: 'Hello', slug: 'hello', author: '123' }
-      const targetData = {}
+        { name: "title", type: "text", localized: true },
+        { name: "slug", type: "text", localized: false },
+        { name: "author", type: "relationship", relationTo: "users", localized: false },
+      ];
+      const sourceData = { title: "Hello", slug: "hello", author: "123" };
+      const targetData = {};
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        title: 'Hello',
-        slug: 'hello',
-        author: '123',
-      })
-    })
-  })
+        title: "Hello",
+        slug: "hello",
+        author: "123",
+      });
+    });
+  });
 
-  describe('nested structures', () => {
-    it('reconciles group fields', () => {
+  describe("nested structures", () => {
+    it("reconciles group fields", () => {
       const schema: Field[] = [
         {
-          name: 'meta',
-          type: 'group',
+          name: "meta",
+          type: "group",
           fields: [
-            { name: 'title', type: 'text', localized: true },
-            { name: 'slug', type: 'text', localized: false },
+            { name: "title", type: "text", localized: true },
+            { name: "slug", type: "text", localized: false },
           ],
         },
-      ]
-      const sourceData = { meta: { title: 'Hello', slug: 'hello' } }
-      const targetData = { meta: { title: 'Existing', slug: '' } }
+      ];
+      const sourceData = { meta: { title: "Hello", slug: "hello" } };
+      const targetData = { meta: { title: "Existing", slug: "" } };
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        meta: { title: 'Existing', slug: 'hello' },
-      })
-    })
+        meta: { title: "Existing", slug: "hello" },
+      });
+    });
 
-    it('reconciles array fields', () => {
+    it("reconciles array fields", () => {
       const schema: Field[] = [
         {
-          name: 'items',
-          type: 'array',
+          name: "items",
+          type: "array",
           fields: [
-            { name: 'label', type: 'text', localized: true },
-            { name: 'value', type: 'text', localized: false },
+            { name: "label", type: "text", localized: true },
+            { name: "value", type: "text", localized: false },
           ],
         },
-      ]
+      ];
       const sourceData = {
         items: [
-          { id: '1', label: 'First', value: 'one' },
-          { id: '2', label: 'Second', value: 'two' },
+          { id: "1", label: "First", value: "one" },
+          { id: "2", label: "Second", value: "two" },
         ],
-      }
+      };
       const targetData = {
         items: [
-          { id: '1', label: 'Translated', value: '' },
-          { id: '2', label: '', value: 'y' },
+          { id: "1", label: "Translated", value: "" },
+          { id: "2", label: "", value: "y" },
         ],
-      }
+      };
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       // Note: id is not included in result - Postgres rejects it on update
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
         items: [
-          { label: 'Translated', value: 'one' },
-          { label: 'Second', value: 'y' },
+          { label: "Translated", value: "one" },
+          { label: "Second", value: "y" },
         ],
-      })
-    })
+      });
+    });
 
-    it('reconciles blocks fields', () => {
+    it("reconciles blocks fields", () => {
       const schema: Field[] = [
         {
-          name: 'layout',
-          type: 'blocks',
+          name: "layout",
+          type: "blocks",
           blocks: [
             {
-              slug: 'text',
+              slug: "text",
               fields: [
-                { name: 'content', type: 'text', localized: true },
-                { name: 'style', type: 'text', localized: false },
+                { name: "content", type: "text", localized: true },
+                { name: "style", type: "text", localized: false },
               ],
             },
           ],
         },
-      ]
+      ];
       const sourceData = {
-        layout: [{ id: '1', blockType: 'text', content: 'Hello', style: 'bold' }],
-      }
+        layout: [{ id: "1", blockType: "text", content: "Hello", style: "bold" }],
+      };
       const targetData = {
-        layout: [{ id: '1', blockType: 'text', content: 'Existing', style: '' }],
-      }
+        layout: [{ id: "1", blockType: "text", content: "Existing", style: "" }],
+      };
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       // Note: id is not included in result - Postgres rejects it on update
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        layout: [{ blockType: 'text', content: 'Existing', style: 'bold' }],
-      })
-    })
+        layout: [{ blockType: "text", content: "Existing", style: "bold" }],
+      });
+    });
 
-    it('uses source for empty target in blocks', () => {
+    it("uses source for empty target in blocks", () => {
       const schema: Field[] = [
         {
-          name: 'layout',
-          type: 'blocks',
+          name: "layout",
+          type: "blocks",
           blocks: [
             {
-              slug: 'text',
-              fields: [{ name: 'content', type: 'text', localized: true }],
+              slug: "text",
+              fields: [{ name: "content", type: "text", localized: true }],
             },
           ],
         },
-      ]
+      ];
       const sourceData = {
-        layout: [{ id: '1', blockType: 'text', content: 'Hello' }],
-      }
+        layout: [{ id: "1", blockType: "text", content: "Hello" }],
+      };
       const targetData = {
-        layout: [{ id: '1', blockType: 'text', content: '' }],
-      }
+        layout: [{ id: "1", blockType: "text", content: "" }],
+      };
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       // Note: id is not included in result - Postgres rejects it on update
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        layout: [{ blockType: 'text', content: 'Hello' }],
-      })
-    })
-  })
+        layout: [{ blockType: "text", content: "Hello" }],
+      });
+    });
+  });
 
-  describe('edge cases', () => {
-    it('handles null targetData', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const sourceData = { title: 'Hello' }
+  describe("edge cases", () => {
+    it("handles null targetData", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const sourceData = { title: "Hello" };
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       expect(reconciler.reconcile(sourceData, null as unknown as Record<string, unknown>)).toEqual({
-        title: 'Hello',
-      })
-    })
+        title: "Hello",
+      });
+    });
 
-    it('skips undefined source values', () => {
+    it("skips undefined source values", () => {
       const schema: Field[] = [
-        { name: 'title', type: 'text', localized: true },
-        { name: 'description', type: 'text', localized: true },
-      ]
-      const sourceData = { title: 'Hello' }
-      const targetData = { title: 'Existing', description: 'Target desc' }
+        { name: "title", type: "text", localized: true },
+        { name: "description", type: "text", localized: true },
+      ];
+      const sourceData = { title: "Hello" };
+      const targetData = { title: "Existing", description: "Target desc" };
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        title: 'Existing',
-      })
-    })
-  })
+        title: "Existing",
+      });
+    });
+  });
 
-  describe('tabs support', () => {
-    it('reconciles fields in named tabs', () => {
+  describe("tabs support", () => {
+    it("reconciles fields in named tabs", () => {
       const schema: Field[] = [
         {
-          type: 'tabs',
+          type: "tabs",
           tabs: [
             {
-              name: 'seo',
+              name: "seo",
               fields: [
-                { name: 'title', type: 'text', localized: true },
-                { name: 'description', type: 'text', localized: true },
+                { name: "title", type: "text", localized: true },
+                { name: "description", type: "text", localized: true },
               ],
             },
           ],
         },
-      ]
-      const sourceData = { seo: { title: 'Hello', description: 'World' } }
-      const targetData = { seo: { title: 'Translated', description: '' } }
+      ];
+      const sourceData = { seo: { title: "Hello", description: "World" } };
+      const targetData = { seo: { title: "Translated", description: "" } };
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        seo: { title: 'Translated', description: 'World' },
-      })
-    })
+        seo: { title: "Translated", description: "World" },
+      });
+    });
 
-    it('reconciles fields in unnamed tabs', () => {
+    it("reconciles fields in unnamed tabs", () => {
       const schema: Field[] = [
         {
-          type: 'tabs',
+          type: "tabs",
           tabs: [
             {
-              label: 'Content',
+              label: "Content",
               fields: [
-                { name: 'title', type: 'text', localized: true },
-                { name: 'body', type: 'text', localized: true },
+                { name: "title", type: "text", localized: true },
+                { name: "body", type: "text", localized: true },
               ],
             },
           ],
         },
-      ]
-      const sourceData = { title: 'Hello', body: 'World' }
-      const targetData = { title: 'Translated', body: '' }
+      ];
+      const sourceData = { title: "Hello", body: "World" };
+      const targetData = { title: "Translated", body: "" };
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        title: 'Translated',
-        body: 'World',
-      })
-    })
+        title: "Translated",
+        body: "World",
+      });
+    });
 
-    it('reconciles multiple tabs with mixed named/unnamed', () => {
+    it("reconciles multiple tabs with mixed named/unnamed", () => {
       const schema: Field[] = [
         {
-          type: 'tabs',
+          type: "tabs",
           tabs: [
             {
-              label: 'Content',
-              fields: [{ name: 'title', type: 'text', localized: true }],
+              label: "Content",
+              fields: [{ name: "title", type: "text", localized: true }],
             },
             {
-              name: 'seo',
-              fields: [{ name: 'metaTitle', type: 'text', localized: true }],
+              name: "seo",
+              fields: [{ name: "metaTitle", type: "text", localized: true }],
             },
           ],
         },
-      ]
-      const sourceData = { title: 'Hello', seo: { metaTitle: 'SEO Title' } }
-      const targetData = { title: 'Translated', seo: { metaTitle: '' } }
+      ];
+      const sourceData = { title: "Hello", seo: { metaTitle: "SEO Title" } };
+      const targetData = { title: "Translated", seo: { metaTitle: "" } };
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        title: 'Translated',
-        seo: { metaTitle: 'SEO Title' },
-      })
-    })
-  })
+        title: "Translated",
+        seo: { metaTitle: "SEO Title" },
+      });
+    });
+  });
 
-  describe('row and collapsible fields', () => {
-    it('reconciles fields in row', () => {
+  describe("row and collapsible fields", () => {
+    it("reconciles fields in row", () => {
       const schema: Field[] = [
         {
-          type: 'row',
+          type: "row",
           fields: [
-            { name: 'firstName', type: 'text', localized: true },
-            { name: 'lastName', type: 'text', localized: true },
+            { name: "firstName", type: "text", localized: true },
+            { name: "lastName", type: "text", localized: true },
           ],
         },
-      ]
-      const sourceData = { firstName: 'John', lastName: 'Doe' }
-      const targetData = { firstName: 'Johann', lastName: '' }
+      ];
+      const sourceData = { firstName: "John", lastName: "Doe" };
+      const targetData = { firstName: "Johann", lastName: "" };
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        firstName: 'Johann',
-        lastName: 'Doe',
-      })
-    })
+        firstName: "Johann",
+        lastName: "Doe",
+      });
+    });
 
-    it('reconciles fields in collapsible', () => {
+    it("reconciles fields in collapsible", () => {
       const schema: Field[] = [
         {
-          type: 'collapsible',
-          label: 'Advanced',
+          type: "collapsible",
+          label: "Advanced",
           fields: [
-            { name: 'seoTitle', type: 'text', localized: true },
-            { name: 'seoDescription', type: 'text', localized: true },
+            { name: "seoTitle", type: "text", localized: true },
+            { name: "seoDescription", type: "text", localized: true },
           ],
         },
-      ]
-      const sourceData = { seoTitle: 'Title', seoDescription: 'Description' }
-      const targetData = { seoTitle: 'Translated', seoDescription: '' }
+      ];
+      const sourceData = { seoTitle: "Title", seoDescription: "Description" };
+      const targetData = { seoTitle: "Translated", seoDescription: "" };
 
-      const reconciler = new DataReconciler(schema)
+      const reconciler = new DataReconciler(schema);
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        seoTitle: 'Translated',
-        seoDescription: 'Description',
-      })
-    })
-  })
-})
+        seoTitle: "Translated",
+        seoDescription: "Description",
+      });
+    });
+  });
+
+  describe("array/blocks edge cases", () => {
+    it("passes non-object array items through unchanged", () => {
+      const schema: Field[] = [{ name: "items", type: "array", fields: [{ name: "text", type: "text", localized: true }] }];
+      const sourceData = { items: [{ text: "A" }, "raw", 42] };
+
+      const reconciler = new DataReconciler(schema);
+      expect(reconciler.reconcile(sourceData, {})).toEqual({
+        items: [{ text: "A" }, "raw", 42],
+      });
+    });
+
+    it("falls back to source when the target array is shorter than source", () => {
+      const schema: Field[] = [{ name: "items", type: "array", fields: [{ name: "label", type: "text", localized: true }] }];
+      const sourceData = { items: [{ label: "A" }, { label: "B" }] };
+      const targetData = { items: [{ label: "T" }] };
+
+      const reconciler = new DataReconciler(schema);
+      expect(reconciler.reconcile(sourceData, targetData)).toEqual({
+        items: [{ label: "T" }, { label: "B" }],
+      });
+    });
+
+    it("passes block items with an unknown blockType through unchanged (source as-is, keeps id)", () => {
+      const schema: Field[] = [
+        {
+          name: "layout",
+          type: "blocks",
+          blocks: [{ slug: "text", fields: [{ name: "body", type: "text", localized: true }] }],
+        },
+      ];
+      const sourceData = { layout: [{ id: "1", blockType: "ghost", body: "X" }] };
+
+      const reconciler = new DataReconciler(schema);
+      expect(reconciler.reconcile(sourceData, {})).toEqual({
+        layout: [{ id: "1", blockType: "ghost", body: "X" }],
+      });
+    });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/field-collector/FieldChunkCollector.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/field-collector/FieldChunkCollector.test.ts
@@ -1,521 +1,521 @@
-import { describe, it, expect } from 'vitest'
-import type { Field } from 'payload'
-import { FieldChunkCollector } from './FieldChunkCollector'
-import { OverwriteStrategy } from '../../strategies/Overwrite.strategy'
-import { SkipExistingStrategy } from '../../strategies/SkipExisting.strategy'
+import { describe, it, expect } from "vitest";
+import type { Field } from "payload";
+import { FieldChunkCollector } from "./FieldChunkCollector";
+import { OverwriteStrategy } from "../../strategies/Overwrite.strategy";
+import { SkipExistingStrategy } from "../../strategies/SkipExisting.strategy";
 
-const strategy = new OverwriteStrategy()
-const skipExistingStrategy = new SkipExistingStrategy()
+const strategy = new OverwriteStrategy();
+const skipExistingStrategy = new SkipExistingStrategy();
 
-describe('FieldChunkCollector', () => {
-  describe('simple fields', () => {
-    it('collects localized text fields', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const data = { title: 'Hello' }
+describe("FieldChunkCollector", () => {
+  describe("simple fields", () => {
+    it("collects localized text fields", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const data = { title: "Hello" };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('title')
-      expect(chunks[0].path).toEqual(['title'])
-      expect(chunks[0].dataRef).toBe(data)
-      expect(chunks[0].schema.type).toBe('text')
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("title");
+      expect(chunks[0].path).toEqual(["title"]);
+      expect(chunks[0].dataRef).toBe(data);
+      expect(chunks[0].schema.type).toBe("text");
+    });
 
-    it('collects multiple localized fields', () => {
+    it("collects multiple localized fields", () => {
       const schema: Field[] = [
-        { name: 'title', type: 'text', localized: true },
-        { name: 'description', type: 'textarea', localized: true },
-      ]
-      const data = { title: 'Hello', description: 'World' }
+        { name: "title", type: "text", localized: true },
+        { name: "description", type: "textarea", localized: true },
+      ];
+      const data = { title: "Hello", description: "World" };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(2)
-      expect(chunks.map((c) => c.key)).toEqual(['title', 'description'])
-    })
+      expect(chunks).toHaveLength(2);
+      expect(chunks.map((c) => c.key)).toEqual(["title", "description"]);
+    });
 
-    it('skips non-localized fields', () => {
+    it("skips non-localized fields", () => {
       const schema: Field[] = [
-        { name: 'title', type: 'text', localized: true },
-        { name: 'slug', type: 'text', localized: false },
-      ]
-      const data = { title: 'Hello', slug: 'hello' }
+        { name: "title", type: "text", localized: true },
+        { name: "slug", type: "text", localized: false },
+      ];
+      const data = { title: "Hello", slug: "hello" };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('title')
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("title");
+    });
 
-    it('skips non-translatable fields', () => {
+    it("skips non-translatable fields", () => {
       const schema: Field[] = [
-        { name: 'title', type: 'text', localized: true },
-        { name: 'author', type: 'relationship', relationTo: 'users', localized: true },
-      ]
-      const data = { title: 'Hello', author: '123' }
+        { name: "title", type: "text", localized: true },
+        { name: "author", type: "relationship", relationTo: "users", localized: true },
+      ];
+      const data = { title: "Hello", author: "123" };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('title')
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("title");
+    });
 
-    it('skips null and undefined values', () => {
+    it("skips null and undefined values", () => {
       const schema: Field[] = [
-        { name: 'title', type: 'text', localized: true },
-        { name: 'subtitle', type: 'text', localized: true },
-      ]
-      const data = { title: null, subtitle: undefined }
+        { name: "title", type: "text", localized: true },
+        { name: "subtitle", type: "text", localized: true },
+      ];
+      const data = { title: null, subtitle: undefined };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(0)
-    })
-  })
+      expect(chunks).toHaveLength(0);
+    });
+  });
 
-  describe('group fields', () => {
-    it('collects nested fields with correct path', () => {
+  describe("group fields", () => {
+    it("collects nested fields with correct path", () => {
       const schema: Field[] = [
         {
-          name: 'meta',
-          type: 'group',
-          fields: [{ name: 'title', type: 'text', localized: true }],
+          name: "meta",
+          type: "group",
+          fields: [{ name: "title", type: "text", localized: true }],
         },
-      ]
-      const data = { meta: { title: 'Hello' } }
+      ];
+      const data = { meta: { title: "Hello" } };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('title')
-      expect(chunks[0].path).toEqual(['meta', 'title'])
-      expect(chunks[0].dataRef).toBe(data.meta)
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("title");
+      expect(chunks[0].path).toEqual(["meta", "title"]);
+      expect(chunks[0].dataRef).toBe(data.meta);
+    });
 
-    it('collects deeply nested fields', () => {
+    it("collects deeply nested fields", () => {
       const schema: Field[] = [
         {
-          name: 'level1',
-          type: 'group',
+          name: "level1",
+          type: "group",
           fields: [
             {
-              name: 'level2',
-              type: 'group',
-              fields: [{ name: 'title', type: 'text', localized: true }],
+              name: "level2",
+              type: "group",
+              fields: [{ name: "title", type: "text", localized: true }],
             },
           ],
         },
-      ]
-      const data = { level1: { level2: { title: 'Deep' } } }
+      ];
+      const data = { level1: { level2: { title: "Deep" } } };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].path).toEqual(['level1', 'level2', 'title'])
-      expect(chunks[0].dataRef).toBe(data.level1.level2)
-    })
-  })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].path).toEqual(["level1", "level2", "title"]);
+      expect(chunks[0].dataRef).toBe(data.level1.level2);
+    });
+  });
 
-  describe('array fields', () => {
-    it('collects fields from each array item', () => {
+  describe("array fields", () => {
+    it("collects fields from each array item", () => {
       const schema: Field[] = [
         {
-          name: 'items',
-          type: 'array',
-          fields: [{ name: 'label', type: 'text', localized: true }],
+          name: "items",
+          type: "array",
+          fields: [{ name: "label", type: "text", localized: true }],
         },
-      ]
+      ];
       const data = {
         items: [
-          { id: '1', label: 'First' },
-          { id: '2', label: 'Second' },
+          { id: "1", label: "First" },
+          { id: "2", label: "Second" },
         ],
-      }
+      };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(2)
-      expect(chunks[0].path).toEqual(['items', '0', 'label'])
-      expect(chunks[1].path).toEqual(['items', '1', 'label'])
-      expect(chunks[0].dataRef).toBe(data.items[0])
-      expect(chunks[1].dataRef).toBe(data.items[1])
-    })
+      expect(chunks).toHaveLength(2);
+      expect(chunks[0].path).toEqual(["items", "0", "label"]);
+      expect(chunks[1].path).toEqual(["items", "1", "label"]);
+      expect(chunks[0].dataRef).toBe(data.items[0]);
+      expect(chunks[1].dataRef).toBe(data.items[1]);
+    });
 
-    it('uses numeric index in path', () => {
+    it("uses numeric index in path", () => {
       const schema: Field[] = [
         {
-          name: 'items',
-          type: 'array',
-          fields: [{ name: 'text', type: 'text', localized: true }],
+          name: "items",
+          type: "array",
+          fields: [{ name: "text", type: "text", localized: true }],
         },
-      ]
-      const data = { items: [{ id: '1', text: 'Hello' }] }
+      ];
+      const data = { items: [{ id: "1", text: "Hello" }] };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks[0].path).toEqual(['items', '0', 'text'])
-    })
-  })
+      expect(chunks[0].path).toEqual(["items", "0", "text"]);
+    });
+  });
 
-  describe('blocks fields', () => {
-    it('collects fields from blocks with correct path', () => {
+  describe("blocks fields", () => {
+    it("collects fields from blocks with correct path", () => {
       const schema: Field[] = [
         {
-          name: 'layout',
-          type: 'blocks',
+          name: "layout",
+          type: "blocks",
           blocks: [
             {
-              slug: 'text',
-              fields: [{ name: 'content', type: 'text', localized: true }],
+              slug: "text",
+              fields: [{ name: "content", type: "text", localized: true }],
             },
           ],
         },
-      ]
+      ];
       const data = {
-        layout: [{ id: '1', blockType: 'text', content: 'Hello' }],
-      }
+        layout: [{ id: "1", blockType: "text", content: "Hello" }],
+      };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].path).toEqual(['layout', '0', 'content'])
-      expect(chunks[0].dataRef).toBe(data.layout[0])
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].path).toEqual(["layout", "0", "content"]);
+      expect(chunks[0].dataRef).toBe(data.layout[0]);
+    });
 
-    it('handles multiple block types', () => {
+    it("handles multiple block types", () => {
       const schema: Field[] = [
         {
-          name: 'layout',
-          type: 'blocks',
+          name: "layout",
+          type: "blocks",
           blocks: [
             {
-              slug: 'text',
-              fields: [{ name: 'content', type: 'text', localized: true }],
+              slug: "text",
+              fields: [{ name: "content", type: "text", localized: true }],
             },
             {
-              slug: 'heading',
-              fields: [{ name: 'title', type: 'text', localized: true }],
+              slug: "heading",
+              fields: [{ name: "title", type: "text", localized: true }],
             },
           ],
         },
-      ]
+      ];
       const data = {
         layout: [
-          { id: '1', blockType: 'text', content: 'Hello' },
-          { id: '2', blockType: 'heading', title: 'Title' },
+          { id: "1", blockType: "text", content: "Hello" },
+          { id: "2", blockType: "heading", title: "Title" },
         ],
-      }
+      };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(2)
-      expect(chunks[0].key).toBe('content')
-      expect(chunks[1].key).toBe('title')
-    })
+      expect(chunks).toHaveLength(2);
+      expect(chunks[0].key).toBe("content");
+      expect(chunks[1].key).toBe("title");
+    });
 
-    it('skips unknown block types', () => {
+    it("skips unknown block types", () => {
       const schema: Field[] = [
         {
-          name: 'layout',
-          type: 'blocks',
+          name: "layout",
+          type: "blocks",
           blocks: [
             {
-              slug: 'text',
-              fields: [{ name: 'content', type: 'text', localized: true }],
+              slug: "text",
+              fields: [{ name: "content", type: "text", localized: true }],
             },
           ],
         },
-      ]
+      ];
       const data = {
-        layout: [{ id: '1', blockType: 'unknown', content: 'Hello' }],
-      }
+        layout: [{ id: "1", blockType: "unknown", content: "Hello" }],
+      };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(0)
-    })
-  })
+      expect(chunks).toHaveLength(0);
+    });
+  });
 
-  describe('tabs and row fields', () => {
-    it('collects fields from tabs', () => {
+  describe("tabs and row fields", () => {
+    it("collects fields from tabs", () => {
       const schema: Field[] = [
         {
-          type: 'tabs',
+          type: "tabs",
           tabs: [
             {
-              label: 'Content',
-              fields: [{ name: 'title', type: 'text', localized: true }],
+              label: "Content",
+              fields: [{ name: "title", type: "text", localized: true }],
             },
           ],
         },
-      ]
-      const data = { title: 'Hello' }
+      ];
+      const data = { title: "Hello" };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].path).toEqual(['title'])
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].path).toEqual(["title"]);
+    });
 
-    it('collects fields from row', () => {
+    it("collects fields from row", () => {
       const schema: Field[] = [
         {
-          type: 'row',
-          fields: [{ name: 'title', type: 'text', localized: true }],
+          type: "row",
+          fields: [{ name: "title", type: "text", localized: true }],
         },
-      ]
-      const data = { title: 'Hello' }
+      ];
+      const data = { title: "Hello" };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].path).toEqual(['title'])
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].path).toEqual(["title"]);
+    });
 
-    it('collects fields from unnamed group (no name property)', () => {
+    it("collects fields from unnamed group (no name property)", () => {
       const schema: Field[] = [
         {
-          type: 'group',
+          type: "group",
           fields: [
-            { name: 'title', type: 'text', localized: true },
-            { name: 'description', type: 'textarea', localized: true },
+            { name: "title", type: "text", localized: true },
+            { name: "description", type: "textarea", localized: true },
           ],
         } as Field, // Cast needed because group without name is valid but not in strict types
-      ]
-      const data = { title: 'Hello', description: 'World' }
+      ];
+      const data = { title: "Hello", description: "World" };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(2)
-      expect(chunks[0].path).toEqual(['title'])
-      expect(chunks[1].path).toEqual(['description'])
-      expect(chunks[0].dataRef).toBe(data)
-    })
-  })
+      expect(chunks).toHaveLength(2);
+      expect(chunks[0].path).toEqual(["title"]);
+      expect(chunks[1].path).toEqual(["description"]);
+      expect(chunks[0].dataRef).toBe(data);
+    });
+  });
 
-  describe('complex nested structures', () => {
-    it('collects array fields inside group', () => {
+  describe("complex nested structures", () => {
+    it("collects array fields inside group", () => {
       const schema: Field[] = [
         {
-          name: 'section',
-          type: 'group',
+          name: "section",
+          type: "group",
           fields: [
             {
-              name: 'items',
-              type: 'array',
-              fields: [{ name: 'label', type: 'text', localized: true }],
+              name: "items",
+              type: "array",
+              fields: [{ name: "label", type: "text", localized: true }],
             },
           ],
         },
-      ]
-      const data = { section: { items: [{ id: '1', label: 'Hello' }] } }
+      ];
+      const data = { section: { items: [{ id: "1", label: "Hello" }] } };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('label')
-      expect(chunks[0].path).toEqual(['section', 'items', '0', 'label'])
-      expect(chunks[0].dataRef).toBe(data.section.items[0])
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("label");
+      expect(chunks[0].path).toEqual(["section", "items", "0", "label"]);
+      expect(chunks[0].dataRef).toBe(data.section.items[0]);
+    });
 
-    it('collects group fields inside array', () => {
+    it("collects group fields inside array", () => {
       const schema: Field[] = [
         {
-          name: 'items',
-          type: 'array',
+          name: "items",
+          type: "array",
           fields: [
             {
-              name: 'meta',
-              type: 'group',
-              fields: [{ name: 'title', type: 'text', localized: true }],
+              name: "meta",
+              type: "group",
+              fields: [{ name: "title", type: "text", localized: true }],
             },
           ],
         },
-      ]
-      const data = { items: [{ id: '1', meta: { title: 'Hello' } }] }
+      ];
+      const data = { items: [{ id: "1", meta: { title: "Hello" } }] };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('title')
-      expect(chunks[0].path).toEqual(['items', '0', 'meta', 'title'])
-      expect(chunks[0].dataRef).toBe(data.items[0].meta)
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("title");
+      expect(chunks[0].path).toEqual(["items", "0", "meta", "title"]);
+      expect(chunks[0].dataRef).toBe(data.items[0].meta);
+    });
 
-    it('collects blocks fields inside group', () => {
+    it("collects blocks fields inside group", () => {
       const schema: Field[] = [
         {
-          name: 'hero',
-          type: 'group',
+          name: "hero",
+          type: "group",
           fields: [
             {
-              name: 'content',
-              type: 'blocks',
+              name: "content",
+              type: "blocks",
               blocks: [
                 {
-                  slug: 'text',
-                  fields: [{ name: 'body', type: 'text', localized: true }],
+                  slug: "text",
+                  fields: [{ name: "body", type: "text", localized: true }],
                 },
               ],
             },
           ],
         },
-      ]
-      const data = { hero: { content: [{ id: '1', blockType: 'text', body: 'Hello' }] } }
+      ];
+      const data = { hero: { content: [{ id: "1", blockType: "text", body: "Hello" }] } };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('body')
-      expect(chunks[0].path).toEqual(['hero', 'content', '0', 'body'])
-      expect(chunks[0].dataRef).toBe(data.hero.content[0])
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("body");
+      expect(chunks[0].path).toEqual(["hero", "content", "0", "body"]);
+      expect(chunks[0].dataRef).toBe(data.hero.content[0]);
+    });
 
-    it('collects group fields inside blocks', () => {
+    it("collects group fields inside blocks", () => {
       const schema: Field[] = [
         {
-          name: 'layout',
-          type: 'blocks',
+          name: "layout",
+          type: "blocks",
           blocks: [
             {
-              slug: 'card',
+              slug: "card",
               fields: [
                 {
-                  name: 'meta',
-                  type: 'group',
-                  fields: [{ name: 'title', type: 'text', localized: true }],
+                  name: "meta",
+                  type: "group",
+                  fields: [{ name: "title", type: "text", localized: true }],
                 },
               ],
             },
           ],
         },
-      ]
-      const data = { layout: [{ id: '1', blockType: 'card', meta: { title: 'Hello' } }] }
+      ];
+      const data = { layout: [{ id: "1", blockType: "card", meta: { title: "Hello" } }] };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('title')
-      expect(chunks[0].path).toEqual(['layout', '0', 'meta', 'title'])
-      expect(chunks[0].dataRef).toBe(data.layout[0].meta)
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("title");
+      expect(chunks[0].path).toEqual(["layout", "0", "meta", "title"]);
+      expect(chunks[0].dataRef).toBe(data.layout[0].meta);
+    });
 
-    it('collects blocks fields inside array', () => {
+    it("collects blocks fields inside array", () => {
       const schema: Field[] = [
         {
-          name: 'sections',
-          type: 'array',
+          name: "sections",
+          type: "array",
           fields: [
             {
-              name: 'blocks',
-              type: 'blocks',
+              name: "blocks",
+              type: "blocks",
               blocks: [
                 {
-                  slug: 'text',
-                  fields: [{ name: 'content', type: 'text', localized: true }],
+                  slug: "text",
+                  fields: [{ name: "content", type: "text", localized: true }],
                 },
               ],
             },
           ],
         },
-      ]
+      ];
       const data = {
-        sections: [{ id: '1', blocks: [{ id: 'b1', blockType: 'text', content: 'Hello' }] }],
-      }
+        sections: [{ id: "1", blocks: [{ id: "b1", blockType: "text", content: "Hello" }] }],
+      };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('content')
-      expect(chunks[0].path).toEqual(['sections', '0', 'blocks', '0', 'content'])
-      expect(chunks[0].dataRef).toBe(data.sections[0].blocks[0])
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("content");
+      expect(chunks[0].path).toEqual(["sections", "0", "blocks", "0", "content"]);
+      expect(chunks[0].dataRef).toBe(data.sections[0].blocks[0]);
+    });
 
-    it('collects fields from named tabs', () => {
+    it("collects fields from named tabs", () => {
       const schema: Field[] = [
         {
-          type: 'tabs',
+          type: "tabs",
           tabs: [
             {
-              name: 'seo',
-              fields: [{ name: 'title', type: 'text', localized: true }],
+              name: "seo",
+              fields: [{ name: "title", type: "text", localized: true }],
             },
           ],
         },
-      ]
-      const data = { seo: { title: 'SEO Title' } }
+      ];
+      const data = { seo: { title: "SEO Title" } };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('title')
-      expect(chunks[0].path).toEqual(['seo', 'title'])
-      expect(chunks[0].dataRef).toBe(data.seo)
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("title");
+      expect(chunks[0].path).toEqual(["seo", "title"]);
+      expect(chunks[0].dataRef).toBe(data.seo);
+    });
 
-    it('collects fields from collapsible', () => {
+    it("collects fields from collapsible", () => {
       const schema: Field[] = [
         {
-          type: 'collapsible',
-          label: 'Advanced',
-          fields: [{ name: 'meta', type: 'text', localized: true }],
+          type: "collapsible",
+          label: "Advanced",
+          fields: [{ name: "meta", type: "text", localized: true }],
         },
-      ]
-      const data = { meta: 'Value' }
+      ];
+      const data = { meta: "Value" };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('meta')
-      expect(chunks[0].path).toEqual(['meta'])
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("meta");
+      expect(chunks[0].path).toEqual(["meta"]);
+    });
 
-    it('collects 4-level nested structure (tabs > group > array > blocks)', () => {
+    it("collects 4-level nested structure (tabs > group > array > blocks)", () => {
       const schema: Field[] = [
         {
-          type: 'tabs',
+          type: "tabs",
           tabs: [
             {
-              name: 'content',
+              name: "content",
               fields: [
                 {
-                  name: 'sections',
-                  type: 'group',
+                  name: "sections",
+                  type: "group",
                   fields: [
                     {
-                      name: 'items',
-                      type: 'array',
+                      name: "items",
+                      type: "array",
                       fields: [
                         {
-                          name: 'blocks',
-                          type: 'blocks',
+                          name: "blocks",
+                          type: "blocks",
                           blocks: [
                             {
-                              slug: 'text',
-                              fields: [{ name: 'body', type: 'text', localized: true }],
+                              slug: "text",
+                              fields: [{ name: "body", type: "text", localized: true }],
                             },
                           ],
                         },
@@ -527,43 +527,43 @@ describe('FieldChunkCollector', () => {
             },
           ],
         },
-      ]
+      ];
       const data = {
         content: {
           sections: {
-            items: [{ id: '1', blocks: [{ id: 'b1', blockType: 'text', body: 'Deep content' }] }],
+            items: [{ id: "1", blocks: [{ id: "b1", blockType: "text", body: "Deep content" }] }],
           },
         },
-      }
+      };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('body')
-      expect(chunks[0].path).toEqual(['content', 'sections', 'items', '0', 'blocks', '0', 'body'])
-      expect(chunks[0].dataRef).toBe(data.content.sections.items[0].blocks[0])
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("body");
+      expect(chunks[0].path).toEqual(["content", "sections", "items", "0", "blocks", "0", "body"]);
+      expect(chunks[0].dataRef).toBe(data.content.sections.items[0].blocks[0]);
+    });
 
-    it('collects multiple fields from complex nested structure', () => {
+    it("collects multiple fields from complex nested structure", () => {
       const schema: Field[] = [
         {
-          name: 'page',
-          type: 'group',
+          name: "page",
+          type: "group",
           fields: [
-            { name: 'title', type: 'text', localized: true },
+            { name: "title", type: "text", localized: true },
             {
-              name: 'sections',
-              type: 'array',
+              name: "sections",
+              type: "array",
               fields: [
-                { name: 'heading', type: 'text', localized: true },
+                { name: "heading", type: "text", localized: true },
                 {
-                  name: 'content',
-                  type: 'blocks',
+                  name: "content",
+                  type: "blocks",
                   blocks: [
                     {
-                      slug: 'paragraph',
-                      fields: [{ name: 'text', type: 'text', localized: true }],
+                      slug: "paragraph",
+                      fields: [{ name: "text", type: "text", localized: true }],
                     },
                   ],
                 },
@@ -571,282 +571,313 @@ describe('FieldChunkCollector', () => {
             },
           ],
         },
-      ]
+      ];
       const data = {
         page: {
-          title: 'Page Title',
+          title: "Page Title",
           sections: [
             {
-              id: '1',
-              heading: 'Section 1',
-              content: [{ id: 'b1', blockType: 'paragraph', text: 'Content 1' }],
+              id: "1",
+              heading: "Section 1",
+              content: [{ id: "b1", blockType: "paragraph", text: "Content 1" }],
             },
             {
-              id: '2',
-              heading: 'Section 2',
-              content: [{ id: 'b2', blockType: 'paragraph', text: 'Content 2' }],
+              id: "2",
+              heading: "Section 2",
+              content: [{ id: "b2", blockType: "paragraph", text: "Content 2" }],
             },
           ],
         },
-      }
+      };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(5)
+      expect(chunks).toHaveLength(5);
       expect(chunks.map((c) => c.path)).toEqual([
-        ['page', 'title'],
-        ['page', 'sections', '0', 'heading'],
-        ['page', 'sections', '0', 'content', '0', 'text'],
-        ['page', 'sections', '1', 'heading'],
-        ['page', 'sections', '1', 'content', '0', 'text'],
-      ])
-    })
-  })
+        ["page", "title"],
+        ["page", "sections", "0", "heading"],
+        ["page", "sections", "0", "content", "0", "text"],
+        ["page", "sections", "1", "heading"],
+        ["page", "sections", "1", "content", "0", "text"],
+      ]);
+    });
+  });
 
-  describe('dataRef mutation capability', () => {
-    it('provides mutable reference to parent object', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const data = { title: 'Hello' }
+  describe("dataRef mutation capability", () => {
+    it("provides mutable reference to parent object", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const data = { title: "Hello" };
 
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
-
-      // Mutate through dataRef
-      chunks[0].dataRef[chunks[0].key] = 'Modified'
-
-      expect(data.title).toBe('Modified')
-    })
-
-    it('provides mutable reference in nested structures', () => {
-      const schema: Field[] = [
-        {
-          name: 'items',
-          type: 'array',
-          fields: [{ name: 'label', type: 'text', localized: true }],
-        },
-      ]
-      const data = { items: [{ id: '1', label: 'Original' }] }
-
-      const collector = new FieldChunkCollector(schema, data, data, {}, strategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
 
       // Mutate through dataRef
-      chunks[0].dataRef[chunks[0].key] = 'Modified'
+      chunks[0].dataRef[chunks[0].key] = "Modified";
 
-      expect(data.items[0].label).toBe('Modified')
-    })
-  })
+      expect(data.title).toBe("Modified");
+    });
 
-  describe('strategy filtering', () => {
-    it('skips fields with existing target values (SkipExisting)', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const filteredData = { title: 'Existing' }
-      const sourceData = { title: 'Hello' }
-      const targetData = { title: 'Existing' }
-
-      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy)
-      const chunks = collector.collect()
-
-      expect(chunks).toHaveLength(0)
-    })
-
-    it('collects fields with empty target values (SkipExisting)', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const filteredData = { title: 'Hello' }
-      const sourceData = { title: 'Hello' }
-      const targetData = { title: '' }
-
-      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy)
-      const chunks = collector.collect()
-
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('title')
-    })
-
-    it('handles mixed fields with SkipExisting', () => {
-      const schema: Field[] = [
-        { name: 'title', type: 'text', localized: true },
-        { name: 'description', type: 'text', localized: true },
-      ]
-      const filteredData = { title: 'Existing', description: 'World' }
-      const sourceData = { title: 'Hello', description: 'World' }
-      const targetData = { title: 'Existing', description: '' }
-
-      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy)
-      const chunks = collector.collect()
-
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].key).toBe('description')
-    })
-
-    it('collects all fields with OverwriteStrategy even when target exists', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const filteredData = { title: 'Existing' }
-      const sourceData = { title: 'Hello' }
-      const targetData = { title: 'Existing' }
-
-      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, strategy)
-      const chunks = collector.collect()
-
-      expect(chunks).toHaveLength(1)
-    })
-
-    it('applies SkipExisting to nested array fields', () => {
+    it("provides mutable reference in nested structures", () => {
       const schema: Field[] = [
         {
-          name: 'items',
-          type: 'array',
-          fields: [{ name: 'label', type: 'text', localized: true }],
+          name: "items",
+          type: "array",
+          fields: [{ name: "label", type: "text", localized: true }],
         },
-      ]
+      ];
+      const data = { items: [{ id: "1", label: "Original" }] };
+
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
+
+      // Mutate through dataRef
+      chunks[0].dataRef[chunks[0].key] = "Modified";
+
+      expect(data.items[0].label).toBe("Modified");
+    });
+  });
+
+  describe("strategy filtering", () => {
+    it("skips fields with existing target values (SkipExisting)", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const filteredData = { title: "Existing" };
+      const sourceData = { title: "Hello" };
+      const targetData = { title: "Existing" };
+
+      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy);
+      const chunks = collector.collect();
+
+      expect(chunks).toHaveLength(0);
+    });
+
+    it("collects fields with empty target values (SkipExisting)", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const filteredData = { title: "Hello" };
+      const sourceData = { title: "Hello" };
+      const targetData = { title: "" };
+
+      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy);
+      const chunks = collector.collect();
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("title");
+    });
+
+    it("handles mixed fields with SkipExisting", () => {
+      const schema: Field[] = [
+        { name: "title", type: "text", localized: true },
+        { name: "description", type: "text", localized: true },
+      ];
+      const filteredData = { title: "Existing", description: "World" };
+      const sourceData = { title: "Hello", description: "World" };
+      const targetData = { title: "Existing", description: "" };
+
+      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy);
+      const chunks = collector.collect();
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("description");
+    });
+
+    it("collects all fields with OverwriteStrategy even when target exists", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const filteredData = { title: "Existing" };
+      const sourceData = { title: "Hello" };
+      const targetData = { title: "Existing" };
+
+      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, strategy);
+      const chunks = collector.collect();
+
+      expect(chunks).toHaveLength(1);
+    });
+
+    it("applies SkipExisting to nested array fields", () => {
+      const schema: Field[] = [
+        {
+          name: "items",
+          type: "array",
+          fields: [{ name: "label", type: "text", localized: true }],
+        },
+      ];
       const filteredData = {
         items: [
-          { id: '1', label: 'Translated' },
-          { id: '2', label: 'Second' },
+          { id: "1", label: "Translated" },
+          { id: "2", label: "Second" },
         ],
-      }
+      };
       const sourceData = {
         items: [
-          { id: '1', label: 'First' },
-          { id: '2', label: 'Second' },
+          { id: "1", label: "First" },
+          { id: "2", label: "Second" },
         ],
-      }
+      };
       const targetData = {
         items: [
-          { id: '1', label: 'Translated' },
-          { id: '2', label: '' },
+          { id: "1", label: "Translated" },
+          { id: "2", label: "" },
         ],
-      }
+      };
 
-      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].path).toEqual(['items', '1', 'label'])
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].path).toEqual(["items", "1", "label"]);
+    });
 
-    it('applies SkipExisting to nested group fields', () => {
+    it("applies SkipExisting to nested group fields", () => {
       const schema: Field[] = [
         {
-          name: 'meta',
-          type: 'group',
+          name: "meta",
+          type: "group",
           fields: [
-            { name: 'title', type: 'text', localized: true },
-            { name: 'description', type: 'text', localized: true },
+            { name: "title", type: "text", localized: true },
+            { name: "description", type: "text", localized: true },
           ],
         },
-      ]
-      const filteredData = { meta: { title: 'Translated', description: 'World' } }
-      const sourceData = { meta: { title: 'Hello', description: 'World' } }
-      const targetData = { meta: { title: 'Translated', description: '' } }
+      ];
+      const filteredData = { meta: { title: "Translated", description: "World" } };
+      const sourceData = { meta: { title: "Hello", description: "World" } };
+      const targetData = { meta: { title: "Translated", description: "" } };
 
-      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].path).toEqual(['meta', 'description'])
-    })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].path).toEqual(["meta", "description"]);
+    });
 
-    it('applies SkipExisting to blocks fields', () => {
+    it("applies SkipExisting to blocks fields", () => {
       const schema: Field[] = [
         {
-          name: 'layout',
-          type: 'blocks',
+          name: "layout",
+          type: "blocks",
           blocks: [
             {
-              slug: 'text',
-              fields: [{ name: 'content', type: 'text', localized: true }],
+              slug: "text",
+              fields: [{ name: "content", type: "text", localized: true }],
             },
           ],
         },
-      ]
+      ];
       const filteredData = {
         layout: [
-          { id: '1', blockType: 'text', content: 'Translated' },
-          { id: '2', blockType: 'text', content: 'World' },
+          { id: "1", blockType: "text", content: "Translated" },
+          { id: "2", blockType: "text", content: "World" },
         ],
-      }
+      };
       const sourceData = {
         layout: [
-          { id: '1', blockType: 'text', content: 'Hello' },
-          { id: '2', blockType: 'text', content: 'World' },
+          { id: "1", blockType: "text", content: "Hello" },
+          { id: "2", blockType: "text", content: "World" },
         ],
-      }
+      };
       const targetData = {
         layout: [
-          { id: '1', blockType: 'text', content: 'Translated' },
-          { id: '2', blockType: 'text', content: '' },
+          { id: "1", blockType: "text", content: "Translated" },
+          { id: "2", blockType: "text", content: "" },
         ],
-      }
+      };
 
-      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy)
-      const chunks = collector.collect()
+      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy);
+      const chunks = collector.collect();
 
-      expect(chunks).toHaveLength(1)
-      expect(chunks[0].path).toEqual(['layout', '1', 'content'])
-    })
-  })
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].path).toEqual(["layout", "1", "content"]);
+    });
+  });
 
-  describe('sourceValue mutation', () => {
-    it('writes sourceValue to filteredData when shouldTranslate is true', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const filteredData = { title: 'Target value' }
-      const sourceData = { title: 'Source value' }
-      const targetData = { title: 'Target value' }
+  describe("sourceValue mutation", () => {
+    it("writes sourceValue to filteredData when shouldTranslate is true", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const filteredData = { title: "Target value" };
+      const sourceData = { title: "Source value" };
+      const targetData = { title: "Target value" };
 
-      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, strategy)
-      collector.collect()
+      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, strategy);
+      collector.collect();
 
-      expect(filteredData.title).toBe('Source value')
-    })
+      expect(filteredData.title).toBe("Source value");
+    });
 
-    it('does not modify filteredData when shouldTranslate is false', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const filteredData = { title: 'Existing' }
-      const sourceData = { title: 'Hello' }
-      const targetData = { title: 'Existing' }
+    it("does not modify filteredData when shouldTranslate is false", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const filteredData = { title: "Existing" };
+      const sourceData = { title: "Hello" };
+      const targetData = { title: "Existing" };
 
-      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy)
-      collector.collect()
+      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy);
+      collector.collect();
 
-      expect(filteredData.title).toBe('Existing')
-    })
+      expect(filteredData.title).toBe("Existing");
+    });
 
-    it('writes sourceValue in nested structures', () => {
+    it("writes sourceValue in nested structures", () => {
       const schema: Field[] = [
         {
-          name: 'meta',
-          type: 'group',
-          fields: [{ name: 'title', type: 'text', localized: true }],
+          name: "meta",
+          type: "group",
+          fields: [{ name: "title", type: "text", localized: true }],
         },
-      ]
-      const filteredData = { meta: { title: 'Target' } }
-      const sourceData = { meta: { title: 'Source' } }
-      const targetData = { meta: { title: 'Target' } }
+      ];
+      const filteredData = { meta: { title: "Target" } };
+      const sourceData = { meta: { title: "Source" } };
+      const targetData = { meta: { title: "Target" } };
 
-      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, strategy)
-      collector.collect()
+      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, strategy);
+      collector.collect();
 
-      expect(filteredData.meta.title).toBe('Source')
-    })
+      expect(filteredData.meta.title).toBe("Source");
+    });
 
-    it('writes sourceValue in array items', () => {
+    it("writes sourceValue in array items", () => {
       const schema: Field[] = [
         {
-          name: 'items',
-          type: 'array',
-          fields: [{ name: 'label', type: 'text', localized: true }],
+          name: "items",
+          type: "array",
+          fields: [{ name: "label", type: "text", localized: true }],
         },
-      ]
-      const filteredData = { items: [{ id: '1', label: 'Target' }] }
-      const sourceData = { items: [{ id: '1', label: 'Source' }] }
-      const targetData = { items: [{ id: '1', label: 'Target' }] }
+      ];
+      const filteredData = { items: [{ id: "1", label: "Target" }] };
+      const sourceData = { items: [{ id: "1", label: "Source" }] };
+      const targetData = { items: [{ id: "1", label: "Target" }] };
 
-      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, strategy)
-      collector.collect()
+      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, strategy);
+      collector.collect();
 
-      expect(filteredData.items[0].label).toBe('Source')
-    })
-  })
-})
+      expect(filteredData.items[0].label).toBe("Source");
+    });
+  });
+
+  describe("array edge cases", () => {
+    it("skips non-object items in arrays (no chunk, no crash)", () => {
+      const schema: Field[] = [{ name: "items", type: "array", fields: [{ name: "label", type: "text", localized: true }] }];
+      const data = { items: [{ id: "1", label: "A" }, "garbage", null] };
+
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].path).toEqual(["items", "0", "label"]);
+    });
+
+    it("falls back to empty source/target per item when the target array is shorter (SkipExisting)", () => {
+      const schema: Field[] = [{ name: "items", type: "array", fields: [{ name: "label", type: "text", localized: true }] }];
+      const filteredData = {
+        items: [
+          { id: "1", label: "A" },
+          { id: "2", label: "B" },
+        ],
+      };
+      const targetData = { items: [{ id: "1", label: "T" }] };
+
+      const collector = new FieldChunkCollector(schema, filteredData, filteredData, targetData, skipExistingStrategy);
+      const chunks = collector.collect();
+
+      // item 0 has an existing target → skipped; item 1's target falls back to {} → collected
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].path).toEqual(["items", "1", "label"]);
+    });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/index.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/index.ts
@@ -1,0 +1,3 @@
+export { classifyField, resolveBlockFields, tabScopes } from "./kernel";
+export type { ChildCursor, ChildOutput, ContainerInfo, FieldStructure, FieldWalker, LeafField, TabScope, WalkSignal } from "./types";
+export { walkFields } from "./walkFields";

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/kernel.test.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/kernel.test.ts
@@ -1,0 +1,126 @@
+import type { ArrayField, BlocksField, Field, NamedGroupField, RowField, TabsField, TextField, UIField } from "payload";
+import { describe, expect, it } from "vitest";
+
+import { classifyField, resolveBlockFields, tabScopes } from "./kernel";
+
+const text = (name: string, extra: Record<string, unknown> = {}): TextField => ({ name, type: "text", ...extra }) as unknown as TextField;
+
+describe("classifyField", () => {
+  it("classifies text/textarea/richText leaves as `leaf`", () => {
+    const field = text("title");
+    expect(classifyField(field)).toEqual({ kind: "leaf", name: "title", field });
+  });
+
+  it("classifies a named group as `group`, exposing name + child fields", () => {
+    const child = text("title");
+    const field = { type: "group", name: "meta", fields: [child] } as unknown as NamedGroupField;
+    expect(classifyField(field as unknown as Field)).toEqual({
+      kind: "group",
+      name: "meta",
+      fields: [child],
+      field,
+    });
+  });
+
+  it("classifies an array as `array`", () => {
+    const child = text("label");
+    const field = { type: "array", name: "items", fields: [child] } as unknown as ArrayField;
+    expect(classifyField(field as unknown as Field)).toEqual({
+      kind: "array",
+      name: "items",
+      fields: [child],
+      field,
+    });
+  });
+
+  it("classifies blocks as `blocks` (child fields resolved per-element later)", () => {
+    const field = { type: "blocks", name: "content", blocks: [] } as unknown as BlocksField;
+    expect(classifyField(field as unknown as Field)).toEqual({ kind: "blocks", name: "content", field });
+  });
+
+  it("classifies a presentational container (row) as `transparent` — same data scope", () => {
+    const inner = text("title");
+    const field = { type: "row", fields: [inner] } as unknown as RowField;
+    expect(classifyField(field as unknown as Field)).toEqual({ kind: "transparent", fields: [inner] });
+  });
+
+  it("classifies an UNNAMED group as `transparent` (it opens no data boundary)", () => {
+    const inner = text("title");
+    const field = { type: "group", fields: [inner] } as unknown as Field;
+    expect(classifyField(field)).toEqual({ kind: "transparent", fields: [inner] });
+  });
+
+  it("classifies a `ui` field as `presentational` (no data, no subfields)", () => {
+    const field = { type: "ui", name: "spacer" } as unknown as UIField;
+    expect(classifyField(field as unknown as Field)).toEqual({ kind: "presentational" });
+  });
+
+  it("classifies a tabs field as `tabs`", () => {
+    const field = { type: "tabs", tabs: [] } as unknown as TabsField;
+    expect(classifyField(field as unknown as Field)).toEqual({ kind: "tabs", field });
+  });
+});
+
+describe("classifyField — dispatch order (disambiguation)", () => {
+  // These fixtures match more than one predicate; only the CHECK ORDER picks the winner.
+  // If classifyField's branches are reordered, exactly these assertions break.
+
+  it("resolves an unnamed group as `transparent`, not `group` (fieldAffectsData gate runs before the group check)", () => {
+    // type === 'group' (→ fieldIsGroupType) AND no name (→ !fieldAffectsData). Order decides.
+    const field = { type: "group", fields: [text("x")] } as unknown as Field;
+    expect(classifyField(field).kind).toBe("transparent");
+  });
+
+  it("resolves a tabs field as `tabs`, not `presentational` (tabs is checked before the non-data-affecting branch)", () => {
+    // Non-data-affecting and has no `.fields`, so a wrong order would mislabel it `presentational`.
+    const field = { type: "tabs", tabs: [{ label: "T", fields: [text("x")] }] } as unknown as Field;
+    expect(classifyField(field).kind).toBe("tabs");
+  });
+
+  it("resolves a named group as `group`, not `transparent` (the gate lets data-affecting fields through)", () => {
+    // Confirms the fieldAffectsData gate does not over-capture: a named group still reaches the group check.
+    const field = { type: "group", name: "meta", fields: [text("x")] } as unknown as Field;
+    expect(classifyField(field).kind).toBe("group");
+  });
+});
+
+describe("tabScopes", () => {
+  it("flattens named + unnamed tabs, preserving order", () => {
+    const a = text("a");
+    const b = text("b");
+    const field = {
+      type: "tabs",
+      tabs: [
+        { name: "seo", fields: [a] },
+        { label: "Layout", fields: [b] },
+      ],
+    } as unknown as TabsField;
+
+    expect(tabScopes(field)).toEqual([
+      { named: true, tab: { name: "seo", fields: [a] } },
+      { named: false, fields: [b] },
+    ]);
+  });
+});
+
+describe("resolveBlockFields", () => {
+  const hero = text("heading");
+  const field = {
+    type: "blocks",
+    name: "content",
+    blocks: [{ slug: "hero", fields: [hero] }],
+  } as unknown as BlocksField;
+
+  it("returns the matching block fields by blockType", () => {
+    expect(resolveBlockFields(field, { blockType: "hero", heading: "Hi" })).toEqual([hero]);
+  });
+
+  it("returns null for an unknown blockType", () => {
+    expect(resolveBlockFields(field, { blockType: "unknown" })).toBeNull();
+  });
+
+  it("returns null for a non-block item", () => {
+    expect(resolveBlockFields(field, "not-an-object")).toBeNull();
+    expect(resolveBlockFields(field, { noBlockType: true })).toBeNull();
+  });
+});

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/kernel.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/kernel.ts
@@ -1,0 +1,125 @@
+import type { BlocksField, Field, TabsField } from "payload";
+import { fieldAffectsData, fieldIsArrayType, fieldIsBlockType, fieldIsGroupType, tabHasName } from "payload/shared";
+
+import { hasFields, isBlockItem, isTabsField } from "../guards";
+import type { FieldStructure, LeafField, TabScope } from "./types";
+
+/**
+ * Classify a single Payload {@link Field} into a discriminated {@link FieldStructure} — the
+ * one place that encodes how Payload field types map onto data boundaries.
+ *
+ * Traversals switch on the result instead of re-deriving the predicate chain
+ * (`fieldAffectsData` / `fieldIsGroupType` / …), so the dispatch — and any future Payload
+ * field type — lives in exactly one place.
+ *
+ * @param field - Any field from a collection/global `fields` array (original, un-sanitized
+ * config).
+ * @returns The field's {@link FieldStructure}:
+ * - `tabs` — a `tabs` field (expand with {@link tabScopes}).
+ * - `transparent` — a presentational container that opens **no** data boundary (`row`,
+ *   `collapsible`, unnamed `group`); its `fields` live in the parent's data scope.
+ * - `presentational` — a `ui` field: no data, no subfields.
+ * - `group` / `array` / `blocks` — named data boundaries (carry `name` + child `fields`,
+ *   except `blocks` whose child fields are per-element via {@link resolveBlockFields}).
+ * - `leaf` — a data-affecting field with no subfields.
+ *
+ * Dispatch order is significant: some fields satisfy more than one predicate and only the
+ * order disambiguates them.
+ * - `tabs` is checked first — it carries `.tabs` (not `.fields`) and is non-data-affecting,
+ *   so a later check would mislabel it `presentational`.
+ * - `fieldAffectsData` is resolved before the `group` check, so an unnamed group resolves to
+ *   `transparent`, never a `group` with `name: undefined`.
+ *
+ * @example
+ * ```ts
+ * const structure = classifyField(field);
+ * switch (structure.kind) {
+ *   case "group": descend(structure.fields, data[structure.name]); break;
+ *   case "leaf":  translate(structure.field, structure.name); break;
+ *   // ...handle the remaining kinds
+ * }
+ * ```
+ *
+ * @see {@link walkFields} — the recursive engine built on this classification.
+ * @public
+ */
+export function classifyField(field: Field): FieldStructure {
+  if (isTabsField(field)) {
+    return { kind: "tabs", field };
+  }
+
+  if (!fieldAffectsData(field)) {
+    return hasFields(field) ? { kind: "transparent", fields: field.fields } : { kind: "presentational" };
+  }
+
+  if (fieldIsGroupType(field)) {
+    return { kind: "group", name: field.name, fields: field.fields, field };
+  }
+
+  if (fieldIsArrayType(field)) {
+    return { kind: "array", name: field.name, fields: field.fields, field };
+  }
+
+  if (fieldIsBlockType(field)) {
+    return { kind: "blocks", name: field.name, field };
+  }
+
+  const leaf = field as LeafField;
+  return { kind: "leaf", name: leaf.name, field: leaf };
+}
+
+/**
+ * Flatten a `tabs` field's tabs into {@link TabScope}s, absorbing the named/unnamed +
+ * `hasFields` handling that field traversals would otherwise each repeat.
+ *
+ * @param field - A Payload `tabs` field.
+ * @returns One {@link TabScope} per tab that has fields, in declaration order:
+ * - a **named** tab → `{ named: true, tab }` — it opens a data boundary at `tab.name`, and
+ *   the `NamedTab` is surfaced so callers can read its `name`/`fields`/config;
+ * - an **unnamed** tab → `{ named: false, fields }` — its fields live in the parent's data
+ *   scope, so only the `fields` are needed.
+ *
+ * @example
+ * ```ts
+ * for (const scope of tabScopes(tabsField)) {
+ *   if (scope.named) descendInto(data[scope.tab.name], scope.tab.fields);
+ *   else descendInto(data, scope.fields); // unnamed tab — same data scope as the parent
+ * }
+ * ```
+ * @public
+ */
+export function tabScopes(field: TabsField): TabScope[] {
+  const scopes: TabScope[] = [];
+  for (const tab of field.tabs) {
+    if (tabHasName(tab)) scopes.push({ named: true, tab });
+    else if (hasFields(tab)) scopes.push({ named: false, fields: tab.fields });
+  }
+  return scopes;
+}
+
+/**
+ * Resolve the child `fields` for a single `blocks` element by matching its `blockType`
+ * against the field's block definitions.
+ *
+ * @param field - A Payload `blocks` field carrying inline block definitions.
+ * @param item - The data for one block element (expected to carry a `blockType` string).
+ * @returns The matched block's `fields`, or `null` when `item` is not a block object or its
+ * `blockType` matches no defined block.
+ *
+ * Assumes the **original, un-sanitized** schema, where blocks are inline `Block` objects on
+ * `field.blocks`. Payload's sanitized config may instead carry `blockReferences` resolved
+ * against the top-level config — not handled here by design, since this package traverses
+ * the original schema to preserve nested `localized` flags.
+ *
+ * @example
+ * ```ts
+ * const fields = resolveBlockFields(blocksField, item);
+ * if (fields) descendInto(item, fields); // null → unknown blockType / not a block → skip
+ * ```
+ * @public
+ */
+export function resolveBlockFields(field: BlocksField, item: unknown): Field[] | null {
+  if (!isBlockItem(item)) return null;
+  const block = field.blocks.find((candidate) => candidate.slug === item.blockType);
+  return block ? block.fields : null;
+}

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/types.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/types.ts
@@ -1,0 +1,163 @@
+import type { ArrayField, BlocksField, Field, FieldAffectingData, NamedGroupField, NamedTab, TabAsField, TabsField } from "payload";
+
+/**
+ * A data-affecting field the engine routes to `leaf`: a scalar/relational leaf, never a
+ * container (`group`/`array`/`blocks`) and never a `TabAsField`. Narrowing `FieldAffectingData`
+ * down to these members is what guarantees `name: string` — the raw union does NOT, because
+ * an unnamed `TabAsField` carries `name?: string`.
+ *
+ * @public
+ */
+export type LeafField = Exclude<FieldAffectingData, ArrayField | BlocksField | NamedGroupField | TabAsField>;
+
+/**
+ * Structural classification of a single Payload field — the one place that encodes
+ * how Payload field types map onto data boundaries (the dispatch order
+ * `tabs → transparent → group → array → blocks → leaf`).
+ *
+ * Consumed by {@link FieldWalker}/`walkFields` (the exhaustive, data-parallel walks)
+ * and by path-navigation; the four hand-rolled traversals collapse onto it so the
+ * dispatch lives in exactly one place.
+ *
+ * - `transparent` — presentational container that does NOT open a data boundary
+ *   (row, collapsible, unnamed group). Its `fields` live in the SAME data scope as
+ *   the parent.
+ * - `presentational` — a `ui` leaf: no data, no subfields.
+ * - `group`/`array`/`blocks` — open a data boundary at `name`.
+ * - `leaf` — a data-affecting field with no subfields.
+ *
+ * @see {@link classifyField} — produces this; {@link walkFields} — consumes it.
+ * @public
+ */
+export type FieldStructure =
+  | { kind: "tabs"; field: TabsField }
+  | { kind: "transparent"; fields: Field[] }
+  | { kind: "presentational" }
+  | { kind: "group"; name: string; fields: Field[]; field: NamedGroupField }
+  | { kind: "array"; name: string; fields: Field[]; field: ArrayField }
+  | { kind: "blocks"; name: string; field: BlocksField }
+  | { kind: "leaf"; name: string; field: LeafField };
+
+/**
+ * A tab flattened by `tabScopes`. A named tab opens a data boundary, so its `NamedTab`
+ * is surfaced (the walker passes it to `enterObject`, and `tab.name` is the data key).
+ * An unnamed tab flattens into the parent data scope, so only its `fields` are needed.
+ *
+ * @see {@link tabScopes}
+ * @public
+ */
+export type TabScope = { named: true; tab: NamedTab } | { named: false; fields: Field[] };
+
+/**
+ * Control signal a walker callback can return instead of descending.
+ * - `skip` — do not descend this branch; continue with siblings.
+ * - `stop` — halt the whole walk (used for path-style navigation / early-exit).
+ *
+ * @public
+ */
+export type WalkSignal = "skip" | "stop";
+
+/**
+ * One child to recurse under an array/blocks boundary. The caller derives these from its own
+ * data (it alone knows how many elements there are and their shape) and returns them from
+ * {@link FieldWalker.enterList}.
+ *
+ * @template Cursor - The walker's data-position type (see {@link FieldWalker}).
+ * @public
+ */
+export interface ChildCursor<Cursor extends object> {
+  cursor: Cursor;
+  /** Child fields to walk under this item. For `blocks`, the resolved `block.fields`. */
+  fields: Field[];
+  /** Index/key this child sits at; surfaced back to `combine`. */
+  key: string | number;
+}
+
+/**
+ * The container the engine asks the walker to assemble, bottom-up.
+ *
+ * - `root` — the top-level field list (`field` is `null`).
+ * - `object` — a `group` or a named tab.
+ * - `list` — an `array` or `blocks` collection (children are its elements, keyed by index).
+ * - `element` — a single element of a list (children are its fields). `field` is the
+ *   parent list field; distinguish array vs blocks via `field.type`.
+ *
+ * @see {@link FieldWalker.combine}
+ * @public
+ */
+export type ContainerInfo =
+  | { kind: "root"; field: null }
+  | { kind: "object"; field: NamedGroupField | NamedTab; key: string }
+  | { kind: "list"; field: ArrayField | BlocksField; key: string }
+  | { kind: "element"; field: ArrayField | BlocksField; key: string | number };
+
+/**
+ * A child's assembled output, tagged with the key it sat at within its parent. Passed to
+ * {@link FieldWalker.combine} as the `children` list.
+ *
+ * @template Out - The walker's per-node output type (see {@link FieldWalker}).
+ * @public
+ */
+export interface ChildOutput<Out> {
+  key: string | number;
+  out: Out;
+}
+
+/**
+ * Behaviour a caller plugs into {@link walkFields}. The engine owns structural dispatch and
+ * recursion over the **schema**; the caller owns the **data** via the opaque `Cursor`
+ * (1..n parallel data trees plus any path live there) and decides what to produce.
+ *
+ * Shapes this is designed to subsume (one engine, many callers):
+ * - build-tree (filter / reconcile) — reconstruct values in `combine`.
+ * - collect + mutate (field-chunk collector) — push/mutate in `leaf`, `combine` is a no-op.
+ * - navigate + early-exit (path resolver) — `enter*` returns `'skip'`/`'stop'`.
+ *
+ * @template Cursor - The data position threaded through the walk. The engine never reads it;
+ * it only passes it to your callbacks and stores the cursors you return. Constrained to
+ * `object` so a cursor can never collide with a {@link WalkSignal} string (`'skip'`/`'stop'`).
+ * @template Out - What you produce per leaf and assemble per container. Use `void` for a
+ * collect-only walk (accumulate in a closure, return `undefined` from `combine`).
+ *
+ * @example
+ * A collect-only walker that records the path of every localized leaf:
+ * ```ts
+ * type Cursor = { data: Record<string, unknown>; path: string[] };
+ * const found: string[] = [];
+ *
+ * const walker: FieldWalker<Cursor, void> = {
+ *   enterObject: (field, c) =>
+ *     isRecord(c.data[field.name])
+ *       ? { data: c.data[field.name], path: [...c.path, field.name] }
+ *       : "skip",
+ *   enterList: (field, c) => toItemCursors(field, c),
+ *   leaf: (field, c) => {
+ *     if (field.localized) found.push([...c.path, field.name].join("."));
+ *     return undefined;
+ *   },
+ *   combine: () => undefined, // collect-only: nothing to assemble
+ * };
+ * ```
+ *
+ * @see {@link walkFields}
+ * @public
+ */
+export interface FieldWalker<Cursor extends object, Out> {
+  /** Enter a single-object boundary (named `group` or named tab). Return the child cursor, or a signal. */
+  enterObject(field: NamedGroupField | NamedTab, cursor: Cursor): Cursor | WalkSignal;
+  /** Enter an `array`/`blocks` boundary. Return one {@link ChildCursor} per element, or a signal. */
+  enterList(field: ArrayField | BlocksField, cursor: Cursor): ChildCursor<Cursor>[] | WalkSignal;
+  /**
+   * Visit a data-affecting leaf. `field` is a {@link LeafField} — the engine has already
+   * resolved it via the `fieldAffectsData` guard and excluded containers/tabs, so `field.name`
+   * is always present and callers never touch the raw `Field` union. Return its output, or
+   * `undefined` to drop it.
+   */
+  leaf(field: LeafField, cursor: Cursor): Out | undefined;
+  /**
+   * Assemble a container from its children's outputs (called bottom-up). Build-tree
+   * callers reconstruct here; collectors return `undefined`. Return `undefined` to drop
+   * the container from its parent (e.g. an empty object after filtering).
+   */
+  combine(container: ContainerInfo, children: ChildOutput<Out>[], cursor: Cursor): Out | undefined;
+}

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/walkFields.test.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/walkFields.test.ts
@@ -1,0 +1,111 @@
+import type { Field } from "payload";
+import { describe, expect, it } from "vitest";
+
+import { resolveBlockFields } from "./kernel";
+import type { FieldWalker, LeafField } from "./types";
+import { walkFields } from "./walkFields";
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null && !Array.isArray(v);
+
+const isLocalizedText = (f: LeafField): boolean => (f.type === "text" || f.type === "textarea" || f.type === "richText") && f.localized === true;
+
+describe("walkFields", () => {
+  it("build-tree shape (filter): keeps localized leaves, rebuilds structure, drops empties", () => {
+    type Cursor = { data: Record<string, unknown> };
+
+    const filterWalker: FieldWalker<Cursor, unknown> = {
+      enterObject(field, cursor) {
+        const v = cursor.data[field.name];
+        return isRecord(v) ? { data: v } : "skip";
+      },
+      enterList(field, cursor) {
+        const v = cursor.data[field.name];
+        if (!Array.isArray(v)) return "skip";
+        return v.flatMap((item, i) => {
+          if (!isRecord(item)) return [];
+          const fields = field.type === "blocks" ? resolveBlockFields(field, item) : field.fields;
+          return fields ? [{ cursor: { data: item }, fields, key: i }] : [];
+        });
+      },
+      leaf(field, cursor) {
+        return isLocalizedText(field) ? cursor.data[field.name] : undefined;
+      },
+      combine(container, children) {
+        if (children.length === 0) return undefined; // drop empty containers
+        if (container.kind === "list") return children.map((c) => c.out);
+        const obj: Record<string, unknown> = {};
+        for (const c of children) obj[c.key] = c.out;
+        return obj;
+      },
+    };
+
+    const schema = [
+      {
+        type: "group",
+        name: "meta",
+        fields: [
+          { name: "title", type: "text", localized: true },
+          { name: "internal", type: "text" },
+        ],
+      },
+      { name: "standalone", type: "text", localized: true },
+    ] as unknown as Field[];
+
+    const data = { meta: { title: "Hi", internal: "x" }, standalone: "S" };
+
+    expect(walkFields(schema, { data }, filterWalker)).toEqual({
+      meta: { title: "Hi" },
+      standalone: "S",
+    });
+  });
+
+  it("collect shape: flat list with path + indices, combine is a no-op (covers arrays + skip)", () => {
+    type Cursor = { data: Record<string, unknown>; path: string[] };
+
+    const collected: Array<{ path: string; value: unknown }> = [];
+    const collectWalker: FieldWalker<Cursor, void> = {
+      enterObject(field, cursor) {
+        const v = cursor.data[field.name];
+        return isRecord(v) ? { data: v, path: [...cursor.path, field.name] } : "skip";
+      },
+      enterList(field, cursor) {
+        const v = cursor.data[field.name];
+        if (!Array.isArray(v)) return "skip";
+        return v.flatMap((item, i) => {
+          if (!isRecord(item)) return [];
+          const fields = field.type === "blocks" ? resolveBlockFields(field, item) : field.fields;
+          return fields ? [{ cursor: { data: item, path: [...cursor.path, field.name, String(i)] }, fields, key: i }] : [];
+        });
+      },
+      leaf(field, cursor) {
+        if (isLocalizedText(field)) {
+          collected.push({ path: [...cursor.path, field.name].join("."), value: cursor.data[field.name] });
+        }
+        return undefined;
+      },
+      combine() {
+        return undefined;
+      },
+    };
+
+    const schema = [
+      {
+        type: "array",
+        name: "items",
+        fields: [
+          { name: "label", type: "text", localized: true },
+          { name: "note", type: "text" },
+        ],
+      },
+    ] as unknown as Field[];
+
+    const data = { items: [{ label: "a", note: "x" }, { label: "b" }] };
+
+    walkFields(schema, { data, path: [] }, collectWalker);
+
+    expect(collected).toEqual([
+      { path: "items.0.label", value: "a" },
+      { path: "items.1.label", value: "b" },
+    ]);
+  });
+});

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/walkFields.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/walkFields.ts
@@ -1,0 +1,153 @@
+import type { ArrayField, BlocksField, Field, NamedGroupField, NamedTab } from "payload";
+
+import { classifyField, tabScopes } from "./kernel";
+import type { ChildOutput, FieldWalker } from "./types";
+
+/**
+ * Internal engine backing {@link walkFields}. Methods return `true` to mean "stop requested —
+ * unwind and halt the entire walk". A class is used (over nested functions) because the three
+ * steps are mutually recursive; methods can reference each other without use-before-define
+ * ordering.
+ *
+ * @internal
+ */
+class FieldTreeWalker<Cursor extends object, Out> {
+  private readonly walker: FieldWalker<Cursor, Out>;
+
+  constructor(walker: FieldWalker<Cursor, Out>) {
+    this.walker = walker;
+  }
+
+  run(fields: Field[], root: Cursor): Out | undefined {
+    const out: ChildOutput<Out>[] = [];
+    if (this.level(fields, root, out)) return undefined;
+    return this.walker.combine({ kind: "root", field: null }, out, root);
+  }
+
+  /** Walk one data level (root, a group/tab body, or a list element), pushing child outputs into `out`. */
+  private level(fields: Field[], cursor: Cursor, out: ChildOutput<Out>[]): boolean {
+    for (const field of fields) {
+      const structure = classifyField(field);
+      switch (structure.kind) {
+        case "presentational":
+          break;
+        case "transparent":
+          if (this.level(structure.fields, cursor, out)) return true;
+          break;
+        case "tabs":
+          for (const scope of tabScopes(structure.field)) {
+            if (scope.named) {
+              if (this.object(scope.tab, scope.tab.name, scope.tab.fields, cursor, out)) return true;
+            } else if (this.level(scope.fields, cursor, out)) {
+              return true;
+            }
+          }
+          break;
+        case "group":
+          if (this.object(structure.field, structure.name, structure.fields, cursor, out)) return true;
+          break;
+        case "array":
+        case "blocks":
+          if (this.list(structure.field, structure.name, cursor, out)) return true;
+          break;
+        case "leaf": {
+          const leafOut = this.walker.leaf(structure.field, cursor);
+          if (leafOut !== undefined) out.push({ key: structure.name, out: leafOut });
+          break;
+        }
+        default: {
+          // Exhaustiveness guard: if a new FieldStructure kind is added, this errors at compile time.
+          const exhaustive: never = structure;
+          throw new Error(`unhandled field structure: ${String(exhaustive)}`);
+        }
+      }
+    }
+    return false;
+  }
+
+  /** Descend a single-object boundary (named group or named tab) and assemble it. */
+  private object(field: NamedGroupField | NamedTab, key: string, childFields: Field[], cursor: Cursor, out: ChildOutput<Out>[]): boolean {
+    const result = this.walker.enterObject(field, cursor);
+    if (result === "stop") return true;
+    if (result === "skip") return false;
+
+    const childOut: ChildOutput<Out>[] = [];
+    if (this.level(childFields, result, childOut)) return true;
+
+    const assembled = this.walker.combine({ kind: "object", field, key }, childOut, result);
+    if (assembled !== undefined) out.push({ key, out: assembled });
+    return false;
+  }
+
+  /** Descend an array/blocks boundary, assembling each element then the list itself. */
+  private list(field: ArrayField | BlocksField, key: string, cursor: Cursor, out: ChildOutput<Out>[]): boolean {
+    const result = this.walker.enterList(field, cursor);
+    if (result === "stop") return true;
+    if (result === "skip") return false;
+
+    const elements: ChildOutput<Out>[] = [];
+    for (const child of result) {
+      const childOut: ChildOutput<Out>[] = [];
+      if (this.level(child.fields, child.cursor, childOut)) return true;
+
+      const elementOut = this.walker.combine({ kind: "element", field, key: child.key }, childOut, child.cursor);
+      if (elementOut !== undefined) elements.push({ key: child.key, out: elementOut });
+    }
+
+    const listOut = this.walker.combine({ kind: "list", field, key }, elements, cursor);
+    if (listOut !== undefined) out.push({ key, out: listOut });
+    return false;
+  }
+}
+
+/**
+ * Depth-first walk of a Payload field **schema**, driving a caller-supplied
+ * {@link FieldWalker}. The single traversal engine this package's data operations build on
+ * (filtering, reconciling, collecting, navigating).
+ *
+ * The engine owns structural dispatch (via {@link classifyField} / {@link tabScopes}) and the
+ * recursion; the caller owns the **data** through the opaque `Cursor` and decides what to
+ * produce. The engine never reads the cursor — so the caller can thread one, two, or more
+ * parallel data trees (plus a path) inside it. Containers are assembled bottom-up via
+ * `combine`, after their children.
+ *
+ * @template Cursor - The caller's data position threaded through the walk (e.g. the current
+ * data object, a `{ source, target }` pair, plus a path). Constrained to `object` so a cursor
+ * can never collide with a {@link WalkSignal} string (`'skip'`/`'stop'`).
+ * @template Out - What the walker produces per node and assembles per container (e.g. a
+ * rebuilt data subtree, or `void` for a collect-only walk).
+ *
+ * @param fields - The schema to walk (a collection/global/group `fields` array).
+ * @param root - The initial `Cursor` paired with the top-level `fields`.
+ * @param walker - The behavior to drive: `enterObject` / `enterList` derive child cursors (or
+ * return a {@link WalkSignal} to `'skip'` a branch or `'stop'` the whole walk), `leaf`
+ * produces a value per data-affecting leaf, and `combine` assembles each container from its
+ * children.
+ * @returns The root `combine` output. `undefined` if the walk was halted by `'stop'` before the
+ * root assembled, OR if the root `combine` itself returned `undefined` (e.g. a collect-only
+ * walker). To distinguish "stopped" from "empty result", track it via the cursor, not this value.
+ *
+ * @example
+ * Keep only localized leaves and rebuild the data tree (a "filter" walk):
+ * ```ts
+ * type Cursor = { data: Record<string, unknown> };
+ *
+ * const filtered = walkFields<Cursor, unknown>(schema, { data }, {
+ *   enterObject: (field, c) =>
+ *     isRecord(c.data[field.name]) ? { data: c.data[field.name] } : "skip",
+ *   enterList: (field, c) => toItemCursors(field, c), // one ChildCursor per element
+ *   leaf: (field, c) => (field.localized ? c.data[field.name] : undefined),
+ *   combine: (container, children) => {
+ *     if (children.length === 0) return undefined; // drop empty containers
+ *     if (container.kind === "list") return children.map((ch) => ch.out);
+ *     return Object.fromEntries(children.map((ch) => [ch.key, ch.out]));
+ *   },
+ * });
+ * ```
+ *
+ * @see {@link FieldWalker} for the full visitor contract and the caller shapes it subsumes.
+ * @public
+ */
+export function walkFields<Cursor extends object, Out>(fields: Field[], root: Cursor, walker: FieldWalker<Cursor, Out>): Out | undefined {
+  return new FieldTreeWalker(walker).run(fields, root);
+}

--- a/packages/payload-plugin-translator/src/server/shared/utils/filterLocalizedFields.test.ts
+++ b/packages/payload-plugin-translator/src/server/shared/utils/filterLocalizedFields.test.ts
@@ -1,387 +1,387 @@
-import type { Field } from 'payload'
-import { describe, expect, it } from 'vitest'
-import { filterLocalizedFields } from './filterLocalizedFields'
+import type { Field } from "payload";
+import { describe, expect, it } from "vitest";
+import { filterLocalizedFields } from "./filterLocalizedFields";
 
-describe('filterLocalizedFields', () => {
-  describe('simple fields', () => {
-    it('should keep localized text field', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const data = { title: 'Hello', other: 'World' }
+describe("filterLocalizedFields", () => {
+  describe("simple fields", () => {
+    it("should keep localized text field", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const data = { title: "Hello", other: "World" };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({ title: 'Hello' })
-    })
+      expect(result).toEqual({ title: "Hello" });
+    });
 
-    it('should filter out non-localized text field', () => {
-      const schema: Field[] = [{ name: 'slug', type: 'text' }]
-      const data = { slug: 'hello-world' }
+    it("should filter out non-localized text field", () => {
+      const schema: Field[] = [{ name: "slug", type: "text" }];
+      const data = { slug: "hello-world" };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
+      expect(result).toEqual({});
+    });
 
-    it('should handle mixed localized and non-localized fields', () => {
+    it("should handle mixed localized and non-localized fields", () => {
       const schema: Field[] = [
-        { name: 'title', type: 'text', localized: true },
-        { name: 'slug', type: 'text' },
-        { name: 'description', type: 'textarea', localized: true },
-      ]
-      const data = { title: 'Hello', slug: 'hello', description: 'World' }
+        { name: "title", type: "text", localized: true },
+        { name: "slug", type: "text" },
+        { name: "description", type: "textarea", localized: true },
+      ];
+      const data = { title: "Hello", slug: "hello", description: "World" };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({ title: 'Hello', description: 'World' })
-    })
+      expect(result).toEqual({ title: "Hello", description: "World" });
+    });
 
-    it('should skip undefined values', () => {
-      const schema: Field[] = [{ name: 'title', type: 'text', localized: true }]
-      const data = {}
+    it("should skip undefined values", () => {
+      const schema: Field[] = [{ name: "title", type: "text", localized: true }];
+      const data = {};
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
-  })
+      expect(result).toEqual({});
+    });
+  });
 
-  describe('group fields', () => {
-    it('should recursively filter group with localized nested field', () => {
+  describe("group fields", () => {
+    it("should recursively filter group with localized nested field", () => {
       const schema: Field[] = [
         {
-          name: 'seo',
-          type: 'group',
+          name: "seo",
+          type: "group",
           fields: [
-            { name: 'title', type: 'text', localized: true },
-            { name: 'canonical', type: 'text' },
+            { name: "title", type: "text", localized: true },
+            { name: "canonical", type: "text" },
           ],
         },
-      ]
-      const data = { seo: { title: 'SEO Title', canonical: '/page' } }
+      ];
+      const data = { seo: { title: "SEO Title", canonical: "/page" } };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({ seo: { title: 'SEO Title' } })
-    })
+      expect(result).toEqual({ seo: { title: "SEO Title" } });
+    });
 
-    it('should exclude group if no localized fields inside', () => {
+    it("should exclude group if no localized fields inside", () => {
       const schema: Field[] = [
         {
-          name: 'settings',
-          type: 'group',
-          fields: [{ name: 'enabled', type: 'checkbox' }],
+          name: "settings",
+          type: "group",
+          fields: [{ name: "enabled", type: "checkbox" }],
         },
-      ]
-      const data = { settings: { enabled: true } }
+      ];
+      const data = { settings: { enabled: true } };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
-  })
+      expect(result).toEqual({});
+    });
+  });
 
-  describe('array fields', () => {
-    it('should recursively filter array items', () => {
+  describe("array fields", () => {
+    it("should recursively filter array items", () => {
       const schema: Field[] = [
         {
-          name: 'items',
-          type: 'array',
+          name: "items",
+          type: "array",
           fields: [
-            { name: 'text', type: 'text', localized: true },
-            { name: 'order', type: 'number' },
+            { name: "text", type: "text", localized: true },
+            { name: "order", type: "number" },
           ],
         },
-      ]
+      ];
       const data = {
         items: [
-          { id: '1', text: 'First', order: 1 },
-          { id: '2', text: 'Second', order: 2 },
+          { id: "1", text: "First", order: 1 },
+          { id: "2", text: "Second", order: 2 },
         ],
-      }
+      };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
       expect(result).toEqual({
         items: [
-          { id: '1', text: 'First' },
-          { id: '2', text: 'Second' },
+          { id: "1", text: "First" },
+          { id: "2", text: "Second" },
         ],
-      })
-    })
+      });
+    });
 
-    it('should exclude array if no localized fields inside items', () => {
+    it("should exclude array if no localized fields inside items", () => {
       const schema: Field[] = [
         {
-          name: 'tags',
-          type: 'array',
-          fields: [{ name: 'name', type: 'text' }],
+          name: "tags",
+          type: "array",
+          fields: [{ name: "name", type: "text" }],
         },
-      ]
-      const data = { tags: [{ id: '1', name: 'tag1' }] }
+      ];
+      const data = { tags: [{ id: "1", name: "tag1" }] };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
-  })
+      expect(result).toEqual({});
+    });
+  });
 
-  describe('blocks fields', () => {
-    it('should recursively filter blocks with blockType and id preserved', () => {
+  describe("blocks fields", () => {
+    it("should recursively filter blocks with blockType and id preserved", () => {
       const schema: Field[] = [
         {
-          name: 'content',
-          type: 'blocks',
+          name: "content",
+          type: "blocks",
           blocks: [
             {
-              slug: 'text',
+              slug: "text",
               fields: [
-                { name: 'body', type: 'richText', localized: true },
-                { name: 'alignment', type: 'select', options: ['left', 'center'] },
+                { name: "body", type: "richText", localized: true },
+                { name: "alignment", type: "select", options: ["left", "center"] },
               ],
             },
           ],
         },
-      ]
+      ];
       const data = {
-        content: [{ id: 'block1', blockType: 'text', body: { root: {} }, alignment: 'center' }],
-      }
+        content: [{ id: "block1", blockType: "text", body: { root: {} }, alignment: "center" }],
+      };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
       expect(result).toEqual({
-        content: [{ id: 'block1', blockType: 'text', body: { root: {} } }],
-      })
-    })
+        content: [{ id: "block1", blockType: "text", body: { root: {} } }],
+      });
+    });
 
-    it('should handle multiple block types', () => {
+    it("should handle multiple block types", () => {
       const schema: Field[] = [
         {
-          name: 'content',
-          type: 'blocks',
+          name: "content",
+          type: "blocks",
           blocks: [
             {
-              slug: 'heading',
-              fields: [{ name: 'title', type: 'text', localized: true }],
+              slug: "heading",
+              fields: [{ name: "title", type: "text", localized: true }],
             },
             {
-              slug: 'image',
-              fields: [{ name: 'alt', type: 'text', localized: true }],
+              slug: "image",
+              fields: [{ name: "alt", type: "text", localized: true }],
             },
           ],
         },
-      ]
+      ];
       const data = {
         content: [
-          { id: '1', blockType: 'heading', title: 'Hello' },
-          { id: '2', blockType: 'image', alt: 'Image alt' },
+          { id: "1", blockType: "heading", title: "Hello" },
+          { id: "2", blockType: "image", alt: "Image alt" },
         ],
-      }
+      };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
       expect(result).toEqual({
         content: [
-          { id: '1', blockType: 'heading', title: 'Hello' },
-          { id: '2', blockType: 'image', alt: 'Image alt' },
+          { id: "1", blockType: "heading", title: "Hello" },
+          { id: "2", blockType: "image", alt: "Image alt" },
         ],
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('tabs fields', () => {
-    it('should process tabs as flat fields', () => {
+  describe("tabs fields", () => {
+    it("should process tabs as flat fields", () => {
       const schema: Field[] = [
         {
-          type: 'tabs',
+          type: "tabs",
           tabs: [
             {
-              label: 'Content',
-              fields: [{ name: 'title', type: 'text', localized: true }],
+              label: "Content",
+              fields: [{ name: "title", type: "text", localized: true }],
             },
             {
-              label: 'Settings',
-              fields: [{ name: 'slug', type: 'text' }],
+              label: "Settings",
+              fields: [{ name: "slug", type: "text" }],
             },
           ],
         },
-      ]
-      const data = { title: 'Hello', slug: 'hello' }
+      ];
+      const data = { title: "Hello", slug: "hello" };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({ title: 'Hello' })
-    })
-  })
+      expect(result).toEqual({ title: "Hello" });
+    });
+  });
 
-  describe('row/collapsible fields', () => {
-    it('should process row fields as flat', () => {
+  describe("row/collapsible fields", () => {
+    it("should process row fields as flat", () => {
       const schema: Field[] = [
         {
-          type: 'row',
+          type: "row",
           fields: [
-            { name: 'firstName', type: 'text', localized: true },
-            { name: 'lastName', type: 'text', localized: true },
+            { name: "firstName", type: "text", localized: true },
+            { name: "lastName", type: "text", localized: true },
           ],
         },
-      ]
-      const data = { firstName: 'John', lastName: 'Doe' }
+      ];
+      const data = { firstName: "John", lastName: "Doe" };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({ firstName: 'John', lastName: 'Doe' })
-    })
+      expect(result).toEqual({ firstName: "John", lastName: "Doe" });
+    });
 
-    it('should process collapsible fields', () => {
+    it("should process collapsible fields", () => {
       const schema: Field[] = [
         {
-          type: 'collapsible',
-          label: 'Advanced',
-          fields: [{ name: 'meta', type: 'text', localized: true }],
+          type: "collapsible",
+          label: "Advanced",
+          fields: [{ name: "meta", type: "text", localized: true }],
         },
-      ]
-      const data = { meta: 'Some meta' }
+      ];
+      const data = { meta: "Some meta" };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({ meta: 'Some meta' })
-    })
-  })
+      expect(result).toEqual({ meta: "Some meta" });
+    });
+  });
 
-  describe('non-translatable fields', () => {
-    it('should filter out localized number field', () => {
-      const schema: Field[] = [{ name: 'count', type: 'number', localized: true }]
-      const data = { count: 42 }
+  describe("non-translatable fields", () => {
+    it("should filter out localized number field", () => {
+      const schema: Field[] = [{ name: "count", type: "number", localized: true }];
+      const data = { count: 42 };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
+      expect(result).toEqual({});
+    });
 
-    it('should filter out localized checkbox field', () => {
-      const schema: Field[] = [{ name: 'enabled', type: 'checkbox', localized: true }]
-      const data = { enabled: true }
+    it("should filter out localized checkbox field", () => {
+      const schema: Field[] = [{ name: "enabled", type: "checkbox", localized: true }];
+      const data = { enabled: true };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
+      expect(result).toEqual({});
+    });
 
-    it('should filter out localized select field', () => {
-      const schema: Field[] = [{ name: 'status', type: 'select', options: ['draft', 'published'], localized: true }]
-      const data = { status: 'draft' }
+    it("should filter out localized select field", () => {
+      const schema: Field[] = [{ name: "status", type: "select", options: ["draft", "published"], localized: true }];
+      const data = { status: "draft" };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
+      expect(result).toEqual({});
+    });
 
-    it('should filter out localized json field', () => {
-      const schema: Field[] = [{ name: 'metadata', type: 'json', localized: true }]
-      const data = { metadata: { key: 'value' } }
+    it("should filter out localized json field", () => {
+      const schema: Field[] = [{ name: "metadata", type: "json", localized: true }];
+      const data = { metadata: { key: "value" } };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
+      expect(result).toEqual({});
+    });
 
-    it('should filter out localized code field', () => {
-      const schema: Field[] = [{ name: 'snippet', type: 'code', localized: true }]
-      const data = { snippet: 'const x = 1' }
+    it("should filter out localized code field", () => {
+      const schema: Field[] = [{ name: "snippet", type: "code", localized: true }];
+      const data = { snippet: "const x = 1" };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
+      expect(result).toEqual({});
+    });
 
-    it('should filter out localized point field', () => {
-      const schema: Field[] = [{ name: 'location', type: 'point', localized: true }]
-      const data = { location: [0, 0] }
+    it("should filter out localized point field", () => {
+      const schema: Field[] = [{ name: "location", type: "point", localized: true }];
+      const data = { location: [0, 0] };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
+      expect(result).toEqual({});
+    });
 
-    it('should filter out localized relationship field', () => {
-      const schema: Field[] = [{ name: 'author', type: 'relationship', relationTo: 'users', localized: true }]
-      const data = { author: '123' }
+    it("should filter out localized relationship field", () => {
+      const schema: Field[] = [{ name: "author", type: "relationship", relationTo: "users", localized: true }];
+      const data = { author: "123" };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
+      expect(result).toEqual({});
+    });
 
-    it('should filter out localized upload field', () => {
-      const schema: Field[] = [{ name: 'image', type: 'upload', relationTo: 'media', localized: true }]
-      const data = { image: '456' }
+    it("should filter out localized upload field", () => {
+      const schema: Field[] = [{ name: "image", type: "upload", relationTo: "media", localized: true }];
+      const data = { image: "456" };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
+      expect(result).toEqual({});
+    });
 
-    it('should filter out localized date field', () => {
-      const schema: Field[] = [{ name: 'publishedAt', type: 'date', localized: true }]
-      const data = { publishedAt: '2024-01-01' }
+    it("should filter out localized date field", () => {
+      const schema: Field[] = [{ name: "publishedAt", type: "date", localized: true }];
+      const data = { publishedAt: "2024-01-01" };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
+      expect(result).toEqual({});
+    });
 
-    it('should filter out localized email field', () => {
-      const schema: Field[] = [{ name: 'contact', type: 'email', localized: true }]
-      const data = { contact: 'test@example.com' }
+    it("should filter out localized email field", () => {
+      const schema: Field[] = [{ name: "contact", type: "email", localized: true }];
+      const data = { contact: "test@example.com" };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
-      expect(result).toEqual({})
-    })
+      expect(result).toEqual({});
+    });
 
-    it('should keep translatable fields while filtering non-translatable', () => {
+    it("should keep translatable fields while filtering non-translatable", () => {
       const schema: Field[] = [
-        { name: 'title', type: 'text', localized: true },
-        { name: 'count', type: 'number', localized: true },
-        { name: 'description', type: 'textarea', localized: true },
-        { name: 'status', type: 'select', options: ['a', 'b'], localized: true },
-        { name: 'body', type: 'richText', localized: true },
-      ]
+        { name: "title", type: "text", localized: true },
+        { name: "count", type: "number", localized: true },
+        { name: "description", type: "textarea", localized: true },
+        { name: "status", type: "select", options: ["a", "b"], localized: true },
+        { name: "body", type: "richText", localized: true },
+      ];
       const data = {
-        title: 'Hello',
+        title: "Hello",
         count: 42,
-        description: 'World',
-        status: 'a',
+        description: "World",
+        status: "a",
         body: { root: {} },
-      }
+      };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
       expect(result).toEqual({
-        title: 'Hello',
-        description: 'World',
+        title: "Hello",
+        description: "World",
         body: { root: {} },
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('nested structures', () => {
-    it('should handle deeply nested localized fields', () => {
+  describe("nested structures", () => {
+    it("should handle deeply nested localized fields", () => {
       const schema: Field[] = [
         {
-          name: 'sections',
-          type: 'array',
+          name: "sections",
+          type: "array",
           fields: [
             {
-              name: 'content',
-              type: 'blocks',
+              name: "content",
+              type: "blocks",
               blocks: [
                 {
-                  slug: 'text',
+                  slug: "text",
                   fields: [
                     {
-                      name: 'wrapper',
-                      type: 'group',
-                      fields: [{ name: 'body', type: 'richText', localized: true }],
+                      name: "wrapper",
+                      type: "group",
+                      fields: [{ name: "body", type: "richText", localized: true }],
                     },
                   ],
                 },
@@ -389,26 +389,70 @@ describe('filterLocalizedFields', () => {
             },
           ],
         },
-      ]
+      ];
       const data = {
         sections: [
           {
-            id: 's1',
-            content: [{ id: 'b1', blockType: 'text', wrapper: { body: { root: {} } } }],
+            id: "s1",
+            content: [{ id: "b1", blockType: "text", wrapper: { body: { root: {} } } }],
           },
         ],
-      }
+      };
 
-      const result = filterLocalizedFields(schema, data)
+      const result = filterLocalizedFields(schema, data);
 
       expect(result).toEqual({
         sections: [
           {
-            id: 's1',
-            content: [{ id: 'b1', blockType: 'text', wrapper: { body: { root: {} } } }],
+            id: "s1",
+            content: [{ id: "b1", blockType: "text", wrapper: { body: { root: {} } } }],
           },
         ],
-      })
-    })
-  })
-})
+      });
+    });
+  });
+
+  describe("edge cases — empty / unknown / non-object", () => {
+    it("drops a blocks field whose blocks have no localized content", () => {
+      const schema: Field[] = [
+        {
+          name: "content",
+          type: "blocks",
+          blocks: [{ slug: "plain", fields: [{ name: "caption", type: "text" }] }],
+        },
+      ];
+      const data = { content: [{ id: "b1", blockType: "plain", caption: "no-translate" }] };
+
+      expect(filterLocalizedFields(schema, data)).toEqual({});
+    });
+
+    it("drops block items with an unknown blockType, keeping known ones", () => {
+      const schema: Field[] = [
+        {
+          name: "content",
+          type: "blocks",
+          blocks: [{ slug: "heading", fields: [{ name: "title", type: "text", localized: true }] }],
+        },
+      ];
+      const data = {
+        content: [
+          { id: "1", blockType: "heading", title: "Hello" },
+          { id: "2", blockType: "ghost", title: "Ignored" },
+        ],
+      };
+
+      expect(filterLocalizedFields(schema, data)).toEqual({
+        content: [{ id: "1", blockType: "heading", title: "Hello" }],
+      });
+    });
+
+    it("drops non-object items from arrays, keeping object items", () => {
+      const schema: Field[] = [{ name: "items", type: "array", fields: [{ name: "text", type: "text", localized: true }] }];
+      const data = { items: [{ id: "1", text: "A" }, "oops", 42, null] };
+
+      expect(filterLocalizedFields(schema, data)).toEqual({
+        items: [{ id: "1", text: "A" }],
+      });
+    });
+  });
+});

--- a/packages/payload-plugin-translator/tsconfig.check.json
+++ b/packages/payload-plugin-translator/tsconfig.check.json
@@ -1,0 +1,13 @@
+{
+  // Type-checking config for `check-types`. Unlike the build config (tsconfig.json,
+  // used by `build:types`), this INCLUDES test files so they are type-checked too —
+  // without that, type errors in `*.test.ts` go undetected (vitest runs via esbuild,
+  // which strips types without checking). Kept separate so the build never emits
+  // `.d.ts` for test files into `dist`.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Adds a single internal field-schema **traversal engine** that the four hand-rolled field traversals in this package will migrate onto (migration is a follow-up). Internal infrastructure — **no public API, no release**.

## What's here
- **`server/shared/field-traversal/`** — the engine:
  - `classifyField` / `tabScopes` / `resolveBlockFields` (kernel) — the one place that encodes Payload's container dispatch order (`tabs → transparent → group → array → blocks → leaf`), so every traversal switches on it instead of re-deriving the predicate chain.
  - `walkFields` (visitor engine) — owns schema dispatch + recursion; callers own the data via an opaque `Cursor` (constrained to `object`), produce per-leaf values, and assemble containers bottom-up via `combine`. One engine subsumes the filter / reconcile / collect / navigate shapes.
- **Characterization tests** locking the current behavior of `filterLocalizedFields`, `DataReconciler`, `FieldChunkCollector` **before** they migrate — including per-site edge-case asymmetries (e.g. on an unknown `blockType`: reconcile passes the item through, filter/collector drop it).
- **`tsconfig.check.json`** wires test files into `check-types` (vitest runs via esbuild, which strips types without checking — this closes that gap).
- Design doc under `docs/plans/`.

## Notes
- **Internal only** — not re-exported from `src/index.ts`, so no `@since` and **no version bump** (`chore`/`test` commits). When these are later exposed as public helpers, that commit will be `feat` + `@since` (next would be `0.6.0` off the current `0.5.0`).
- Reviewed via `/simplify` + `/iterative-review`: `ContainerInfo` is a discriminated union, `Cursor extends object` enforces the no-collision-with-`skip`/`stop` invariant, and a switch exhaustiveness guard catches future `FieldStructure` kinds at compile time. Dispatch-order disambiguation is mutation-tested.
- `check-types` (incl. tests) clean · 5 test files / 103 tests green · lint 0/0.

Commits: `32051e6` (engine), `748d3e2` (characterization tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)