### PR TITLE
chore(translator): migrate field traversals onto the walkFields engine

### DIFF
--- a/packages/payload-plugin-translator/src/server/features/translate-field/resolveFieldSubtree.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-field/resolveFieldSubtree.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import type { Field } from "payload";
+
+import { resolveFieldSubtree } from "./resolveFieldSubtree";
+
+// Minimal field configs cast to Field — enough for payload/shared predicates,
+// which key on `type` / `name` / `fields` / `tabs`.
+const f = (config: Record<string, unknown>): Field => config as unknown as Field;
+
+const schema: Field[] = [
+  f({ name: "title", type: "text", localized: true }),
+  f({ name: "count", type: "number" }),
+  f({ name: "hero", type: "group", fields: [f({ name: "heading", type: "text", localized: true })] }),
+  f({ name: "items", type: "array", fields: [f({ name: "label", type: "text", localized: true })] }),
+  f({
+    type: "tabs",
+    tabs: [
+      { name: "meta", fields: [f({ name: "slug", type: "text", localized: true })] },
+      { label: "Main", fields: [f({ name: "intro", type: "textarea", localized: true })] },
+    ],
+  }),
+  f({ type: "row", fields: [f({ name: "col", type: "text", localized: true })] }),
+  f({ name: "layout", type: "blocks", blocks: [{ slug: "hero", fields: [f({ name: "headline", type: "text", localized: true })] }] }),
+];
+
+describe("resolveFieldSubtree", () => {
+  it("resolves a top-level leaf, rooting the value under its name", () => {
+    const result = resolveFieldSubtree(schema, "title", "Hello");
+    expect(result).toEqual({
+      status: "resolved",
+      schema: [schema[0]],
+      sourceData: { title: "Hello" },
+      fieldName: "title",
+    });
+  });
+
+  it("resolves a leaf nested in a group", () => {
+    const result = resolveFieldSubtree(schema, "hero.heading", "Hi");
+    expect(result.status).toBe("resolved");
+    if (result.status === "resolved") {
+      expect(result.fieldName).toBe("heading");
+      expect(result.sourceData).toEqual({ heading: "Hi" });
+    }
+  });
+
+  it("resolves through an array, dropping the numeric index", () => {
+    const byIndex = resolveFieldSubtree(schema, "items.0.label", "A");
+    const byName = resolveFieldSubtree(schema, "items.label", "A");
+    expect(byIndex.status).toBe("resolved");
+    expect(byName).toEqual(byIndex);
+    if (byIndex.status === "resolved") expect(byIndex.fieldName).toBe("label");
+  });
+
+  it("resolves a leaf under a named tab (tab name is a segment)", () => {
+    const result = resolveFieldSubtree(schema, "meta.slug", "x");
+    expect(result.status).toBe("resolved");
+  });
+
+  it("resolves a leaf under an unnamed tab (transparent, no segment)", () => {
+    const result = resolveFieldSubtree(schema, "intro", "x");
+    expect(result.status).toBe("resolved");
+  });
+
+  it("resolves a leaf inside a presentational row (transparent)", () => {
+    const result = resolveFieldSubtree(schema, "col", "x");
+    expect(result.status).toBe("resolved");
+  });
+
+  it("returns not-found for a path that matches no field (typo)", () => {
+    expect(resolveFieldSubtree(schema, "nope", "x").status).toBe("not-found");
+    expect(resolveFieldSubtree(schema, "hero.missing", "x").status).toBe("not-found");
+    expect(resolveFieldSubtree(schema, "", "x").status).toBe("not-found");
+  });
+
+  it("returns not-translatable for a non-text leaf", () => {
+    expect(resolveFieldSubtree(schema, "count", 5).status).toBe("not-translatable");
+  });
+
+  it("returns not-translatable when the path ends at a container (named tab)", () => {
+    expect(resolveFieldSubtree(schema, "meta", {}).status).toBe("not-translatable");
+  });
+
+  it("returns inside-blocks when the path descends through a blocks field", () => {
+    expect(resolveFieldSubtree(schema, "layout.0.headline", "x").status).toBe("inside-blocks");
+  });
+
+  it("returns not-found when the path continues past a leaf", () => {
+    expect(resolveFieldSubtree(schema, "title.deeper", "x").status).toBe("not-found");
+  });
+
+  describe("path normalization", () => {
+    it("trims whitespace around segments", () => {
+      const result = resolveFieldSubtree(schema, " hero . heading ", "Hi");
+      expect(result.status).toBe("resolved");
+      if (result.status === "resolved") expect(result.fieldName).toBe("heading");
+    });
+
+    it("drops empty segments from consecutive, leading, and trailing dots", () => {
+      expect(resolveFieldSubtree(schema, "hero..heading", "Hi").status).toBe("resolved");
+      expect(resolveFieldSubtree(schema, ".title.", "Hello")).toEqual({
+        status: "resolved",
+        schema: [schema[0]],
+        sourceData: { title: "Hello" },
+        fieldName: "title",
+      });
+    });
+
+    it("returns not-found when a path normalizes to nothing (only index / only whitespace)", () => {
+      expect(resolveFieldSubtree(schema, "0", "x").status).toBe("not-found");
+      expect(resolveFieldSubtree(schema, "   ", "x").status).toBe("not-found");
+    });
+  });
+
+  it("resolves a leaf through group > array (drops the index mid-path)", () => {
+    const cell = f({ name: "cell", type: "text", localized: true });
+    const nested: Field[] = [f({ name: "sect", type: "group", fields: [f({ name: "rows", type: "array", fields: [cell] })] })];
+    const byIndex = resolveFieldSubtree(nested, "sect.rows.0.cell", "A");
+    const byName = resolveFieldSubtree(nested, "sect.rows.cell", "A");
+    expect(byName).toEqual(byIndex);
+    expect(byIndex).toEqual({
+      status: "resolved",
+      schema: [cell],
+      sourceData: { cell: "A" },
+      fieldName: "cell",
+    });
+  });
+
+  it("returns not-translatable for any container at the path end (group / array / blocks)", () => {
+    expect(resolveFieldSubtree(schema, "hero", {}).status).toBe("not-translatable"); // group
+    expect(resolveFieldSubtree(schema, "items", []).status).toBe("not-translatable"); // array
+    expect(resolveFieldSubtree(schema, "layout", []).status).toBe("not-translatable"); // blocks
+  });
+});

