### PR TITLE
fix(translator): pair localized blocks/arrays by id across locales

### DIFF
--- a/packages/payload-plugin-translator/docs/plans/2026-06-12-cross-locale-block-identity.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-12-cross-locale-block-identity.md
@@ -1,0 +1,112 @@
+# Cross-locale block identity — design
+
+**Date:** 2026-06-12
+**Status:** Document-level fix implemented (this patch) — `DataReconciler` + `FieldChunkCollector` both pair by `id` via a shared `matchElementById` helper; field-level guard pending (ships with the field-level feature).
+**Scope:** Internal behaviour of `blocks`/`array` reconciliation + chunk collection across locales, plus a documented support boundary for both the document level and the upcoming field level. No public API change, no `@since`.
+
+## The problem
+
+A `blocks` (or `array`) field can be declared **`localized: true`**. Payload then stores an
+**independent array per locale**: the locales can have a different order, a different count, even
+different block types. There is no built-in identifier that links "this `fr` block" to "that `en`
+block" — localized arrays/blocks are independent partitions by design, and you cannot store a
+shared (non-localized) correlation key *inside* a localized field, because the whole subtree is
+locale-partitioned.
+
+This breaks every attempt to translate **between** locales, because translation needs to know
+which target element corresponds to which source element. Three call sites hit it — two in the
+document-level pipeline, one in the field level:
+
+- **Document level — `DataReconciler`** merges source-locale data with the existing target-locale
+  data to produce the full document shape for saving. It paired array/block elements **by
+  position** (`target[index]`). When the target locale's blocks were reordered or different, each
+  source block was merged with an unrelated target block: values from one block leaked into
+  another, and `blockType` came from source while values came from a different block. This is the
+  "blocks don't line up across locales" bug.
+- **Document level — `FieldChunkCollector`** decides *what gets sent to the translator*. It paired
+  `target` by position too, feeding the wrong element's value into `strategy.shouldTranslate`.
+  Under `skip_existing` with reordered blocks that meant **silently skipping** a block that had no
+  translation (a different, populated block sat at its index) or **re-translating** one that was
+  already done — arguably worse than the reconciler symptom, since the field never enters the
+  chunk list at all.
+- **Field level** (per-field translate control, separate feature) — resolves a field by its
+  indexed `path` and reads the **same** path from the source-locale document. Under a localized
+  `blocks`/`array` ancestor, `path` index N in the target locale need not be the same element as
+  index N in the source locale → it pulls a different block's value.
+
+Same root cause, three sites.
+
+## Why no signal can auto-match independent localized blocks
+
+| Candidate | Why it fails |
+| --- | --- |
+| **Position / index** | The premise is that the locales were reordered. |
+| **Block `id`** | For a *localized* field the per-locale rows get independent ids; they don't correspond. (For a *non-localized* field there is one shared row → the id **is** a stable cross-locale key — see below.) |
+| **Block type** | Ambiguous: three `Copy` blocks → which maps to which? |
+| **"Same path has a field"** | Coincidence; different block types can share a field name at the same path and get silently overwritten. |
+| **Content similarity** | Circular for translation: the target value is either empty (nothing to compare) or already in another language (nothing to find). |
+
+Conclusion: **independent localized blocks cannot be auto-matched reliably.** The honest product
+move is to constrain to the regime where identity is well-defined, and to refuse rather than
+silently corrupt outside it.
+
+## Decisions
+
+### 1. Supported regime: localize the leaves, not the container
+
+The recommended (and only fully-correct) shape is a **non-localized** `blocks`/`array` with
+**localized leaf fields** inside it:
+
+- The structure is shared across locales (one array, one set of ids, one order).
+- Only leaf **values** differ per locale.
+- Identity = position = shared `id`; matching is exact for both the reconciler and the field level.
+- The user's "reorder per locale" scenario is impossible by construction — reordering is global,
+  which is correct for *translation* (translating should not restructure the page).
+
+If different layouts per locale are genuinely required, that is authoring, not translation, and
+"pull a translation from another locale" is not a well-defined operation for those blocks.
+
+### 2. Document-level pipeline: match by `id`, not position (this patch)
+
+Both multi-tree pipeline sites now pair their `target` array against the source/reference element
+by **`id`** (and, for blocks, the same `blockType`) instead of by position, through one shared
+helper `matchElementById` in `shared/field-traversal` (sibling of `resolveBlockFields`). No match →
+empty target → the source value fills in. The helper lives in the shared engine because the
+positional bug was duplicated across both sites; the `walkFields` engine itself stays
+data-agnostic (it never reads the cursor), so the pairing is a caller-side helper, not an engine
+change.
+
+- **`DataReconciler`** iterates `source` and matches each element to the target by id. Output order
+  always follows source.
+- **`FieldChunkCollector`** iterates `filteredData` (the reconciler's output: source order, `id`
+  stripped). Its `source` still pairs by position — `filteredData` shares source order 1:1 — but
+  the `id` to match the target with is read off that source element. So `shouldTranslate` now sees
+  the correct target value even when the target locale is reordered.
+
+| Field shape | Source/target ids | Behaviour |
+| --- | --- | --- |
+| Non-localized blocks/array (leaves localized) | Shared (same row across locales) | id-match == old positional match → **unchanged**, and now robust to any ordering. |
+| Localized blocks/array, reordered, ids preserved (e.g. fallback-seeded) | Correspond | Correct element paired regardless of order (was the bug). |
+| Localized blocks/array, independently authored | Diverge | No match → mirror source instead of grafting a different block's values (was silent corruption / wrong skip decision). |
+| Same id, different `blockType` | — | Not the same block → no merge → source fills. |
+
+**Honest limit:** this removes the *corruption / wrong skip*, but it does not make `skip_existing`
+preserve per-block target edits for genuinely-independent localized blocks — there is no identity to
+preserve them by, and the reconciler strips `id` on output (Postgres rejects it on update) so a
+re-translated target gets fresh ids anyway. For independent localized blocks, re-translation
+effectively re-mirrors source. That is the correct, consistent behaviour given no identity.
+
+### 3. Field level: guard, don't pretend (ships with the field-level feature)
+
+When a field's `path` crosses any **localized** `blocks`/`array` ancestor, the per-field translate
+endpoint returns a `noop` with a notice ("this field lives inside a localized block — its position
+may not match the source locale; translate at the document level") instead of resolving the source
+value positionally. Pure `schemaMap` check, no extra DB round-trip. Implemented alongside the
+field-level feature (minor), not in this patch.
+
+## Out of scope
+
+- **Author-managed correlation key** for the genuine "different layout per locale + translate
+  between them" case. Requires the author to maintain a matching key by hand in each locale (it
+  cannot live inside the localized field automatically). Only worth building against a concrete
+  demand; deferred.

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/data-reconciler/DataReconciler.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/data-reconciler/DataReconciler.test.ts
@@ -336,14 +336,32 @@ describe("DataReconciler", () => {
       });
     });
 
