### PR TITLE
fix(translator): tidy shared UI primitives (Button/Select/Popup)

### DIFF
--- a/packages/payload-plugin-translator/src/client/shared/ui/Button/Button.tsx
+++ b/packages/payload-plugin-translator/src/client/shared/ui/Button/Button.tsx
@@ -1,74 +1,58 @@
-import classNames from 'classnames'
-import type { ComponentPropsWithRef, CSSProperties, ReactNode } from 'react'
-import { forwardRef } from 'react'
+import classNames from "classnames";
+import type { ComponentPropsWithRef, CSSProperties, ReactNode } from "react";
+import { forwardRef } from "react";
 
-import Loading from '../Loading'
+import Loading from "../Loading";
 
-import styles from './styles.module.scss'
+import styles from "./styles.module.scss";
 
-type ButtonProps = ComponentPropsWithRef<'button'> & {
-  $fullWidth?: boolean
-  $variant?: 'outlined' | 'filled' | 'unstyled' | 'transparent' | 'light'
-  $startContent?: ReactNode
-  $size?: 'sm' | 'md' | 'lg'
-  $isLoading?: boolean
-  $isIconButton?: boolean
-}
+type ButtonProps = ComponentPropsWithRef<"button"> & {
+  $fullWidth?: boolean;
+  $variant?: "outlined" | "filled" | "unstyled" | "transparent" | "light";
+  $startContent?: ReactNode;
+  $size?: "sm" | "md" | "lg";
+  $isLoading?: boolean;
+  $isIconButton?: boolean;
+};
 
 const sizes = {
   sm: {
-    height: '24px',
-    paddingInline: '0.25rem',
+    height: "24px",
+    paddingInline: "0.25rem",
   },
   md: {
-    height: '32px',
-    paddingInline: '0.5rem',
+    height: "32px",
+    paddingInline: "0.5rem",
   },
   lg: {
-    height: '40px',
-    paddingInline: '0.75rem',
+    height: "40px",
+    paddingInline: "0.75rem",
   },
-}
+};
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  {
-    className = '',
-    children,
-    $fullWidth,
-    style,
-    $startContent,
-    $variant,
-    $isLoading,
-    $size = 'md',
-    $isIconButton,
-    ...props
-  },
-  ref,
+  { className = "", children, $fullWidth, style, $startContent, $variant, $isLoading, $size = "md", $isIconButton, ...props },
+  ref
 ) {
   const _style = {
-    '--button-width': $fullWidth ? '100%' : 'auto',
-    '--height': sizes[$size].height,
-    '--padding-inline': $isIconButton ? '0' : sizes[$size].paddingInline,
-    '--width': $isIconButton ? sizes[$size].height : 'auto',
+    "--button-width": $fullWidth ? "100%" : "auto",
+    "--height": sizes[$size].height,
+    "--padding-inline": $isIconButton ? "0" : sizes[$size].paddingInline,
+    "--width": $isIconButton ? sizes[$size].height : "auto",
     ...style,
-  } as CSSProperties
+  } as CSSProperties;
 
   const buttonClassName =
-    $variant === 'unstyled'
-      ? classNames(styles['unstyled'], className, $isIconButton && styles['icon-button'])
-      : classNames(
-          styles['button'],
-          className,
-          $variant ? styles[$variant] : undefined,
-          $isIconButton && styles['icon-button'],
-        )
+    $variant === "unstyled"
+      ? classNames(styles["unstyled"], className, $isIconButton && styles["icon-button"])
+      : classNames(styles["button"], className, $variant ? styles[$variant] : undefined, $isIconButton && styles["icon-button"]);
 
   return (
     <button {...props} style={_style} ref={ref} className={buttonClassName}>
-      {$startContent && <div className={styles['start-content']}>{$startContent}</div>}
-      {$isLoading ? <Loading size={$isIconButton ? 'small' : 'medium'} /> : children}
+      {$startContent && <div className={styles["start-content"]}>{$startContent}</div>}
+      {$isLoading ? <Loading size={$isIconButton ? "small" : "medium"} /> : children}
     </button>
-  )
-})
+  );
+});
 
-export default Button
+export default Button;