--- a/packages/payload-plugin-translator/src/server/features/translate-field/resolveFieldSubtree.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-field/resolveFieldSubtree.ts
@@ -1,0 +1,56 @@
+import type { Field } from "payload";
+
+import { isTranslatableField } from "../../shared";
+import { findFieldByPath } from "../../shared/field-traversal";
+
+/**
+ * Outcome of mapping a declared field path to a translatable subtree.
+ *
+ * - `resolved` — the path lands on a translatable leaf; `schema` + `sourceData`
+ *   are ready for `translateContent`, and `fieldName` is the key to unwrap the result.
+ * - `not-found` — the path resolves to no field at all (a typo) → caller returns 400.
+ * - `not-translatable` — resolves to a field that isn't a text-like leaf → caller no-ops.
+ * - `inside-blocks` — the path descends through a polymorphic `blocks` field, which
+ *   can't be resolved from the path alone (the blockType lives in the data) → caller no-ops.
+ */
+export type FieldSubtreeResolution =
+  | { status: "resolved"; schema: Field[]; sourceData: Record<string, unknown>; fieldName: string }
+  | { status: "not-found" }
+  | { status: "not-translatable" }
+  | { status: "inside-blocks" };
+
+const isIndexSegment = (segment: string): boolean => /^\d+$/u.test(segment);
+
+/**
+ * Map a declared `fieldPath` to the `{ schema, sourceData }` pair `translateContent` expects.
+ * Walks the schema by field name (via the shared {@link findFieldByPath}), dropping array indices
+ * (a field's config is shared across array items). Descends transparently through presentational
+ * containers (row, collapsible, unnamed tabs) and through named group/array/tab containers. A path
+ * that descends through a `blocks` field returns `inside-blocks`.
+ */
+export function resolveFieldSubtree(rootFields: Field[], fieldPath: string, value: unknown): FieldSubtreeResolution {
+  const segments = fieldPath
+    .split(".")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0 && !isIndexSegment(segment));
+  if (segments.length === 0) return { status: "not-found" };
+
+  const result = findFieldByPath(rootFields, segments);
+  switch (result.status) {
+    case "leaf":
+      return isTranslatableField(result.field)
+        ? {
+            status: "resolved",
+            schema: [result.field],
+            sourceData: { [result.field.name]: value },
+            fieldName: result.field.name,
+          }
+        : { status: "not-translatable" };
+    case "container":
+      return { status: "not-translatable" };
+    case "inside-blocks":
+      return { status: "inside-blocks" };
+    case "not-found":
+      return { status: "not-found" };
+  }
+}

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/data-reconciler/DataReconciler.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/data-reconciler/DataReconciler.test.ts
@@ -363,4 +363,18 @@ describe("DataReconciler", () => {
       });
     });
   });
+
+  describe("malformed source", () => {
+    it("drops a group field whose source value is not an object", () => {
+      const schema: Field[] = [
+        { name: "meta", type: "group", fields: [{ name: "title", type: "text", localized: true }] },
+        { name: "keep", type: "text", localized: true },
+      ];
+      const sourceData = { meta: null, keep: "K" };
+
+      const reconciler = new DataReconciler(schema);
+      // non-object source for a group → the group is skipped entirely
+      expect(reconciler.reconcile(sourceData, {})).toEqual({ keep: "K" });
+    });
+  });
 });

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/data-reconciler/DataReconciler.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/data-reconciler/DataReconciler.ts
@@ -1,112 +1,91 @@
-import type { Field } from 'payload'
-import { fieldAffectsData, fieldIsArrayType, fieldIsBlockType, fieldIsGroupType, tabHasName } from 'payload/shared'
+import type { Field } from "payload";
 
-import { hasFields, isBlockItem, isTabsField, isEmpty, isObject } from '../../../../shared'
+import { isEmpty, isObject } from "../../../../shared";
+import type { ChildCursor, FieldWalker } from "../../../../shared/field-traversal";
+import { resolveBlockFields, walkFields } from "../../../../shared/field-traversal";
+
+/** Data position for the reconcile walk: the source + target objects at the current level. */
+type Cursor = { source: Record<string, unknown>; target: Record<string, unknown> };
+
+const asObject = (value: unknown): Record<string, unknown> => (isObject(value) ? value : {});
 
 /**
- * Deep merges source and target data with target priority.
- * Creates full document shape needed for Payload validation.
- *
- * Logic:
- * - If targetValue exists and is not empty → use targetValue
- * - Otherwise → use sourceValue
+ * Reconcile walker: produces the full document shape from source + target, with target
+ * priority (source fills empty target slots). Iteration is driven by `source`; a field with
+ * no source value is dropped, `id` is stripped from array/block elements (Postgres rejects it
+ * on update), `blockType` is preserved, and non-object array items / unknown blocks pass
+ * through unchanged.
+ */
+const reconcileWalker: FieldWalker<Cursor, unknown> = {
+  enterObject(field, cursor) {
+    const sourceValue = cursor.source[field.name];
+    if (!isObject(sourceValue)) return "skip"; // undefined / non-object source → drop the field
+    return { source: sourceValue, target: asObject(cursor.target[field.name]) };
+  },
+
+  enterList(field, cursor) {
+    const sourceValue = cursor.source[field.name];
+    if (!Array.isArray(sourceValue)) return "skip";
+    const targetValue = cursor.target[field.name];
+    const targetArr: unknown[] = Array.isArray(targetValue) ? targetValue : [];
+
+    const children: ChildCursor<Cursor>[] = [];
+    sourceValue.forEach((item, index) => {
+      if (!isObject(item)) return; // non-object element → passthrough (rebuilt in combine)
+      const fields = field.type === "blocks" ? resolveBlockFields(field, item) : field.fields;
+      if (!fields) return; // unknown blockType → passthrough
+      children.push({ cursor: { source: item, target: asObject(targetArr[index]) }, fields, key: index });
+    });
+    return children;
+  },
+
+  leaf(field, cursor) {
+    const sourceValue = cursor.source[field.name];
+    if (sourceValue === undefined) return undefined; // no source value → field dropped
+    const targetValue = cursor.target[field.name];
+    return isEmpty(targetValue) ? sourceValue : targetValue; // target priority, fallback to source
+  },
+
+  combine(container, children, cursor) {
+    if (container.kind === "list") {
+      // Rebuild the full array: reconciled objects where present (by index), raw source items otherwise.
+      const sourceArr = (cursor.source[container.key] ?? []) as unknown[];
+      const byIndex = new Map(children.map((child) => [child.key, child.out]));
+      return sourceArr.map((item, index) => (byIndex.has(index) ? byIndex.get(index) : item));
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const child of children) result[child.key] = child.out;
+    // Block elements keep their blockType; id is intentionally stripped (Postgres rejects it on update).
+    if (container.kind === "element" && container.field.type === "blocks") {
+      result.blockType = cursor.source.blockType;
+    }
+    return result;
+  },
+};
+
+/**
+ * Deep-merges source and target data with target priority, producing the full document shape
+ * Payload validation needs. Built on the shared {@link walkFields} engine.
  *
  * Stage 1 of the translation pipeline.
  */
 export class DataReconciler {
-  constructor(private readonly schema: Field[]) {}
+  private readonly schema: Field[];
+
+  constructor(schema: Field[]) {
+    this.schema = schema;
+  }
 
   /**
    * Reconciles source and target data into a complete document shape.
-   * The result contains all fields needed for Payload validation.
    *
    * @param sourceData - Source locale document data
    * @param targetData - Target locale document data (may be empty/partial)
    * @returns Complete document shape with reconciled field values
    */
   reconcile(sourceData: Record<string, unknown>, targetData: Record<string, unknown>): Record<string, unknown> {
-    return this.reconcileFields(this.schema, sourceData, targetData ?? {})
-  }
-
-  private reconcileFields(
-    fields: Field[],
-    source: Record<string, unknown>,
-    target: Record<string, unknown>,
-  ): Record<string, unknown> {
-    const result: Record<string, unknown> = {}
-
-    for (const field of fields) {
-      if (isTabsField(field)) {
-        for (const tab of field.tabs) {
-          if (hasFields(tab)) {
-            if (tabHasName(tab)) {
-              const tabSource = source[tab.name]
-              const tabTarget = target[tab.name]
-              if (isObject(tabSource)) {
-                result[tab.name] = this.reconcileFields(tab.fields, tabSource, isObject(tabTarget) ? tabTarget : {})
-              }
-            } else {
-              Object.assign(result, this.reconcileFields(tab.fields, source, target))
-            }
-          }
-        }
-        continue
-      }
-
-      if (!fieldAffectsData(field)) {
-        if (hasFields(field)) Object.assign(result, this.reconcileFields(field.fields, source, target))
-        continue
-      }
-
-      const sourceValue = source[field.name]
-      const targetValue = target[field.name]
-
-      // Skip undefined source values
-      if (sourceValue === undefined) continue
-
-      // Group - recursively reconcile
-      if (fieldIsGroupType(field) && isObject(sourceValue)) {
-        const targetGroup = isObject(targetValue) ? targetValue : {}
-        result[field.name] = this.reconcileFields(field.fields, sourceValue, targetGroup)
-        continue
-      }
-
-      // Array - recursively reconcile each item (without id - Postgres rejects it)
-      if (fieldIsArrayType(field) && Array.isArray(sourceValue)) {
-        const targetArray = Array.isArray(targetValue) ? targetValue : []
-        result[field.name] = sourceValue.map((sourceItem, index) => {
-          if (isObject(sourceItem)) {
-            const targetItem = isObject(targetArray[index]) ? targetArray[index] : {}
-            return this.reconcileFields(field.fields, sourceItem, targetItem)
-          }
-          return sourceItem
-        })
-        continue
-      }
-
-      // Blocks - recursively reconcile each block (without id - Postgres rejects it)
-      if (fieldIsBlockType(field) && Array.isArray(sourceValue)) {
-        const targetArray = Array.isArray(targetValue) ? targetValue : []
-        result[field.name] = sourceValue.map((sourceItem, index) => {
-          if (isBlockItem(sourceItem)) {
-            const block = field.blocks.find((b) => b.slug === sourceItem.blockType)
-            if (block) {
-              const targetItem = isObject(targetArray[index]) ? targetArray[index] : {}
-              return {
-                ...this.reconcileFields(block.fields, sourceItem, targetItem),
-                blockType: sourceItem.blockType,
-              }
-            }
-          }
-          return sourceItem
-        })
-        continue
-      }
-
-      // Deep merge: target priority, fallback to source
-      result[field.name] = isEmpty(targetValue) ? sourceValue : targetValue
-    }
-
-    return result
+    const root: Cursor = { source: sourceData, target: targetData ?? {} };
+    return (walkFields(this.schema, root, reconcileWalker) as Record<string, unknown> | undefined) ?? {};
   }
 }

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/field-collector/FieldChunkCollector.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/field-collector/FieldChunkCollector.test.ts
@@ -880,4 +880,20 @@ describe("FieldChunkCollector", () => {
       expect(chunks[0].path).toEqual(["items", "1", "label"]);
     });
   });