-    it("falls back to source when the target array is shorter than source", () => {
+    it("falls back to source for a source element with no id-match in target", () => {
       const schema: Field[] = [{ name: "items", type: "array", fields: [{ name: "label", type: "text", localized: true }] }];
-      const sourceData = { items: [{ label: "A" }, { label: "B" }] };
-      const targetData = { items: [{ label: "T" }] };
+      const sourceData = {
+        items: [
+          { id: "1", label: "A" },
+          { id: "2", label: "B" },
+        ],
+      };
+      const targetData = { items: [{ id: "1", label: "T" }] };
 
       const reconciler = new DataReconciler(schema);
+      // id 1 → target "T" wins; id 2 → no counterpart → source "B"
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
         items: [{ label: "T" }, { label: "B" }],
+      });
+    });
+
+    it("mirrors source when array items carry no id to match on", () => {
+      const schema: Field[] = [{ name: "items", type: "array", fields: [{ name: "label", type: "text", localized: true }] }];
+      const sourceData = { items: [{ label: "A" }, { label: "B" }] };
+      const targetData = { items: [{ label: "T" }, { label: "U" }] };
+
+      const reconciler = new DataReconciler(schema);
+      // No ids on either side → nothing to pair → target is ignored, source fills throughout.
+      expect(reconciler.reconcile(sourceData, targetData)).toEqual({
+        items: [{ label: "A" }, { label: "B" }],
       });
     });
 