--- a/packages/payload-plugin-translator/src/client/shared/ui/Button/styles.module.scss
+++ b/packages/payload-plugin-translator/src/client/shared/ui/Button/styles.module.scss
@@ -7,7 +7,7 @@
   justify-content: center;
   align-items: center;
   text-decoration: none;
-  transition: background 0.1sease-in-out, opacity 0.2sease-in-out, border-color 0.2sease-in-out;
+  transition: background 0.1s ease-in-out, opacity 0.2s ease-in-out, border-color 0.2s ease-in-out;
   background: none;
   padding-block: 0.25rem;
   padding-inline: var(--padding-inline);

--- a/packages/payload-plugin-translator/src/client/shared/ui/Popup/Popup.tsx
+++ b/packages/payload-plugin-translator/src/client/shared/ui/Popup/Popup.tsx
@@ -1,27 +1,33 @@
-import * as Popover from '@radix-ui/react-popover'
-import type { PropsWithChildren, ReactElement } from 'react'
+import * as Popover from "@radix-ui/react-popover";
+import type { PropsWithChildren, ReactElement } from "react";
 
-import style from './styles.module.scss'
+import style from "./styles.module.scss";
 
 type PopupProps = PropsWithChildren<{
-  $trigger: ReactElement
-  $align?: 'center' | 'end' | 'start'
-  $side?: 'top' | 'right' | 'bottom' | 'left'
-  open: boolean
-  onOpenChange: (open: boolean) => void
-}>
+  $trigger: ReactElement;
+  $align?: "center" | "end" | "start";
+  $side?: "top" | "right" | "bottom" | "left";
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Forwarded to Radix `Popover.Content`. Call `event.preventDefault()` to stop the popover
+   * from auto-focusing its first focusable child on open — useful when that child is a
+   * tooltip trigger (Radix tooltips open on focus, so autofocus would flash the tooltip).
+   */
+  onOpenAutoFocus?: (event: Event) => void;
+}>;
 
-function Popup({ open, children, onOpenChange, $trigger, $align, $side }: PopupProps) {
+function Popup({ open, children, onOpenChange, $trigger, $align, $side, onOpenAutoFocus }: PopupProps) {
   return (
     <Popover.Root open={open} onOpenChange={onOpenChange}>
       <Popover.Trigger asChild>{$trigger}</Popover.Trigger>
       <Popover.Portal>
-        <Popover.Content sideOffset={8} side={$side} align={$align} className={style.popover}>
+        <Popover.Content sideOffset={8} side={$side} align={$align} className={style.popover} onOpenAutoFocus={onOpenAutoFocus}>
           {children}
         </Popover.Content>
       </Popover.Portal>
     </Popover.Root>
-  )
+  );
 }
 
-export default Popup
+export default Popup;

--- a/packages/payload-plugin-translator/src/client/shared/ui/Select/Select.tsx
+++ b/packages/payload-plugin-translator/src/client/shared/ui/Select/Select.tsx
@@ -1,77 +1,80 @@
-import classNames from 'classnames'
-import type { ComponentPropsWithoutRef, ComponentPropsWithRef, CSSProperties } from 'react'
-import { forwardRef } from 'react'
+import classNames from "classnames";
+import type { ComponentPropsWithoutRef, ComponentPropsWithRef, CSSProperties } from "react";
+import { forwardRef } from "react";
 
-import styles from './styles.module.scss'
+import styles from "./styles.module.scss";
 
-type SelectProps = ComponentPropsWithRef<'select'> & {
-  emptyOption?: boolean
-  hasError?: boolean
-  $size?: 'sm' | 'md' | 'lg'
-  'aria-describedby'?: string
-  'aria-invalid'?: boolean
-}
+type SelectProps = ComponentPropsWithRef<"select"> & {
+  emptyOption?: boolean;
+  hasError?: boolean;
+  $size?: "sm" | "md" | "lg";
+  /** Stretch to fill the container (default). Set `false` to size to content — useful inline. */
+  $fullWidth?: boolean;
+  "aria-describedby"?: string;
+  "aria-invalid"?: boolean;
+};
 
 const sizes = {
   sm: {
-    height: '24px',
-    paddingInline: '0.25rem',
-    fontSize: '0.875rem',
+    height: "24px",
+    paddingInline: "0.25rem",
+    fontSize: "0.875rem",
   },
   md: {
-    height: '32px',
-    paddingInline: '0.5rem',
-    fontSize: '1rem',
+    height: "32px",
+    paddingInline: "0.5rem",
+    fontSize: "1rem",
   },
   lg: {
-    height: '40px',
-    paddingInline: '0.75rem',
-    fontSize: '1rem',
+    height: "40px",
+    paddingInline: "0.75rem",
+    fontSize: "1rem",
   },
-}
-type SelectOptionProps = ComponentPropsWithoutRef<'option'>
-type SelectEmptyOptionProps = Omit<SelectOptionProps, 'value' | 'disabled' | 'hidden'>
+};
+type SelectOptionProps = ComponentPropsWithoutRef<"option">;
+type SelectEmptyOptionProps = Omit<SelectOptionProps, "value" | "disabled" | "hidden">;
 