+
+  describe("excluded fields", () => {
+    it("skips fields excluded via custom.translateKit.exclude", () => {
+      const schema: Field[] = [
+        { name: "title", type: "text", localized: true, custom: { translateKit: { exclude: true } } },
+        { name: "subtitle", type: "text", localized: true },
+      ];
+      const data = { title: "Hello", subtitle: "World" };
+
+      const collector = new FieldChunkCollector(schema, data, data, {}, strategy);
+      const chunks = collector.collect();
+
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].key).toBe("subtitle"); // title excluded via translateKit.exclude
+    });
+  });
 });

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/field-collector/FieldChunkCollector.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/field-collector/FieldChunkCollector.ts
@@ -1,150 +1,110 @@
-import type { Field } from 'payload'
-import { fieldAffectsData, fieldIsArrayType, fieldIsBlockType, fieldIsGroupType, tabHasName } from 'payload/shared'
+import type { Field } from "payload";
 
-import {
-  hasFields,
-  isBlockItem,
-  isLocalizedField,
-  isObject,
-  isTabsField,
-  isTranslatableField,
-  isFieldExcludedFromTranslation,
-} from '../../../../shared'
-import type { FieldChunk } from '../../types'
-import type { TranslationStrategy } from '../../strategies'
+import { isFieldExcludedFromTranslation, isLocalizedField, isObject, isTranslatableField } from "../../../../shared";
+import type { ChildCursor, FieldWalker } from "../../../../shared/field-traversal";
+import { resolveBlockFields, walkFields } from "../../../../shared/field-traversal";
+import type { TranslationStrategy } from "../../strategies";
+import type { FieldChunk } from "../../types";
+
+/** Data position for the collect walk: the three parallel trees plus the path from root. */
+type Cursor = {
+  data: Record<string, unknown>;
+  source: Record<string, unknown>;
+  target: Record<string, unknown>;
+  path: string[];
+};
+
+const asObject = (value: unknown): Record<string, unknown> => (isObject(value) ? value : {});
 
 /**
- * Collects FieldChunks by traversing schema and data in parallel.
- * Each chunk contains a reference to the parent data object for later mutation.
+ * Collects FieldChunks by walking schema + data with the shared {@link walkFields} engine.
+ * Iteration is driven by `filteredData`; each translatable, localized, non-excluded leaf that
+ * the strategy approves is written with its source value and pushed as a chunk carrying a
+ * mutable reference to its parent object (for later write-back). Collect-only — `combine` is a
+ * no-op; results accumulate in a closure.
  *
- * Applies all filtering logic:
- * - isTranslatableField
- * - isLocalizedField
- * - strategy.shouldTranslate(sourceValue, targetValue)
- * - !isFieldExcludedFromTranslation
- *
- * IMPORTANT: Expects ORIGINAL collection schemas (before Payload sanitization).
- * Original schemas preserve `localized: true` on nested fields.
+ * IMPORTANT: Expects ORIGINAL collection schemas (before Payload sanitization). Original
+ * schemas preserve `localized: true` on nested fields.
  */
 export class FieldChunkCollector {
-  private chunks: FieldChunk[] = []
+  private readonly schema: Field[];
+  private readonly filteredData: Record<string, unknown>;
+  private readonly sourceData: Record<string, unknown>;
+  private readonly targetData: Record<string, unknown>;
+  private readonly strategy: TranslationStrategy;
 
-  constructor(
-    private readonly schema: Field[],
-    private readonly filteredData: Record<string, unknown>,
-    private readonly sourceData: Record<string, unknown>,
-    private readonly targetData: Record<string, unknown>,
-    private readonly strategy: TranslationStrategy,
-  ) {}
-
-  /**
-   * Collects translatable field chunks that need translation.
-   */
-  collect(): FieldChunk[] {
-    this.chunks = []
-    this.traverseFields(this.schema, this.filteredData, this.sourceData, this.targetData, [])
-    return this.chunks
+  constructor(schema: Field[], filteredData: Record<string, unknown>, sourceData: Record<string, unknown>, targetData: Record<string, unknown>, strategy: TranslationStrategy) {
+    this.schema = schema;
+    this.filteredData = filteredData;
+    this.sourceData = sourceData;
+    this.targetData = targetData;
+    this.strategy = strategy;
   }
 
-  /**
-   * Traverses fields recursively, collecting translatable fields that need translation.
-   * Uses strategy.shouldTranslate() to determine if field needs translation.
-   */
-  private traverseFields(
-    fields: Field[],
-    data: Record<string, unknown>,
-    source: Record<string, unknown>,
-    target: Record<string, unknown>,
-    path: string[],
-  ): void {
-    for (const field of fields) {
-      if (isTabsField(field)) {
-        for (const tab of field.tabs) {
-          if (hasFields(tab)) {
-            if (tabHasName(tab)) {
-              const tabData = data[tab.name]
-              const tabSource = source[tab.name]
-              const tabTarget = target[tab.name]
-              if (isObject(tabData)) {
-                this.traverseFields(
-                  tab.fields,
-                  tabData,
-                  isObject(tabSource) ? tabSource : {},
-                  isObject(tabTarget) ? tabTarget : {},
-                  [...path, tab.name],
-                )
-              }
-            } else {
-              this.traverseFields(tab.fields, data, source, target, path)
-            }
-          }
+  /** Collects translatable field chunks that need translation. */
+  collect(): FieldChunk[] {
+    const chunks: FieldChunk[] = [];
+    const { strategy } = this;
+
+    const walker: FieldWalker<Cursor, unknown> = {
+      enterObject(field, cursor) {
+        const value = cursor.data[field.name];
+        if (!isObject(value)) return "skip";
+        return {
+          data: value,
+          source: asObject(cursor.source[field.name]),
+          target: asObject(cursor.target[field.name]),
+          path: [...cursor.path, field.name],
+        };
+      },
+
+      enterList(field, cursor) {
+        const value = cursor.data[field.name];
+        if (!Array.isArray(value)) return "skip";
+        const sourceValue = cursor.source[field.name];
+        const targetValue = cursor.target[field.name];
+        const sourceArr: unknown[] = Array.isArray(sourceValue) ? sourceValue : [];
+        const targetArr: unknown[] = Array.isArray(targetValue) ? targetValue : [];
+
+        const children: ChildCursor<Cursor>[] = [];
+        value.forEach((item, index) => {
+          if (!isObject(item)) return;
+          const fields = field.type === "blocks" ? resolveBlockFields(field, item) : field.fields;
+          if (!fields) return; // unknown blockType → skip element
+          children.push({
+            cursor: {
+              data: item,
+              source: asObject(sourceArr[index]),
+              target: asObject(targetArr[index]),
+              path: [...cursor.path, field.name, String(index)],
+            },
+            fields,
+            key: index,
+          });
+        });
+        return children;
+      },
+
+      leaf(field, cursor) {
+        const value = cursor.data[field.name];
+        if (value === undefined || value === null) return undefined;
+
+        const sourceValue = cursor.source[field.name];
+        const targetValue = cursor.target[field.name];
+        if (isTranslatableField(field) && isLocalizedField(field) && !isFieldExcludedFromTranslation(field) && strategy.shouldTranslate({ sourceValue, targetValue })) {
+          cursor.data[field.name] = sourceValue; // write source value into filteredData — this is what gets translated
+          chunks.push({ schema: field, dataRef: cursor.data, key: field.name, path: [...cursor.path, field.name] });
         }
-        continue
-      }
+        return undefined;
+      },
 
-      if (!fieldAffectsData(field)) {
-        if (hasFields(field)) this.traverseFields(field.fields, data, source, target, path)
-        continue
-      }
+      combine() {
+        return undefined; // collect-only — nothing to assemble
+      },
+    };
 
-      const value = data[field.name]
-      const sourceValue = source[field.name]
-      const targetValue = target[field.name]
-      if (value === undefined || value === null) continue
+    walkFields(this.schema, { data: this.filteredData, source: this.sourceData, target: this.targetData, path: [] }, walker);
 
-      const currentPath = [...path, field.name]
-
-      if (fieldIsGroupType(field) && isObject(value)) {
-        this.traverseFields(
-          field.fields,
-          value,
-          isObject(sourceValue) ? sourceValue : {},
-          isObject(targetValue) ? targetValue : {},
-          currentPath,
-        )
-        continue
-      }
-
-      if (fieldIsArrayType(field) && Array.isArray(value)) {
-        const sourceArray = Array.isArray(sourceValue) ? sourceValue : []
-        const targetArray = Array.isArray(targetValue) ? targetValue : []
-        value.forEach((item, index) => {
-          if (isObject(item)) {
-            const sourceItem = isObject(sourceArray[index]) ? sourceArray[index] : {}
-            const targetItem = isObject(targetArray[index]) ? targetArray[index] : {}
-            this.traverseFields(field.fields, item, sourceItem, targetItem, [...currentPath, String(index)])
-          }
-        })
-        continue
-      }
-
-      if (fieldIsBlockType(field) && Array.isArray(value)) {
-        const sourceArray = Array.isArray(sourceValue) ? sourceValue : []
-        const targetArray = Array.isArray(targetValue) ? targetValue : []
-        value.forEach((item, index) => {
-          if (isBlockItem(item)) {
-            const block = field.blocks.find((b) => b.slug === item.blockType)
-            if (block) {
-              const sourceItem = isObject(sourceArray[index]) ? sourceArray[index] : {}
-              const targetItem = isObject(targetArray[index]) ? targetArray[index] : {}
-              this.traverseFields(block.fields, item, sourceItem, targetItem, [...currentPath, String(index)])
-            }
-          }
-        })
-        continue
-      }
-
-      // Collect if: translatable, localized, not excluded, and strategy says to translate
-      if (
-        isTranslatableField(field) &&
-        isLocalizedField(field) &&
-        !isFieldExcludedFromTranslation(field) &&
-        this.strategy.shouldTranslate({ sourceValue, targetValue })
-      ) {
-        // Write sourceValue to filteredData — this is what will be translated
-        data[field.name] = sourceValue
-        this.chunks.push({ schema: field, dataRef: data, key: field.name, path: currentPath })
-      }
-    }
+    return chunks;
   }
 }

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/findFieldByPath.test.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/findFieldByPath.test.ts
@@ -1,0 +1,124 @@
+import type { Field } from "payload";
+import { describe, expect, it } from "vitest";
+
+import { findFieldByPath } from "./findFieldByPath";
+
+const f = (config: Record<string, unknown>): Field => config as unknown as Field;
+
+const schema: Field[] = [
+  f({ name: "title", type: "text" }),
+  f({ name: "hero", type: "group", fields: [f({ name: "heading", type: "text" })] }),
+  f({ name: "items", type: "array", fields: [f({ name: "label", type: "text" })] }),
+  f({
+    type: "tabs",
+    tabs: [
+      { name: "meta", fields: [f({ name: "slug", type: "text" })] },
+      { label: "Main", fields: [f({ name: "intro", type: "text" })] },
+    ],
+  }),
+  f({ type: "row", fields: [f({ name: "col", type: "text" })] }),
+  f({ name: "layout", type: "blocks", blocks: [{ slug: "hero", fields: [f({ name: "headline", type: "text" })] }] }),
+];
+
+describe("findFieldByPath", () => {
+  it("finds a top-level leaf and returns the field", () => {
+    const result = findFieldByPath(schema, ["title"]);
+    expect(result.status).toBe("leaf");
+    if (result.status === "leaf") expect(result.field.name).toBe("title");
+  });
+
+  it("finds a leaf nested in a group", () => {
+    expect(findFieldByPath(schema, ["hero", "heading"]).status).toBe("leaf");
+  });
+
+  it("finds a leaf inside an array (segments are name-only — indices dropped by the caller)", () => {
+    expect(findFieldByPath(schema, ["items", "label"]).status).toBe("leaf");
+  });
+
+  it("finds a leaf under a named tab", () => {
+    expect(findFieldByPath(schema, ["meta", "slug"]).status).toBe("leaf");
+  });
+
+  it("finds a leaf under an unnamed tab (transparent — same scope)", () => {
+    expect(findFieldByPath(schema, ["intro"]).status).toBe("leaf");
+  });
+
+  it("finds a leaf inside a presentational row (transparent)", () => {
+    expect(findFieldByPath(schema, ["col"]).status).toBe("leaf");
+  });
+
+  it("returns `container` when the path ends on a group / array", () => {
+    expect(findFieldByPath(schema, ["hero"]).status).toBe("container");
+    expect(findFieldByPath(schema, ["items"]).status).toBe("container");
+  });
+
+  it("returns `container` when the path ends on a named tab", () => {
+    expect(findFieldByPath(schema, ["meta"]).status).toBe("container");
+  });
+
+  it("returns `container` when the path ends on a blocks field", () => {
+    expect(findFieldByPath(schema, ["layout"]).status).toBe("container");
+  });
+
+  it("returns `inside-blocks` when the path descends through a blocks field", () => {
+    expect(findFieldByPath(schema, ["layout", "headline"]).status).toBe("inside-blocks");
+  });
+
+  it("returns `not-found` for an unknown segment", () => {
+    expect(findFieldByPath(schema, ["nope"]).status).toBe("not-found");
+    expect(findFieldByPath(schema, ["hero", "missing"]).status).toBe("not-found");
+  });
+
+  it("returns `not-found` when the path continues past a leaf", () => {
+    expect(findFieldByPath(schema, ["title", "deeper"]).status).toBe("not-found");
+  });
+});
+
+describe("findFieldByPath — deeply nested schemas", () => {
+  const deep: Field[] = [
+    f({
+      name: "a",
+      type: "group",
+      fields: [f({ name: "b", type: "group", fields: [f({ name: "c", type: "array", fields: [f({ name: "leaf", type: "text" })] })] })],
+    }),
+    f({ name: "arr", type: "array", fields: [f({ name: "g", type: "group", fields: [f({ name: "deep", type: "text" })] })] }),
+    f({
+      type: "tabs",
+      tabs: [{ name: "tab1", fields: [f({ name: "tg", type: "group", fields: [f({ name: "tleaf", type: "text" })] })] }],
+    }),
+    f({ name: "withBlocks", type: "group", fields: [f({ name: "bl", type: "blocks", blocks: [{ slug: "x", fields: [f({ name: "y", type: "text" })] }] })] }),
+  ];
+
+  it("resolves a leaf through group → group → array (indices dropped)", () => {
+    const r = findFieldByPath(deep, ["a", "b", "c", "leaf"]);
+    expect(r.status).toBe("leaf");
+    if (r.status === "leaf") expect(r.field.name).toBe("leaf");
+  });
+
+  it("resolves a leaf through array → group", () => {
+    expect(findFieldByPath(deep, ["arr", "g", "deep"]).status).toBe("leaf");
+  });
+
+  it("resolves a leaf through a named tab → group", () => {
+    expect(findFieldByPath(deep, ["tab1", "tg", "tleaf"]).status).toBe("leaf");
+  });
+
+  it("returns `inside-blocks` when a deep path descends through a nested blocks field", () => {
+    expect(findFieldByPath(deep, ["withBlocks", "bl", "y"]).status).toBe("inside-blocks");
+  });
+
+  it("returns `container` for deep paths ending on a container at any depth", () => {
+    expect(findFieldByPath(deep, ["a", "b"]).status).toBe("container"); // group
+    expect(findFieldByPath(deep, ["a", "b", "c"]).status).toBe("container"); // array
+    expect(findFieldByPath(deep, ["withBlocks", "bl"]).status).toBe("container"); // blocks
+  });
+
+  it("returns `not-found` for a wrong segment deep in the path, or a path past a deep leaf", () => {
+    expect(findFieldByPath(deep, ["a", "b", "nope"]).status).toBe("not-found");
+    expect(findFieldByPath(deep, ["a", "b", "c", "leaf", "extra"]).status).toBe("not-found");
+  });
+
+  it("returns `not-found` for empty segments", () => {
+    expect(findFieldByPath(deep, []).status).toBe("not-found");
+  });
+});

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/findFieldByPath.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/findFieldByPath.ts
@@ -1,0 +1,85 @@
+import type { Field } from "payload";
+
+import { classifyField, tabScopes } from "./kernel";
+import type { LeafField } from "./types";
+
+/**
+ * Outcome of navigating a field schema by a path of segment names (see {@link findFieldByPath}).
+ *
+ * - `leaf` — the path lands on a data-affecting leaf field (carries it).
+ * - `container` — the path lands on a `group`/`array`/`blocks` field or a named tab (a container,
+ *   not a leaf).
+ * - `inside-blocks` — the path descends THROUGH a `blocks` field, which can't be resolved from the
+ *   schema alone (the block's `blockType` lives in the data, not the schema).
+ * - `not-found` — no field matches a segment, or the path continues past a leaf.
+ *
+ * @public
+ */
+export type FieldPathResult = { status: "leaf"; field: LeafField } | { status: "container" } | { status: "inside-blocks" } | { status: "not-found" };
+
+/**
+ * Navigate a field schema by a path of segment NAMES, descending one matching branch at a time
+ * with early-exit (targeted navigation, not an exhaustive walk). Presentational containers
+ * (`row`/`collapsible`/unnamed `group`) and unnamed tabs are transparent — searched in the same
+ * path scope. Built on {@link classifyField} / {@link tabScopes} so the structural dispatch lives
+ * in one place.
+ *
+ * The caller supplies already-prepared name segments (split, trimmed, with array indices dropped —
+ * a field's config is shared across array items, so indices never appear in the schema).
+ *
+ * @param fields - The schema level to search.
+ * @param segments - Remaining path segments (names) to match, head-first.
+ * @returns A {@link FieldPathResult}.
+ * @public
+ */
+export function findFieldByPath(fields: Field[], segments: string[]): FieldPathResult {
+  const [head, ...rest] = segments;
+  if (head === undefined) return { status: "not-found" };
+
+  for (const field of fields) {
+    const structure = classifyField(field);
+
+    switch (structure.kind) {
+      case "tabs": {
+        for (const scope of tabScopes(structure.field)) {
+          if (scope.named) {
+            if (scope.tab.name === head) {
+              return rest.length === 0 ? { status: "container" } : findFieldByPath(scope.tab.fields, rest);
+            }
+          } else {
+            const found = findFieldByPath(scope.fields, segments); // unnamed tab → same path scope
+            if (found.status !== "not-found") return found;
+          }
+        }
+        break;
+      }
+      case "transparent": {
+        const found = findFieldByPath(structure.fields, segments); // row/collapsible/unnamed group → same scope
+        if (found.status !== "not-found") return found;
+        break;
+      }
+      case "presentational":
+        break;
+      case "group":
+      case "array": {
+        if (structure.name !== head) break;
+        return rest.length === 0 ? { status: "container" } : findFieldByPath(structure.fields, rest);
+      }
+      case "blocks": {
+        if (structure.name !== head) break;
+        return rest.length === 0 ? { status: "container" } : { status: "inside-blocks" };
+      }
+      case "leaf": {
+        if (structure.name !== head) break;
+        return rest.length === 0 ? { status: "leaf", field: structure.field } : { status: "not-found" };
+      }
+      default: {
+        // Exhaustiveness guard: a new FieldStructure kind would error here at compile time.
+        const exhaustive: never = structure;
+        throw new Error(`unhandled field structure: ${String(exhaustive)}`);
+      }
+    }
+  }
+
+  return { status: "not-found" };
+}

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/index.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/index.ts
@@ -1,3 +1,5 @@
+export { findFieldByPath } from "./findFieldByPath";
+export type { FieldPathResult } from "./findFieldByPath";
 export { classifyField, resolveBlockFields, tabScopes } from "./kernel";
 export type { ChildCursor, ChildOutput, ContainerInfo, FieldStructure, FieldWalker, LeafField, TabScope, WalkSignal } from "./types";
 export { walkFields } from "./walkFields";

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/walkFields.test.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/walkFields.test.ts
@@ -1,8 +1,8 @@
-import type { Field } from "payload";
+import type { ArrayField, BlocksField, Field, NamedGroupField, NamedTab } from "payload";
 import { describe, expect, it } from "vitest";
 
 import { resolveBlockFields } from "./kernel";
-import type { FieldWalker, LeafField } from "./types";
+import type { ChildCursor, FieldWalker, LeafField } from "./types";
 import { walkFields } from "./walkFields";
 
 const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null && !Array.isArray(v);
@@ -107,5 +107,290 @@ describe("walkFields", () => {
       { path: "items.0.label", value: "a" },
       { path: "items.1.label", value: "b" },
     ]);
+  });
+});
+
+// ── instrumentation helpers for deep-nesting / engine-mechanics tests ──
+
+type Cur = { data: Record<string, unknown>; path: string[] };
+
+const stdEnterObject = (field: NamedGroupField | NamedTab, c: Cur): Cur | "skip" => {
+  const value = c.data[field.name];
+  return isRecord(value) ? { data: value, path: [...c.path, field.name] } : "skip";
+};
+
+const stdEnterList = (field: ArrayField | BlocksField, c: Cur): ChildCursor<Cur>[] => {
+  const value = c.data[field.name];
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item, index) => {
+    if (!isRecord(item)) return [];
+    const fields = field.type === "blocks" ? resolveBlockFields(field, item) : field.fields;
+    return fields ? [{ cursor: { data: item, path: [...c.path, field.name, String(index)] }, fields, key: index }] : [];
+  });
+};
+
+/** Collect every visited leaf as `path → value`, in visit order. */
+const collectLeaves = (schema: Field[], data: Record<string, unknown>): Array<{ path: string; value: unknown }> => {
+  const leaves: Array<{ path: string; value: unknown }> = [];
+  walkFields<Cur, void>(
+    schema,
+    { data, path: [] },
+    {
+      enterObject: stdEnterObject,
+      enterList: stdEnterList,
+      leaf: (field, c) => {
+        leaves.push({ path: [...c.path, field.name].join("."), value: c.data[field.name] });
+      },
+      combine: () => undefined,
+    }
+  );
+  return leaves;
+};
+
+/** Rebuild the full data tree (keep ALL leaves), dropping empty containers, preserving id/blockType. */
+const rebuildAll = (schema: Field[], data: Record<string, unknown>): unknown =>
+  walkFields<Cur, unknown>(
+    schema,
+    { data, path: [] },
+    {
+      enterObject: stdEnterObject,
+      enterList: stdEnterList,
+      leaf: (field, c) => c.data[field.name],
+      combine: (container, children, c) => {
+        if (children.length === 0) return undefined;
+        if (container.kind === "list") return children.map((child) => child.out);
+        const obj: Record<string, unknown> = {};
+        for (const child of children) obj[child.key] = child.out;
+        if (container.kind === "element") {
+          if (c.data.id !== undefined) obj.id = c.data.id;
+          if (container.field.type === "blocks") obj.blockType = c.data.blockType;
+        }
+        return obj;
+      },
+    }
+  );
+
+describe("walkFields — deep nesting & engine mechanics", () => {
+  const deepSchema = [
+    { name: "title", type: "text" },
+    {
+      name: "seo",
+      type: "group",
+      fields: [
+        { name: "metaTitle", type: "text" },
+        { name: "og", type: "group", fields: [{ name: "ogTitle", type: "text" }] },
+      ],
+    },
+    {
+      name: "sections",
+      type: "array",
+      fields: [
+        { name: "heading", type: "text" },
+        {
+          name: "content",
+          type: "blocks",
+          blocks: [
+            { slug: "text", fields: [{ name: "body", type: "text" }] },
+            {
+              slug: "cta",
+              fields: [
+                { name: "label", type: "text" },
+                { name: "links", type: "array", fields: [{ name: "url", type: "text" }] },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: "tabs",
+      tabs: [
+        { name: "meta", fields: [{ name: "slug", type: "text" }] },
+        {
+          label: "More",
+          fields: [
+            { name: "intro", type: "text" },
+            { type: "row", fields: [{ name: "rowField", type: "text" }] },
+          ],
+        },
+      ],
+    },
+    { type: "ui", name: "spacer" },
+  ] as unknown as Field[];
+
+  const deepData = {
+    title: "T",
+    seo: { metaTitle: "MT", og: { ogTitle: "OG" } },
+    sections: [
+      {
+        id: "s0",
+        heading: "H0",
+        content: [
+          { id: "c0", blockType: "text", body: "B0" },
+          {
+            id: "c1",
+            blockType: "cta",
+            label: "L0",
+            links: [
+              { id: "k0", url: "U0" },
+              { id: "k1", url: "U1" },
+            ],
+          },
+        ],
+      },
+      { id: "s1", heading: "H1", content: [] },
+    ],
+    meta: { slug: "S" },
+    intro: "I",
+    rowField: "RF",
+  };
+
+  it("descends every container kind with correct paths and visit order (group-in-group, blocks-in-array, array-in-block, named/unnamed tabs, row; ui ignored)", () => {
+    expect(collectLeaves(deepSchema, deepData)).toEqual([
+      { path: "title", value: "T" },
+      { path: "seo.metaTitle", value: "MT" },
+      { path: "seo.og.ogTitle", value: "OG" },
+      { path: "sections.0.heading", value: "H0" },
+      { path: "sections.0.content.0.body", value: "B0" },
+      { path: "sections.0.content.1.label", value: "L0" },
+      { path: "sections.0.content.1.links.0.url", value: "U0" },
+      { path: "sections.0.content.1.links.1.url", value: "U1" },
+      { path: "sections.1.heading", value: "H1" },
+      { path: "meta.slug", value: "S" },
+      { path: "intro", value: "I" },
+      { path: "rowField", value: "RF" },
+    ]);
+  });
+
+  it("reconstructs the full nested tree: named tabs nest, unnamed tabs/rows flatten, empty containers drop, id/blockType preserved", () => {
+    expect(rebuildAll(deepSchema, deepData)).toEqual({
+      title: "T",
+      seo: { metaTitle: "MT", og: { ogTitle: "OG" } },
+      sections: [
+        {
+          id: "s0",
+          heading: "H0",
+          content: [
+            { id: "c0", blockType: "text", body: "B0" },
+            {
+              id: "c1",
+              blockType: "cta",
+              label: "L0",
+              links: [
+                { id: "k0", url: "U0" },
+                { id: "k1", url: "U1" },
+              ],
+            },
+          ],
+        },
+        { id: "s1", heading: "H1" }, // content [] → dropped
+      ],
+      meta: { slug: "S" }, // named tab → nested under its name
+      intro: "I", // unnamed tab → flattened to parent scope
+      rowField: "RF", // row → flattened to parent scope
+    });
+  });
+
+  it("enterObject 'skip' prunes one branch but continues siblings", () => {
+    const seen: string[] = [];
+    walkFields<Cur, void>(
+      deepSchema,
+      { data: deepData, path: [] },
+      {
+        enterObject: (field, c) => (field.name === "seo" ? "skip" : stdEnterObject(field, c)),
+        enterList: stdEnterList,
+        leaf: (field, c) => {
+          seen.push([...c.path, field.name].join("."));
+        },
+        combine: () => undefined,
+      }
+    );
+    expect(seen).not.toContain("seo.metaTitle");
+    expect(seen).not.toContain("seo.og.ogTitle");
+    expect(seen).toEqual(expect.arrayContaining(["title", "sections.0.heading", "meta.slug", "intro", "rowField"]));
+  });
+
+  it("enterList 'skip' prunes the whole list", () => {
+    const seen: string[] = [];
+    walkFields<Cur, void>(
+      deepSchema,
+      { data: deepData, path: [] },
+      {
+        enterObject: stdEnterObject,
+        enterList: (field, c) => (field.name === "sections" ? "skip" : stdEnterList(field, c)),
+        leaf: (field, c) => {
+          seen.push([...c.path, field.name].join("."));
+        },
+        combine: () => undefined,
+      }
+    );
+    expect(seen.some((p) => p.startsWith("sections"))).toBe(false);
+    expect(seen).toEqual(expect.arrayContaining(["title", "seo.metaTitle", "meta.slug"]));
+  });
+
+  it("enterObject 'stop' halts the entire walk and returns undefined", () => {
+    const seen: string[] = [];
+    const result = walkFields<Cur, unknown>(
+      deepSchema,
+      { data: deepData, path: [] },
+      {
+        enterObject: (field, c) => (field.name === "seo" ? "stop" : stdEnterObject(field, c)),
+        enterList: stdEnterList,
+        leaf: (field, c) => {
+          seen.push([...c.path, field.name].join("."));
+          return undefined;
+        },
+        combine: () => ({}),
+      }
+    );
+    expect(result).toBeUndefined();
+    expect(seen).toEqual(["title"]); // only the leaf before "seo"; everything after is halted
+  });
+
+  it("enterList 'stop' halts the entire walk and returns undefined", () => {
+    const seen: string[] = [];
+    const result = walkFields<Cur, unknown>(
+      deepSchema,
+      { data: deepData, path: [] },
+      {
+        enterObject: stdEnterObject,
+        enterList: (field, c) => (field.name === "sections" ? "stop" : stdEnterList(field, c)),
+        leaf: (field, c) => {
+          seen.push([...c.path, field.name].join("."));
+          return undefined;
+        },
+        combine: () => ({}),
+      }
+    );
+    expect(result).toBeUndefined();
+    expect(seen).toEqual(["title", "seo.metaTitle", "seo.og.ogTitle"]); // up to just before "sections"
+  });
+
+  it("combine fires bottom-up — children before their container, root last", () => {
+    const order: string[] = [];
+    const orderSchema = [{ name: "items", type: "array", fields: [{ name: "g", type: "group", fields: [{ name: "x", type: "text" }] }] }] as unknown as Field[];
+    walkFields<Cur, unknown>(
+      orderSchema,
+      { data: { items: [{ g: { x: "v" } }] }, path: [] },
+      {
+        enterObject: stdEnterObject,
+        enterList: stdEnterList,
+        leaf: () => undefined,
+        combine: (container) => {
+          order.push(container.kind === "root" ? "root" : `${container.kind}:${container.key}`);
+          return {}; // non-undefined → nothing dropped
+        },
+      }
+    );
+    expect(order).toEqual(["object:g", "element:0", "list:items", "root"]);
+  });
+
+  it("drops empty containers, cascading up (empty array inside group → group omitted)", () => {
+    const schema = [{ name: "wrap", type: "group", fields: [{ name: "list", type: "array", fields: [{ name: "x", type: "text" }] }] }] as unknown as Field[];
+    expect(rebuildAll(schema, { wrap: { list: [] } })).toBeUndefined();
+  });
+
+  it("returns undefined for an empty schema", () => {
+    expect(rebuildAll([], { anything: 1 })).toBeUndefined();
   });
 });

--- a/packages/payload-plugin-translator/src/server/shared/utils/filterLocalizedFields.test.ts
+++ b/packages/payload-plugin-translator/src/server/shared/utils/filterLocalizedFields.test.ts
@@ -455,4 +455,20 @@ describe("filterLocalizedFields", () => {
       });
     });
   });
+
+  describe("named tab", () => {
+    it("keeps localized fields inside a NAMED tab, nested under the tab name", () => {
+      const schema: Field[] = [{ type: "tabs", tabs: [{ name: "seo", fields: [{ name: "title", type: "text", localized: true }] }] }];
+      // Named tabs nest data under the tab name; the walk descends into data.seo. (Before the
+      // walkFields migration this site read flat and silently dropped the field — now fixed.)
+      const data = { seo: { title: "Hi" } };
+      expect(filterLocalizedFields(schema, data)).toEqual({ seo: { title: "Hi" } });
+    });
+
+    it("drops a named tab whose fields have no localized content", () => {
+      const schema: Field[] = [{ type: "tabs", tabs: [{ name: "seo", fields: [{ name: "slug", type: "text" }] }] }];
+      const data = { seo: { slug: "x" } };
+      expect(filterLocalizedFields(schema, data)).toEqual({});
+    });
+  });
 });