@@ -360,6 +378,111 @@ describe("DataReconciler", () => {
       const reconciler = new DataReconciler(schema);
       expect(reconciler.reconcile(sourceData, {})).toEqual({
         layout: [{ id: "1", blockType: "ghost", body: "X" }],
+      });
+    });
+
+    it("ignores the target when the source element id is null", () => {
+      const schema: Field[] = [{ name: "items", type: "array", fields: [{ name: "label", type: "text", localized: true }] }];
+      const sourceData = { items: [{ id: null, label: "A" }] };
+      const targetData = { items: [{ id: null, label: "T" }] };
+
+      const reconciler = new DataReconciler(schema);
+      // id null → no usable key → no match → source fills (target ignored)
+      expect(reconciler.reconcile(sourceData, targetData)).toEqual({ items: [{ label: "A" }] });
+    });
+
+    it("pairs reordered array items by id (output keeps source order)", () => {
+      const schema: Field[] = [{ name: "items", type: "array", fields: [{ name: "label", type: "text", localized: true }] }];
+      const sourceData = {
+        items: [
+          { id: "1", label: "A" },
+          { id: "2", label: "B" },
+        ],
+      };
+      const targetData = {
+        items: [
+          { id: "2", label: "T2" },
+          { id: "1", label: "T1" },
+        ],
+      };
+
+      const reconciler = new DataReconciler(schema);
+      // id 1 ↔ "T1", id 2 ↔ "T2"; output follows source order
+      expect(reconciler.reconcile(sourceData, targetData)).toEqual({ items: [{ label: "T1" }, { label: "T2" }] });
+    });
+
+    it("drops target elements with no source counterpart", () => {
+      const schema: Field[] = [{ name: "items", type: "array", fields: [{ name: "label", type: "text", localized: true }] }];
+      const sourceData = { items: [{ id: "1", label: "A" }] };
+      const targetData = {
+        items: [
+          { id: "1", label: "T" },
+          { id: "2", label: "Extra" },
+        ],
+      };
+
+      const reconciler = new DataReconciler(schema);
+      // output is driven by source → only id 1 survives, id-1 target value wins
+      expect(reconciler.reconcile(sourceData, targetData)).toEqual({ items: [{ label: "T" }] });
+    });
+  });
+
+  describe("cross-locale block identity", () => {
+    const blocksSchema: Field[] = [
+      {
+        name: "layout",
+        type: "blocks",
+        blocks: [
+          { slug: "text", fields: [{ name: "content", type: "text", localized: true }] },
+          { slug: "quote", fields: [{ name: "content", type: "text", localized: true }] },
+        ],
+      },
+    ];
+
+    it("pairs reordered blocks by id, not position (output keeps source order)", () => {
+      const sourceData = {
+        layout: [
+          { id: "1", blockType: "text", content: "Hello" },
+          { id: "2", blockType: "text", content: "World" },
+        ],
+      };
+      // Same blocks, reordered in the target locale (independent per-locale ordering).
+      const targetData = {
+        layout: [
+          { id: "2", blockType: "text", content: "Welt" },
+          { id: "1", blockType: "text", content: "Hallo" },
+        ],
+      };
+
+      const reconciler = new DataReconciler(blocksSchema);
+      // id 1 ↔ "Hallo", id 2 ↔ "Welt"; positional merge would wrongly give block 1 "Welt".
+      expect(reconciler.reconcile(sourceData, targetData)).toEqual({
+        layout: [
+          { blockType: "text", content: "Hallo" },
+          { blockType: "text", content: "Welt" },
+        ],
+      });
+    });
+
+    it("uses source when no target block shares the id (independent localized content)", () => {
+      const sourceData = { layout: [{ id: "en-1", blockType: "text", content: "Hello" }] };
+      const targetData = { layout: [{ id: "fr-9", blockType: "text", content: "Hallo" }] };
+
+      const reconciler = new DataReconciler(blocksSchema);
+      // Ids don't correspond → no merge → mirror source, never graft the other block's value.
+      expect(reconciler.reconcile(sourceData, targetData)).toEqual({
+        layout: [{ blockType: "text", content: "Hello" }],
+      });
+    });
+
+    it("does not merge a target block of a different type that shares an id", () => {
+      const sourceData = { layout: [{ id: "1", blockType: "text", content: "Hello" }] };
+      const targetData = { layout: [{ id: "1", blockType: "quote", content: "Zitat" }] };
+
+      const reconciler = new DataReconciler(blocksSchema);
+      // Same id but different blockType → not the same block → source fills.
+      expect(reconciler.reconcile(sourceData, targetData)).toEqual({
+        layout: [{ blockType: "text", content: "Hello" }],
       });
     });
   });

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/data-reconciler/DataReconciler.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/data-reconciler/DataReconciler.ts
@@ -2,7 +2,7 @@ import type { Field } from "payload";
 
 import { isEmpty, isObject } from "../../../../shared";
 import type { ChildCursor, FieldWalker } from "../../../../shared/field-traversal";