-const SelectOption = ({ children, ...props }: SelectOptionProps) => <option {...props}>{children}</option>
+const SelectOption = ({ children, ...props }: SelectOptionProps) => <option {...props}>{children}</option>;
 
 const SelectEmptyOption = ({ children, ...props }: SelectEmptyOptionProps) => (
   <option value="" {...props}>
     {children}
   </option>
-)
+);
 
 const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
-  { children, className = '', hasError = false, $size = 'lg', style, 'aria-invalid': ariaInvalid, ...props },
-  ref,
+  { children, className = "", hasError = false, $size = "lg", $fullWidth = true, style, "aria-invalid": ariaInvalid, ...props },
+  ref
 ) {
   const _style: CSSProperties = {
-    '--height': sizes[$size].height,
-    '--padding-inline': sizes[$size].paddingInline,
-    '--font-size': sizes[$size].fontSize,
+    "--height": sizes[$size].height,
+    "--padding-inline": sizes[$size].paddingInline,
+    "--font-size": sizes[$size].fontSize,
     ...style,
-  } as CSSProperties
+  } as CSSProperties;
 
   const selectClassName = classNames(
     styles.select,
     styles[`size-${$size}`],
     {
       [styles.selectError]: hasError,
+      [styles.auto]: !$fullWidth,
     },
-    className,
-  )
+    className
+  );
 
   return (
     <select ref={ref} className={selectClassName} style={_style} aria-invalid={ariaInvalid ?? hasError} {...props}>
       {children}
     </select>
-  )
-})
+  );
+});
 
 type SelectComponent = typeof Select & {
-  SelectOption: typeof SelectOption
-  SelectEmptyOption: typeof SelectEmptyOption
-}
-;(Select as SelectComponent).SelectOption = SelectOption
-;(Select as SelectComponent).SelectEmptyOption = SelectEmptyOption
+  SelectOption: typeof SelectOption;
+  SelectEmptyOption: typeof SelectEmptyOption;
+};
+(Select as SelectComponent).SelectOption = SelectOption;
+(Select as SelectComponent).SelectEmptyOption = SelectEmptyOption;
 
-export default Select as SelectComponent
+export default Select as SelectComponent;

--- a/packages/payload-plugin-translator/src/client/shared/ui/Select/styles.module.scss
+++ b/packages/payload-plugin-translator/src/client/shared/ui/Select/styles.module.scss
@@ -31,6 +31,11 @@
   }
 }
 
+/* Opt out of full width (`$fullWidth={false}`) — size to content, e.g. inline in a row. */
+.auto {
+  width: auto;
+}
+
 /* Size-specific styles if needed */
 .size-sm {
   background-size: 12px 12px;


### PR DESCRIPTION
## Shared UI primitive tidy-ups (Button / Select / Popup)

Independent, backward-compatible improvements to the translator's internal UI
primitives, split out of the in-progress field-level translation work so they can
ship on their own as a patch.

- **Button** — fix an invalid `transition` shorthand (`0.1sease-in-out` → `0.1s ease-in-out`); the missing space meant the transition never applied, on every button in the admin UI. `Button.tsx` also gets a formatter pass (quotes/semicolons) — no behavior change.
- **Select** — add optional `$fullWidth` prop (default `true`, so existing usages are unchanged) to opt out of full width and size to content inline.
- **Popup** — forward `onOpenAutoFocus` to Radix `Popover.Content`, letting callers prevent the popover from auto-focusing its first child on open.

These components aren't exported from the package entry; existing widgets render
identically apart from the now-working Button transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