--- a/packages/payload-plugin-translator/src/server/shared/utils/filterLocalizedFields.ts
+++ b/packages/payload-plugin-translator/src/server/shared/utils/filterLocalizedFields.ts
@@ -1,81 +1,67 @@
-import type { Field } from 'payload'
-import { fieldAffectsData, fieldIsArrayType, fieldIsBlockType, fieldIsGroupType } from 'payload/shared'
+import type { Field } from "payload";
 
-import { hasFields, isBlockItem, isLocalizedField, isTabsField, isTranslatableField } from '../guards'
-import { isObject } from './isObject'
-import { isEmpty } from './isEmpty'
+import type { ChildCursor, FieldWalker } from "../field-traversal";
+import { resolveBlockFields, walkFields } from "../field-traversal";
+import { isLocalizedField, isTranslatableField } from "../guards";
+import { isObject } from "./isObject";
+
+/** Data position for the filter walk: a single data object at the current schema level. */
+type Cursor = { data: Record<string, unknown> };
 
 /**
- * Filters data to keep only translatable localized fields.
- * For container fields (group, array, blocks) recursively filters nested data.
+ * Filter walker: keeps only translatable, localized leaves, rebuilding the surrounding
+ * object/array/blocks structure and dropping any container left empty. `id` (array/block
+ * elements) and `blockType` (block elements) are preserved since they aren't schema fields.
+ */
+const filterWalker: FieldWalker<Cursor, unknown> = {
+  enterObject(field, cursor) {
+    const value = cursor.data[field.name];
+    return isObject(value) ? { data: value } : "skip";
+  },
+
+  enterList(field, cursor) {
+    const value = cursor.data[field.name];
+    if (!Array.isArray(value)) return "skip";
+
+    const children: ChildCursor<Cursor>[] = [];
+    value.forEach((item, index) => {
+      if (!isObject(item)) return; // drop non-object elements
+      const fields = field.type === "blocks" ? resolveBlockFields(field, item) : field.fields;
+      if (fields) children.push({ cursor: { data: item }, fields, key: index }); // unknown blockType → fields null → drop
+    });
+    return children;
+  },
+
+  leaf(field, cursor) {
+    return isTranslatableField(field) && isLocalizedField(field) ? cursor.data[field.name] : undefined;
+  },
+
+  combine(container, children, cursor) {
+    if (children.length === 0) return undefined; // drop empty containers/lists
+
+    if (container.kind === "list") return children.map((child) => child.out);
+
+    const result: Record<string, unknown> = {};
+    for (const child of children) result[child.key] = child.out;
+
+    if (container.kind === "element") {
+      const item = cursor.data;
+      if (item.id !== undefined) result.id = item.id;
+      if (container.field.type === "blocks") result.blockType = item.blockType;
+    }
+
+    return result;
+  },
+};
+
+/**
+ * Filters data to keep only translatable localized fields, recursively for container fields
+ * (group, array, blocks, named tabs). Built on the shared {@link walkFields} engine.
  *
  * @param schema - Payload field schema (original, not sanitized)
  * @param data - Document data to filter
  * @returns Filtered data containing only translatable localized fields
  */
 export function filterLocalizedFields(schema: Field[], data: Record<string, unknown>): Record<string, unknown> {
-  const result: Record<string, unknown> = {}
-
-  for (const field of schema) {
-    if (isTabsField(field)) {
-      for (const tab of field.tabs) {
-        if (hasFields(tab)) Object.assign(result, filterLocalizedFields(tab.fields, data))
-      }
-      continue
-    }
-
-    if (!fieldAffectsData(field)) {
-      if (hasFields(field)) Object.assign(result, filterLocalizedFields(field.fields, data))
-      continue
-    }
-
-    const value = data[field.name]
-    if (value === undefined) continue
-
-    if (fieldIsGroupType(field) && isObject(value)) {
-      const filtered = filterLocalizedFields(field.fields, value)
-      if (!isEmpty(filtered)) result[field.name] = filtered
-      continue
-    }
-
-    if (fieldIsArrayType(field) && Array.isArray(value)) {
-      const filteredArray = value
-        .map((item) => {
-          if (isObject(item)) {
-            const filtered = filterLocalizedFields(field.fields, item)
-            if (!isEmpty(filtered)) return { ...filtered, id: item.id }
-          }
-          return null
-        })
-        .filter(Boolean)
-
-      if (!isEmpty(filteredArray)) result[field.name] = filteredArray
-      continue
-    }
-
-    if (fieldIsBlockType(field) && Array.isArray(value)) {
-      const filteredBlocks = value
-        .map((item) => {
-          if (isBlockItem(item)) {
-            const block = field.blocks.find((b) => b.slug === item.blockType)
-            if (block) {
-              const filtered = filterLocalizedFields(block.fields, item)
-              if (!isEmpty(filtered)) return { ...filtered, blockType: item.blockType, id: item.id }
-            }
-          }
-          return null
-        })
-        .filter(Boolean)
-
-      if (!isEmpty(filteredBlocks)) result[field.name] = filteredBlocks
-      continue
-    }
-
-    if (isTranslatableField(field) && isLocalizedField(field)) {
-      result[field.name] = value
-      continue
-    }
-  }
-
-  return result
+  return (walkFields(schema, { data }, filterWalker) as Record<string, unknown> | undefined) ?? {};
 }