-import { resolveBlockFields, walkFields } from "../../../../shared/field-traversal";
+import { matchElementById, resolveBlockFields, walkFields } from "../../../../shared/field-traversal";
 
 /** Data position for the reconcile walk: the source + target objects at the current level. */
 type Cursor = { source: Record<string, unknown>; target: Record<string, unknown> };
@@ -15,6 +15,9 @@ const asObject = (value: unknown): Record<string, unknown> => (isObject(value) ?
  * no source value is dropped, `id` is stripped from array/block elements (Postgres rejects it
  * on update), `blockType` is preserved, and non-object array items / unknown blocks pass
  * through unchanged.
+ *
+ * Array/block elements are paired with their target counterpart by `id`, not by position (see
+ * {@link matchElementById}); output order always follows `source`.
  */
 const reconcileWalker: FieldWalker<Cursor, unknown> = {
   enterObject(field, cursor) {
@@ -28,13 +31,15 @@ const reconcileWalker: FieldWalker<Cursor, unknown> = {
     if (!Array.isArray(sourceValue)) return "skip";
     const targetValue = cursor.target[field.name];
     const targetArr: unknown[] = Array.isArray(targetValue) ? targetValue : [];
+    const isBlocks = field.type === "blocks";
 
     const children: ChildCursor<Cursor>[] = [];
     sourceValue.forEach((item, index) => {
       if (!isObject(item)) return; // non-object element → passthrough (rebuilt in combine)
-      const fields = field.type === "blocks" ? resolveBlockFields(field, item) : field.fields;
+      const fields = isBlocks ? resolveBlockFields(field, item) : field.fields;
       if (!fields) return; // unknown blockType → passthrough
-      children.push({ cursor: { source: item, target: asObject(targetArr[index]) }, fields, key: index });
+      // Pair by id, not position: target[index] may be a different element under per-locale ordering.
+      children.push({ cursor: { source: item, target: matchElementById(targetArr, item, isBlocks) }, fields, key: index });
     });
     return children;
   },
@@ -48,7 +53,8 @@ const reconcileWalker: FieldWalker<Cursor, unknown> = {
 
   combine(container, children, cursor) {
     if (container.kind === "list") {
-      // Rebuild the full array: reconciled objects where present (by index), raw source items otherwise.
+      // Rebuild the full array in source order: reconciled objects keyed by source position, raw
+      // source items (non-object / unknown block) otherwise.
       const sourceArr = (cursor.source[container.key] ?? []) as unknown[];
       const byIndex = new Map(children.map((child) => [child.key, child.out]));
       return sourceArr.map((item, index) => (byIndex.has(index) ? byIndex.get(index) : item));

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/field-collector/FieldChunkCollector.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/field-collector/FieldChunkCollector.test.ts
@@ -786,6 +786,48 @@ describe("FieldChunkCollector", () => {
       expect(chunks).toHaveLength(1);
       expect(chunks[0].path).toEqual(["layout", "1", "content"]);
     });
+
+    it("pairs the target by id, not position, for reordered localized blocks (SkipExisting)", () => {
+      // Regression: the target locale orders its blocks differently from source. Pairing target by
+      // position would feed shouldTranslate the WRONG block's value — skipping a block that needs
+      // translation and re-translating one that doesn't.
+      const schema: Field[] = [
+        {
+          name: "layout",
+          type: "blocks",
+          blocks: [{ slug: "text", fields: [{ name: "content", type: "text", localized: true }] }],
+        },
+      ];
+      // filteredData is post-reconcile: source order, id stripped, blockType kept.
+      const filteredData = {
+        layout: [
+          { blockType: "text", content: "Hello" },
+          { blockType: "text", content: "World" },
+        ],
+      };
+      const sourceData = {
+        layout: [
+          { id: "1", blockType: "text", content: "Hello" },
+          { id: "2", blockType: "text", content: "World" },
+        ],
+      };
+      // Reordered target: id 2 first (empty → needs translation), id 1 second (already translated).
+      const targetData = {
+        layout: [
+          { id: "2", blockType: "text", content: "" },
+          { id: "1", blockType: "text", content: "Hallo" },
+        ],
+      };
+
+      const collector = new FieldChunkCollector(schema, filteredData, sourceData, targetData, skipExistingStrategy);
+      const chunks = collector.collect();
+
+      // Only id-2's content (source index 1) is collected; id-1 is skipped (its target is non-empty).
+      // Positional pairing would have collected index 0 and skipped index 1 — both wrong.
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].path).toEqual(["layout", "1", "content"]);
+      expect(chunks[0].dataRef.content).toBe("World");
+    });
   });
 
   describe("sourceValue mutation", () => {

--- a/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/field-collector/FieldChunkCollector.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-pipeline/stages/field-collector/FieldChunkCollector.ts
@@ -2,7 +2,7 @@ import type { Field } from "payload";
 
 import { isFieldExcludedFromTranslation, isLocalizedField, isObject, isTranslatableField } from "../../../../shared";
 import type { ChildCursor, FieldWalker } from "../../../../shared/field-traversal";
-import { resolveBlockFields, walkFields } from "../../../../shared/field-traversal";
+import { matchElementById, resolveBlockFields, walkFields } from "../../../../shared/field-traversal";
 import type { TranslationStrategy } from "../../strategies";
 import type { FieldChunk } from "../../types";
 
@@ -22,6 +22,11 @@ const asObject = (value: unknown): Record<string, unknown> => (isObject(value) ?
  * the strategy approves is written with its source value and pushed as a chunk carrying a
  * mutable reference to its parent object (for later write-back). Collect-only — `combine` is a
  * no-op; results accumulate in a closure.
+ *
+ * Array/block elements pair their `source` by position (`filteredData` is built in source order)
+ * but their `target` by `id` (see {@link matchElementById}) — the target locale's elements may be
+ * independently ordered, so a positional target would feed `strategy.shouldTranslate` the wrong
+ * element's value and skip/re-translate the wrong leaf.
  *
  * IMPORTANT: Expects ORIGINAL collection schemas (before Payload sanitization). Original
  * schemas preserve `localized: true` on nested fields.
@@ -65,17 +70,21 @@ export class FieldChunkCollector {
         const targetValue = cursor.target[field.name];
         const sourceArr: unknown[] = Array.isArray(sourceValue) ? sourceValue : [];
         const targetArr: unknown[] = Array.isArray(targetValue) ? targetValue : [];
+        const isBlocks = field.type === "blocks";
 
         const children: ChildCursor<Cursor>[] = [];
         value.forEach((item, index) => {
           if (!isObject(item)) return;
-          const fields = field.type === "blocks" ? resolveBlockFields(field, item) : field.fields;
+          const fields = isBlocks ? resolveBlockFields(field, item) : field.fields;
           if (!fields) return; // unknown blockType → skip element
+          // source pairs by index (filteredData shares source order); target by the source
+          // element's id, since the target locale may be reordered independently.
+          const sourceItem = asObject(sourceArr[index]);
           children.push({
             cursor: {
               data: item,
-              source: asObject(sourceArr[index]),
-              target: asObject(targetArr[index]),
+              source: sourceItem,
+              target: matchElementById(targetArr, sourceItem, isBlocks),
               path: [...cursor.path, field.name, String(index)],
             },
             fields,

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/index.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/index.ts
@@ -1,5 +1,5 @@
 export { findFieldByPath } from "./findFieldByPath";
 export type { FieldPathResult } from "./findFieldByPath";
-export { classifyField, resolveBlockFields, tabScopes } from "./kernel";
+export { classifyField, matchElementById, resolveBlockFields, tabScopes } from "./kernel";
 export type { ChildCursor, ChildOutput, ContainerInfo, FieldStructure, FieldWalker, LeafField, TabScope, WalkSignal } from "./types";
 export { walkFields } from "./walkFields";

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/kernel.test.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/kernel.test.ts
@@ -1,7 +1,7 @@
 import type { ArrayField, BlocksField, Field, NamedGroupField, RowField, TabsField, TextField, UIField } from "payload";
 import { describe, expect, it } from "vitest";
 
-import { classifyField, resolveBlockFields, tabScopes } from "./kernel";
+import { classifyField, matchElementById, resolveBlockFields, tabScopes } from "./kernel";
 
 const text = (name: string, extra: Record<string, unknown> = {}): TextField => ({ name, type: "text", ...extra }) as unknown as TextField;
 
@@ -122,5 +122,34 @@ describe("resolveBlockFields", () => {
   it("returns null for a non-block item", () => {
     expect(resolveBlockFields(field, "not-an-object")).toBeNull();
     expect(resolveBlockFields(field, { noBlockType: true })).toBeNull();
+  });
+});
+
+describe("matchElementById", () => {
+  it("finds the array element with the matching id, regardless of position", () => {
+    const arr = [
+      { id: "2", v: "b" },
+      { id: "1", v: "a" },
+    ];
+    expect(matchElementById(arr, { id: "1" }, false)).toEqual({ id: "1", v: "a" });
+  });
+
+  it("returns {} when no element shares the id", () => {
+    expect(matchElementById([{ id: "1" }], { id: "9" }, false)).toEqual({});
+  });
+
+  it("returns {} when the reference element has no usable id (undefined or null)", () => {
+    expect(matchElementById([{ id: "1" }], {}, false)).toEqual({});
+    expect(matchElementById([{ id: "1" }], { id: null }, false)).toEqual({});
+  });
+
+  it("requires blockType to match too when isBlocks is true", () => {
+    const arr = [{ id: "1", blockType: "quote", v: "x" }];
+    expect(matchElementById(arr, { id: "1", blockType: "text" }, true)).toEqual({}); // same id, wrong type
+    expect(matchElementById(arr, { id: "1", blockType: "quote" }, true)).toEqual({ id: "1", blockType: "quote", v: "x" });
+  });
+
+  it("ignores non-object candidates", () => {
+    expect(matchElementById(["raw", 42, { id: "1", v: "a" }], { id: "1" }, false)).toEqual({ id: "1", v: "a" });
   });
 });

--- a/packages/payload-plugin-translator/src/server/shared/field-traversal/kernel.ts
+++ b/packages/payload-plugin-translator/src/server/shared/field-traversal/kernel.ts
@@ -2,6 +2,7 @@ import type { BlocksField, Field, TabsField } from "payload";
 import { fieldAffectsData, fieldIsArrayType, fieldIsBlockType, fieldIsGroupType, tabHasName } from "payload/shared";
 
 import { hasFields, isBlockItem, isTabsField } from "../guards";
+import { isObject } from "../utils";
 import type { FieldStructure, LeafField, TabScope } from "./types";
 
 /**
@@ -122,4 +123,32 @@ export function resolveBlockFields(field: BlocksField, item: unknown): Field[] |
   if (!isBlockItem(item)) return null;
   const block = field.blocks.find((candidate) => candidate.slug === item.blockType);
   return block ? block.fields : null;
+}
+
+/**
+ * Find the element of a parallel data array that corresponds to `refItem` by `id` — not by
+ * position.
+ *
+ * Localized `blocks`/`array` fields are stored independently per locale, so the locales can be
+ * reordered or differ entirely; pairing two parallel trees by position then cross-contaminates
+ * unrelated elements ("blocks don't line up across locales"). Matching by `id` is correct in both
+ * regimes: a non-localized field is one shared row with the same `id` across locales (so id-match
+ * equals the old positional match), while independent localized content has diverging ids (no
+ * match → the caller falls back to `refItem`'s own values, never another element's). For blocks the
+ * `blockType` must also match, so an id collision across types can't graft mismatched fields.
+ *
+ * Shared by the translation pipeline's two multi-tree walkers — reconcile and collect — to pair
+ * their `target` array against the source/reference element currently being visited.
+ *
+ * @param arr - The array to search (e.g. the target-locale elements).
+ * @param refItem - The element being matched, carrying the canonical `id` (and `blockType`).
+ * @param isBlocks - Whether the field is a `blocks` field (then `blockType` must also match).
+ * @returns The matched element, or `{}` when there is no counterpart (or `refItem` carries no `id`).
+ * @public
+ */
+export function matchElementById(arr: unknown[], refItem: Record<string, unknown>, isBlocks: boolean): Record<string, unknown> {
+  const id = refItem.id;
+  if (id === undefined || id === null) return {};
+  const match = arr.find((candidate) => isObject(candidate) && candidate.id === id && (!isBlocks || candidate.blockType === refItem.blockType));
+  return isObject(match) ? match : {};
 }


### PR DESCRIPTION
## Problem

The translation pipeline paired source/target array & block elements **by position** in two places. When a localized `blocks`/`array` field is reordered or independently authored per locale, position no longer identifies the same element:

- **`DataReconciler`** merged each source block with whatever target block sat at the same index → values leaked between unrelated blocks (`blockType` from one, values from another).
- **`FieldChunkCollector`** fed the wrong element's value into `strategy.shouldTranslate` → under `skip_existing`, a block needing translation was **silently skipped** (a populated, unrelated block sat at its index) and an already-translated one **re-sent**.

Same root cause as the per-field translate control will hit — there is no cross-locale block identity for localized blocks (independent per-locale partitions).

## Fix

Extract one shared helper `matchElementById` into `shared/field-traversal` (beside `resolveBlockFields`), used by **both** pipeline sites: pair the target element by **`id`** (and, for blocks, `blockType`); no match → fall back to source. The `walkFields` engine stays data-agnostic — pairing is caller-side.

| Field shape | Source/target ids | Behaviour |
|---|---|---|
| Non-localized blocks/array (leaves localized) | shared | id-match == old positional → **unchanged**, now order-robust |
| Localized, reordered, ids preserved | correspond | correct element paired regardless of order (**was the bug**) |
| Localized, independently authored | diverge | no match → mirror source, never graft another block's values (**was silent corruption / wrong skip**) |
| Same id, different `blockType` | — | not the same block → source |

**Honest limit:** removes the corruption / wrong-skip; it does **not** make `skip_existing` preserve per-block target edits for genuinely-independent localized blocks — no identity to preserve them by. See the design doc.

## Scope

Document-level pipeline only. The **field-level** per-field control (separate feature) gets its own guard (refuse with a notice under a localized blocks/array ancestor) — tracked in the design doc, ships with that feature.

## Tests / verification

- `matchElementById` unit tests (`kernel.test.ts`)
- reconciler: reorder / independent-ids / different-type / count-mismatch / array reorder / null-id
- collector: **reorder-under-`skip_existing` regression** (collects the right block, skips the right one)
- `check-types` ✓ · `ultracite` ✓ · `vitest` **688 passed**

Design: `packages/payload-plugin-translator/docs/plans/2026-06-12-cross-locale-block-identity.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)