### PR TITLE
chore(seo): mark payload-plugin-seo private until its first publish

### DIFF
--- a/packages/payload-plugin-seo/package.json
+++ b/packages/payload-plugin-seo/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/focusreactive/payload-plugins",
     "directory": "packages/payload-plugin-seo"
   },
-  "private": false,
+  "private": true,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

Temporarily marks `@focus-reactive/payload-plugin-seo` as **`private: true`** so the shared monorepo release stops failing.

## Why

The `Release` workflow has failed on every push to `main` (runs for PRs #31–#36). Root cause: `payload-plugin-seo` is `private: false` (so it's in the release set) but has **never been published to npm** and has no npm Trusted Publisher configured. `@semantic-release/npm` fails `verifyConditions` with `ENONPMTOKEN`, and because `multi-semantic-release` aborts on the first failing package, **nothing publishes** — `payload-plugin-translator` 0.6.0 and the 0.6.1 patch are stuck behind it.

Confirmed not on npm: `npm view @focus-reactive/payload-plugin-seo` → `E404` (no versions at all).

## What this changes

- `private: false → true` → `--ignore-private-packages` drops `seo` from the release set → the run goes green → the other packages (translator) release normally.
- No functional impact inside the monorepo: apps consume `seo` via `workspace:*`, which is unaffected by `private`.
- Fully reversible (one-line revert).

## Follow-up — owner action

@ChiefCreator this is your package. When you're ready to actually publish it, revert to `private: false` **together with**:

1. a one-time manual `npm publish --access public` (creates the package on npm — CI can't do the first publish under the OIDC/Trusted-Publishing model), then
2. configuring npm Trusted Publishing for it (this repo + the `Release` workflow + `main`).

Until then it stays private so it doesn't block everyone else's releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