### PR DESCRIPTION
Migrates the four hand-rolled field-schema traversals onto the shared `walkFields` engine landed in #28, removing the duplicated `tabs → group → array → blocks` dispatch that was copy-pasted across each site.

## What changed
| Site | Now delegates to |
| --- | --- |
| `filterLocalizedFields` | `walkFields` (FieldWalker visitor) |
| `DataReconciler` | `walkFields` |
| `FieldChunkCollector` | `walkFields` |
| `resolveFieldSubtree` | `findFieldByPath` (kernel path-navigation, **added here**) |

`findFieldByPath` is the navigation counterpart to `walkFields` — `resolveFieldSubtree` is targeted path-resolution with early-exit, not an exhaustive walk, so it builds on the kernel (`classifyField`/`tabScopes`) rather than the recursive engine. This realizes the "two shapes, one kernel" split: 3 exhaustive walks → `walkFields`; 1 navigation → `findFieldByPath`.

## Behaviour
- **Behaviour-preserving** for all four (per-site suites + full translation pipeline green).
- **One deliberate bug fix**: `filterLocalizedFields` previously flattened tabs and so **silently dropped localized fields inside named tabs** (it read `data[field]` instead of `data[tab][field]`). It now treats named tabs as a data boundary, matching `DataReconciler`/`FieldChunkCollector`/the engine.

## No release
All affected modules are **internal** (not re-exported from `src/index.ts`), and nothing user-facing changes → `chore`, **no version bump**.

## Review
Ran `/simplify` (4 cleanup angles) + `/iterative-review` (correctness/contracts/tests/adversarial). Correctness & adversarial passes found **0 bugs**; applied an exhaustive-switch tidy-up + 5 characterization tests for coverage gaps the review surfaced (exclude-gate, non-object source, container-at-end statuses, empty named-tab, empty path). `check-types` (incl. tests) clean · lint 0/0 · all suites green.

> Pre-existing note (not this migration): `FieldChunkCollector` writes `sourceValue` even when `undefined` (source array shorter than filtered) — preserved bit-for-bit from the original; worth a separate look at whether `SkipExisting` gates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)