### PR TITLE
feature/existing pages analytics

### DIFF
--- a/apps/cms/src/app/(frontend)/[locale]/[...slug]/page.tsx
+++ b/apps/cms/src/app/(frontend)/[locale]/[...slug]/page.tsx
@@ -1,7 +1,10 @@
+import { TrackPage } from "@focus-reactive/payload-plugin-analytics/client";
 import type { Metadata } from "next";
+import { draftMode } from "next/headers";
 import React from "react";
 
 import { RenderBlocks } from "@/blocks/RenderBlocks";
+import { SYNTHETIC_REFS } from "@/core/lib/analytics/SYNTHETIC_REFS";
 import { generateMeta } from "@/core/lib/generateMeta";
 import { generateNotFoundMeta } from "@/core/lib/generateNotFoundMeta";
 import { parseSlugToPath } from "@/core/lib/parseSlugToPath";
@@ -30,13 +33,17 @@ export default async function Page({ params }: Args) {
   }
 
   const page = await getPageBySlug(decodedSegments, locale);
+  const { isEnabled: draft } = await draftMode();
 
   if (!page) {
     return <PayloadRedirects url={url} locale={locale} />;
   }
 
+  const pageRef = decodedSegments[0] === "home" || decodedSegments.length === 0 ? SYNTHETIC_REFS.home : `page:${page.id}`;
+
   return (
     <>
+      <TrackPage pageRef={pageRef} locale={locale} enabled={!draft} />
       <Header data={page.header as HeaderType} />
       <main>
         <div>

--- a/apps/cms/src/app/(frontend)/[locale]/blog/[slug]/page.tsx
+++ b/apps/cms/src/app/(frontend)/[locale]/blog/[slug]/page.tsx
@@ -1,4 +1,6 @@
+import { TrackPage } from "@focus-reactive/payload-plugin-analytics/client";
 import type { Metadata } from "next";
+import { draftMode } from "next/headers";
 import React from "react";
 
 import { generateMeta } from "@/core/lib/generateMeta";
@@ -31,9 +33,11 @@ export default async function Page({ params }: Args) {
   if (!post) {
     return <PayloadRedirects url={url} locale={locale} />;
   }
+  const { isEnabled: draft } = await draftMode();
 
   return (
     <>
+      <TrackPage collection="posts" id={post.id} locale={locale} enabled={!draft} />
       <Header data={siteSettings.header as HeaderType} />
       <main>
         <ArticleJsonLd post={post} siteName={siteSettings.siteName as string} locale={locale} />

--- a/apps/cms/src/app/(frontend)/[locale]/blog/page.tsx
+++ b/apps/cms/src/app/(frontend)/[locale]/blog/page.tsx
@@ -1,7 +1,10 @@
+import { TrackPage } from "@focus-reactive/payload-plugin-analytics/client";
 import type { Metadata } from "next/types";
+import { draftMode } from "next/headers";
 import React, { Suspense } from "react";
 
 import { BLOG_CONFIG } from "@/core/config/blog";
+import { SYNTHETIC_REFS } from "@/core/lib/analytics/SYNTHETIC_REFS";
 import { I18N_CONFIG } from "@/core/config/i18n";
 import { generateMeta } from "@/core/lib/generateMeta";
 import type { Locale } from "@/core/types";
@@ -29,11 +32,13 @@ export const experimental_ppr = true;
 
 export default async function Page({ searchParams, params }: Props) {
   const { locale } = await params;
+  const { isEnabled: draft } = await draftMode();
 
   const siteSettings = await getSiteSettings({ locale });
 
   return (
     <>
+      <TrackPage pageRef={SYNTHETIC_REFS.blogIndex} locale={locale} enabled={!draft} />
       <Header data={siteSettings.header as HeaderType} />
       <main>
         <Suspense>

--- a/apps/cms/src/app/(frontend)/[locale]/search/page.tsx
+++ b/apps/cms/src/app/(frontend)/[locale]/search/page.tsx
@@ -1,6 +1,9 @@
+import { TrackPage } from "@focus-reactive/payload-plugin-analytics/client";
 import type { Metadata } from "next";
+import { draftMode } from "next/headers";
 import { Suspense } from "react";
 
+import { SYNTHETIC_REFS } from "@/core/lib/analytics/SYNTHETIC_REFS";
 import type { Locale } from "@/core/types";
 import { getSiteSettings } from "@/dal/getSiteSettings";
 import type { Footer as FooterType, Header as HeaderType } from "@/payload-types";
@@ -17,10 +20,12 @@ interface Args {
 export default async function SearchPage({ params, searchParams }: Args) {
   const [{ locale }, { query: rawQuery }] = await Promise.all([params, searchParams]);
   const query = rawQuery && decodeURIComponent(rawQuery);
+  const { isEnabled: draft } = await draftMode();
   const siteSettings = await getSiteSettings({ locale });
 
   return (
     <div className="flex min-h-screen flex-col">
+      <TrackPage pageRef={SYNTHETIC_REFS.search} locale={locale} enabled={!draft} />
       <Header data={siteSettings.header as HeaderType} />
       <main className="grow">
         <div className="mx-auto max-w-2xl px-4 py-8">

--- a/apps/cms/src/core/lib/analytics/AnalyticsProviderClient.tsx
+++ b/apps/cms/src/core/lib/analytics/AnalyticsProviderClient.tsx
@@ -9,5 +9,9 @@ interface AnalyticsProviderClientProps {
 }
 
 export function AnalyticsProviderClient({ measurementId, children }: AnalyticsProviderClientProps) {
-  return <AnalyticsProvider provider={ga4Provider({ measurementId })}>{children}</AnalyticsProvider>;
+  return (
+    <AnalyticsProvider provider={ga4Provider({ measurementId })} trackRouteChanges={false}>
+      {children}
+    </AnalyticsProvider>
+  );
 }

--- a/apps/cms/src/core/lib/analytics/SYNTHETIC_REFS.ts
+++ b/apps/cms/src/core/lib/analytics/SYNTHETIC_REFS.ts
@@ -1,0 +1,5 @@
+export const SYNTHETIC_REFS = {
+  home: "__home",
+  blogIndex: "__blog-index",
+  search: "__search",
+} as const;

--- a/apps/cms/src/plugins/index.ts
+++ b/apps/cms/src/plugins/index.ts
@@ -262,6 +262,10 @@ export const plugins: Plugin[] = [
     ab: {
       experimentsCollectionSlug: "ab-experiments",
     },
+    pages: {
+      collections: ["page", "posts"],
+      syntheticRefs: ["__home", "__blog-index", "__search"],
+    },
   }),
 
   visualEditingPlugin({

--- a/apps/cms/src/plugins/index.ts
+++ b/apps/cms/src/plugins/index.ts
@@ -8,7 +8,7 @@ import { visualEditingPlugin } from "@fr-private/payload-plugin-visual-editing";
 import { nestedDocsPlugin } from "@payloadcms/plugin-nested-docs";
 import { redirectsPlugin } from "@payloadcms/plugin-redirects";
 import { vercelBlobStorage } from "@payloadcms/storage-vercel-blob";
-import type { Field, Plugin } from "payload";
+import type { Field, PayloadRequest, Plugin } from "payload";
 
 import { Authors } from "@/collections/Authors";
 import { Categories } from "@/collections/Categories";
@@ -17,6 +17,7 @@ import { Header } from "@/collections/Header/config";
 import { Page as PageCollection } from "@/collections/Page/Page";
 import { Posts } from "@/collections/Posts";
 import { Testimonials } from "@/collections/Testimonials";
+import { CUSTOM_PAGES_CONFIG } from "@/core/config/customPages";
 import { I18N_CONFIG } from "@/core/config/i18n";
 import { abAdapter } from "@/core/lib/abTesting/abAdapter";
 import { buildVariantData } from "@/core/lib/abTesting/buildVariantData";
@@ -25,12 +26,67 @@ import { superAdmin, or, authenticated, user } from "@/core/lib/access";
 import { shouldIncludeLocalePrefix } from "@/core/lib/localePrefix";
 import { validateRedirectPath } from "@/core/lib/redirectUrl";
 import { isDev } from "@/core/utils/isDev";
+import { buildUrl } from "@/core/utils/path/buildUrl";
 import { normalizeRedirectFields } from "@/hooks/normalizeRedirectFields";
 import { revalidateRedirects } from "@/hooks/revalidateRedirects";
 import type { Page } from "@/payload-types";
 
 import { mcpPluginConfig } from "./mcp";
 import seoPlugin from "./seoPlugin";
+
+const resolveAnalyticsPagePath = async (ref: string, req: PayloadRequest): Promise<string> => {
+  const { defaultLocale } = I18N_CONFIG;
+
+  if (ref === "__home") return "/";
+  if (ref === "__blog-index") return CUSTOM_PAGES_CONFIG.blog.resolver(defaultLocale);
+  if (ref === "__search") return CUSTOM_PAGES_CONFIG.search.resolver(defaultLocale);
+
+  const idx = ref.indexOf(":");
+  if (idx <= 0) return "";
+
+  const collection = ref.slice(0, idx);
+  const id = ref.slice(idx + 1);
+
+  if (collection === "page") {
+    const doc = await req.payload
+      .findByID({
+        collection: "page",
+        id,
+        depth: 0,
+        overrideAccess: true,
+      })
+      .catch(() => null);
+
+    return (
+      buildUrl({
+        collection: "page",
+        breadcrumbs: doc?.breadcrumbs,
+        absolute: false,
+        locale: defaultLocale,
+      }) || "/"
+    );
+  }
+
+  if (collection === "posts") {
+    const doc = await req.payload
+      .findByID({
+        collection: "posts",
+        id,
+        depth: 0,
+        overrideAccess: true,
+      })
+      .catch(() => null);
+
+    return buildUrl({
+      collection: "posts",
+      slug: doc?.slug,
+      absolute: false,
+      locale: defaultLocale,
+    });
+  }
+
+  return "";
+};
 
 export const plugins: Plugin[] = [
   vercelBlobStorage({
@@ -265,6 +321,7 @@ export const plugins: Plugin[] = [
     pages: {
       collections: ["page", "posts"],
       syntheticRefs: ["__home", "__blog-index", "__search"],
+      resolvePagePath: resolveAnalyticsPagePath,
     },
   }),
 

--- a/apps/dev/src/app/(frontend)/AnalyticsProviderClient.tsx
+++ b/apps/dev/src/app/(frontend)/AnalyticsProviderClient.tsx
@@ -9,5 +9,9 @@ interface AnalyticsProviderClientProps {
 }
 
 export function AnalyticsProviderClient({ measurementId, children }: AnalyticsProviderClientProps) {
-  return <AnalyticsProvider provider={ga4Provider({ measurementId })}>{children}</AnalyticsProvider>;
+  return (
+    <AnalyticsProvider provider={ga4Provider({ measurementId })} trackRouteChanges={false}>
+      {children}
+    </AnalyticsProvider>
+  );
 }

--- a/apps/dev/src/app/(frontend)/SYNTHETIC_REFS.ts
+++ b/apps/dev/src/app/(frontend)/SYNTHETIC_REFS.ts
@@ -1,0 +1,3 @@
+export const SYNTHETIC_REFS = {
+  home: "__home",
+} as const;

--- a/apps/dev/src/app/(frontend)/[slug]/page.tsx
+++ b/apps/dev/src/app/(frontend)/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { TrackPage } from "@focus-reactive/payload-plugin-analytics/client";
 import { notFound } from "next/navigation";
 import { getPayload } from "payload";
 import React from "react";
@@ -26,5 +27,10 @@ export default async function Page({ params }: Props) {
     notFound();
   }
 
-  return <PageClient initialData={page as any} serverURL={process.env.NEXT_PUBLIC_SERVER_URL ?? ""} />;
+  return (
+    <>
+      <TrackPage collection="pages" id={page.id} locale="en" />
+      <PageClient initialData={page as any} serverURL={process.env.NEXT_PUBLIC_SERVER_URL ?? ""} />
+    </>
+  );
 }

--- a/apps/dev/src/app/(frontend)/page.tsx
+++ b/apps/dev/src/app/(frontend)/page.tsx
@@ -1,10 +1,11 @@
+import { TrackPage } from "@focus-reactive/payload-plugin-analytics/client";
 import { headers as getHeaders } from "next/headers.js";
 import Image from "next/image";
 import { getPayload } from "payload";
-import React from "react";
 
 import config from "@/payload.config";
 import { AnalyticsDemo } from "./AnalyticsDemo";
+import { SYNTHETIC_REFS } from "./SYNTHETIC_REFS";
 import "./styles.css";
 
 export default async function HomePage() {
@@ -17,6 +18,7 @@ export default async function HomePage() {
 
   return (
     <div className="home">
+      <TrackPage pageRef={SYNTHETIC_REFS.home} locale="en" />
       <div className="content">
         <picture>
           <source srcSet="https://raw.githubusercontent.com/payloadcms/payload/main/packages/ui/src/assets/payload-favicon.svg" />

--- a/apps/dev/src/components/blocks/HeroSection.tsx
+++ b/apps/dev/src/components/blocks/HeroSection.tsx
@@ -1,3 +1,4 @@
+import { TrackLeadAction } from "@focus-reactive/payload-plugin-analytics/client";
 import React from "react";
 
 interface Cta {
@@ -26,9 +27,11 @@ export function HeroSection({ title, description, image, cta }: Props) {
       {cta && cta.length > 0 && (
         <div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
           {cta.map((item, i) => (
-            <a href={item.url} key={i} style={{ background: "#111", borderRadius: 6, color: "#fff", padding: "10px 20px", textDecoration: "none" }}>
-              {item.label}
-            </a>
+            <TrackLeadAction key={i} on="click" type="hero_cta_click" payload={{ label: item.label, position: i, url: item.url }}>
+              <a href={item.url} style={{ background: "#111", borderRadius: 6, color: "#fff", padding: "10px 20px", textDecoration: "none" }}>
+                {item.label}
+              </a>
+            </TrackLeadAction>
           ))}
         </div>
       )}

--- a/apps/dev/src/lead-actions-admin.tsx
+++ b/apps/dev/src/lead-actions-admin.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { createLeadActionRegistry } from "@focus-reactive/payload-plugin-analytics/client";
-import { Zap } from "lucide-react";
+import { MousePointerClick, Zap } from "lucide-react";
 
 export default createLeadActionRegistry({
   cta_pricing_click: { icon: Zap, label: "Pricing CTA" },
+  hero_cta_click: { icon: MousePointerClick, label: "Hero CTA" },
 });

--- a/apps/dev/src/payload.config.ts
+++ b/apps/dev/src/payload.config.ts
@@ -115,16 +115,36 @@ export default buildConfig({
       pages: {
         collections: ["pages"],
         syntheticRefs: ["__home"],
+        resolvePagePath: async (ref, req) => {
+          if (ref === "__home") return "/";
+
+          const [collection, id] = ref.split(":");
+          if (collection !== "pages" || !id) return "";
+
+          const doc = await req.payload.findByID({ collection: "pages", id, depth: 0, overrideAccess: true }).catch(() => null);
+          const slug = (doc as { slug?: string } | null)?.slug;
+
+          return slug ? `/${slug}` : "";
+        },
       },
+      mocks: true,
     }),
     seoPlugin({
       collections: [
         {
           slug: "pages",
-          fields: { seoTitle: "seoTitle", metaDescription: "metaDescription", slug: "slug", content: "sections" },
+          fields: {
+            seoTitle: "seoTitle",
+            metaDescription: "metaDescription",
+            slug: "slug",
+            content: "sections",
+          },
         },
       ],
-      site: { name: "Dev Site", baseUrl: process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:3000" },
+      site: {
+        name: "Dev Site",
+        baseUrl: process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:3000",
+      },
       supportedLocales: ["en", "de", "fr", "es"],
     }),
   ],

--- a/apps/dev/src/payload.config.ts
+++ b/apps/dev/src/payload.config.ts
@@ -106,11 +106,15 @@ export default buildConfig({
         },
       },
       leadActions: {
-        types: ["phone_click", "email_click", "directions_click", "whatsapp_click", "telegram_click", "website_click", "booking_click", "form_submit", "cta_pricing_click"],
+        types: ["phone_click", "email_click", "directions_click", "whatsapp_click", "telegram_click", "website_click", "booking_click", "form_submit", "cta_pricing_click", "hero_cta_click"],
         adminRegistry: "@/lead-actions-admin#default",
       },
       ab: {
         variantFields: { name: "title" },
+      },
+      pages: {
+        collections: ["pages"],
+        syntheticRefs: ["__home"],
       },
     }),
     seoPlugin({

--- a/packages/payload-plugin-analytics/src/client/Track/TrackPage.tsx
+++ b/packages/payload-plugin-analytics/src/client/Track/TrackPage.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAnalyticsProvider } from "../hooks/useAnalytics";
+import { setPageContext } from "../pageContext/store";
+import { formatPageRef } from "../../utils/page/formatPageRef";
+import { getPagePath } from "../../utils/page/getPagePath";
+
+type TrackPageProps = {
+  locale: string;
+  path?: string;
+  enabled?: boolean;
+} & ({ pageRef: string; collection?: never; id?: never } | { collection: string; id: string | number; pageRef?: never });
+
+export function TrackPage(props: TrackPageProps) {
+  const { locale, path, enabled = true } = props;
+  const provider = useAnalyticsProvider();
+  const pageRef = props.pageRef === undefined ? formatPageRef(props.collection, props.id) : props.pageRef;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const resolvedPath = path ?? (typeof window === "undefined" ? "" : getPagePath(window.location.pathname, window.location.search));
+
+    setPageContext({ pageRef, locale });
+    provider.pageView(resolvedPath);
+  }, [enabled, pageRef, locale, path, provider]);
+
+  return null;
+}

--- a/packages/payload-plugin-analytics/src/client/index.ts
+++ b/packages/payload-plugin-analytics/src/client/index.ts
@@ -4,6 +4,7 @@ export { AnalyticsProvider } from "./AnalyticsProvider";
 export type { AnalyticsProviderProps } from "./AnalyticsProvider";
 export { useLeadActionTypes } from "./AnalyticsProvider/LeadActionTypesContext";
 export { Track } from "./Track";
+export { TrackPage } from "./Track/TrackPage";
 export { TrackLeadAction } from "./Track/TrackLeadAction";
 export type { TrackLeadActionProps } from "./Track/TrackLeadAction";
 export { useAnalytics } from "./hooks/useAnalytics";

--- a/packages/payload-plugin-analytics/src/client/pageContext/store.ts
+++ b/packages/payload-plugin-analytics/src/client/pageContext/store.ts
@@ -1,0 +1,18 @@
+export interface PageContext {
+  pageRef: string;
+  locale: string;
+}
+
+let current: PageContext | null = null;
+
+export function setPageContext(ctx: PageContext): void {
+  current = ctx;
+}
+
+export function getPageContext(): PageContext | null {
+  return current;
+}
+
+export function clearPageContext(): void {
+  current = null;
+}

--- a/packages/payload-plugin-analytics/src/components/AnalyticsView/ui/SetupRequiredCard.tsx
+++ b/packages/payload-plugin-analytics/src/components/AnalyticsView/ui/SetupRequiredCard.tsx
@@ -7,6 +7,8 @@ const KEY_COPY: Record<CustomRegistrationKey, string> = {
   fr_elapsed_ms: "Register `fr_elapsed_ms` as a Standard custom metric (Milliseconds) in GA4 Admin.",
   fr_session_start: "Register `fr_session_start` as a custom dimension (event-scoped) in GA4 Admin.",
   fr_lead_type: "Register `fr_lead_type` as a custom dimension (event-scoped) in GA4 Admin to enable lead-action breakdowns.",
+  fr_page_ref: "Register `fr_page_ref` as a custom dimension (event-scoped) in GA4 Admin to scope analytics to existing pages.",
+  fr_content_locale: "Register `fr_content_locale` as a custom dimension (event-scoped) in GA4 Admin to enable per-locale page analytics.",
 };
 
 const SETUP_GUIDE_URL = "https://github.com/focusreactive/payload-plugins/blob/main/packages/payload-plugin-analytics/docs/setup-ga4.md#stage-3-custom-registrations";

--- a/packages/payload-plugin-analytics/src/components/AnalyticsView/ui/SetupWarningIcon.tsx
+++ b/packages/payload-plugin-analytics/src/components/AnalyticsView/ui/SetupWarningIcon.tsx
@@ -7,6 +7,8 @@ const SETUP_COPY: Record<CustomRegistrationKey, string> = {
   fr_event_seq: "Register `fr_event_seq` as a custom dimension to enable within-minute event ordering.",
   fr_session_start: "Register `fr_session_start` as an event-scoped custom dimension to populate session start time.",
   fr_lead_type: "Register `fr_lead_type` as an event-scoped custom dimension to track lead action types.",
+  fr_page_ref: "Register `fr_page_ref` as an event-scoped custom dimension to scope analytics to existing pages.",
+  fr_content_locale: "Register `fr_content_locale` as an event-scoped custom dimension to enable per-locale page analytics.",
 };
 
 const SETUP_GUIDE_URL = "https://github.com/focusreactive/payload-plugins/blob/main/packages/payload-plugin-analytics/docs/setup-ga4.md#stage-3-custom-registrations";

--- a/packages/payload-plugin-analytics/src/config.ts
+++ b/packages/payload-plugin-analytics/src/config.ts
@@ -1,4 +1,6 @@
 import { PLUGIN_NAME } from "./constants";
+import { resolvePagesConfig } from './config/resolvePagesConfig';
+import type { ResolvedPagesConfig } from './config/resolvePagesConfig';
 import type { AnalyticsPluginConfig } from "./types/config";
 import type { BlockDefinition, BlockId, ResolvedLayout } from "./types/layout";
 
@@ -45,4 +47,8 @@ export function getResolvedBlockRegistry(): Record<BlockId, BlockDefinition> {
   }
 
   return registry;
+}
+
+export function getResolvedPagesConfig(): ResolvedPagesConfig | null {
+  return resolvePagesConfig(getPluginConfig().pages);
 }

--- a/packages/payload-plugin-analytics/src/config/resolvePagesConfig.ts
+++ b/packages/payload-plugin-analytics/src/config/resolvePagesConfig.ts
@@ -1,0 +1,21 @@
+import type { PagesAnalyticsConfig, PagesCollectionConfig } from "../types/config";
+import { DEFAULT_PAGE_DIMENSIONS } from "../constants/page";
+
+export interface ResolvedPagesConfig {
+  collections: Required<PagesCollectionConfig>[];
+  syntheticRefs: string[];
+  dimensions: { pageRef: string; contentLocale: string };
+}
+
+export function resolvePagesConfig(pages: PagesAnalyticsConfig | undefined): ResolvedPagesConfig | null {
+  if (!pages) return null;
+
+  return {
+    collections: pages.collections.map((c) => (typeof c === "string" ? { slug: c, publishedOnly: true } : { slug: c.slug, publishedOnly: c.publishedOnly ?? true })),
+    syntheticRefs: pages.syntheticRefs ?? [],
+    dimensions: {
+      pageRef: pages.dimensions?.pageRef ?? DEFAULT_PAGE_DIMENSIONS.pageRef,
+      contentLocale: pages.dimensions?.contentLocale ?? DEFAULT_PAGE_DIMENSIONS.contentLocale,
+    },
+  };
+}

--- a/packages/payload-plugin-analytics/src/config/resolvePagesConfig.ts
+++ b/packages/payload-plugin-analytics/src/config/resolvePagesConfig.ts
@@ -1,21 +1,26 @@
+import type { PayloadRequest } from "payload";
 import type { PagesAnalyticsConfig, PagesCollectionConfig } from "../types/config";
 import { DEFAULT_PAGE_DIMENSIONS } from "../constants/page";
 
 export interface ResolvedPagesConfig {
-  collections: Required<PagesCollectionConfig>[];
+  collections: Array<Required<Omit<PagesCollectionConfig, "titleField">> & { titleField: string }>;
   syntheticRefs: string[];
   dimensions: { pageRef: string; contentLocale: string };
+  resolvePagePath?: (ref: string, req: PayloadRequest) => string | Promise<string>;
 }
 
 export function resolvePagesConfig(pages: PagesAnalyticsConfig | undefined): ResolvedPagesConfig | null {
   if (!pages) return null;
 
   return {
-    collections: pages.collections.map((c) => (typeof c === "string" ? { slug: c, publishedOnly: true } : { slug: c.slug, publishedOnly: c.publishedOnly ?? true })),
+    collections: pages.collections.map((c) =>
+      typeof c === "string" ? { slug: c, publishedOnly: true, titleField: "title" } : { slug: c.slug, publishedOnly: c.publishedOnly ?? true, titleField: c.titleField ?? "title" }
+    ),
     syntheticRefs: pages.syntheticRefs ?? [],
     dimensions: {
       pageRef: pages.dimensions?.pageRef ?? DEFAULT_PAGE_DIMENSIONS.pageRef,
       contentLocale: pages.dimensions?.contentLocale ?? DEFAULT_PAGE_DIMENSIONS.contentLocale,
     },
+    resolvePagePath: pages.resolvePagePath,
   };
 }

--- a/packages/payload-plugin-analytics/src/constants/page.ts
+++ b/packages/payload-plugin-analytics/src/constants/page.ts
@@ -1,0 +1,11 @@
+export const PAGE_PARAM_KEYS = {
+  pageRef: "fr_page_ref",
+  contentLocale: "fr_content_locale",
+} as const;
+
+export const SYNTHETIC_REF_PREFIX = "__" as const;
+
+export const DEFAULT_PAGE_DIMENSIONS = {
+  pageRef: `customEvent:${PAGE_PARAM_KEYS.pageRef}`,
+  contentLocale: `customEvent:${PAGE_PARAM_KEYS.contentLocale}`,
+} as const;

--- a/packages/payload-plugin-analytics/src/endpoints/errorMapping.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/errorMapping.ts
@@ -1,4 +1,5 @@
 import type { CustomRegistrationKey } from "../types/query";
+import { CUSTOM_KEY_PATTERNS } from "../utils/ga4/deriveMissing";
 
 export interface MappedGa4Error {
   status: number;
@@ -7,24 +8,58 @@ export interface MappedGa4Error {
   missingKey?: CustomRegistrationKey;
 }
 
-const MISSING_KEY_PATTERNS: Array<{ key: CustomRegistrationKey; regex: RegExp }> = [
-  { key: "fr_session_id", regex: /customEvent:fr_session_id/u },
-  { key: "fr_event_seq", regex: /customEvent:fr_event_seq/u },
-  { key: "fr_elapsed_ms", regex: /(?:average)?[cC]ustomEvent:fr_elapsed_ms/u },
-  { key: "fr_session_start", regex: /customEvent:fr_session_start/u },
-  { key: "fr_lead_type", regex: /customEvent:fr_lead_type/u },
-];
-
 function deriveMissingKey(msg: string): CustomRegistrationKey | undefined {
-  for (const { key, regex } of MISSING_KEY_PATTERNS) {
+  for (const { key, regex } of CUSTOM_KEY_PATTERNS) {
     if (regex.test(msg)) return key;
   }
 
   return undefined;
 }
 
+function detailToString(detail: unknown): string {
+  if (typeof detail === "string") return detail;
+
+  if (Array.isArray(detail)) {
+    return detail
+      .map((d) => {
+        if (typeof d === "string") return d;
+        if (d && typeof d === "object") {
+          const obj = d as Record<string, unknown>;
+          const candidate = obj.description ?? obj.message ?? obj.detail ?? obj.reason;
+          if (typeof candidate === "string") return candidate;
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("; ");
+  }
+
+  return "";
+}
+
+function enrichMessage(err: unknown): string {
+  const base = err instanceof Error ? err.message : String(err);
+
+  if (!err || typeof err !== "object") return base;
+
+  const carriers = err as Record<string, unknown>;
+  const detailStrings = [carriers.details, carriers.statusDetails, carriers.metadata].map(detailToString).filter(Boolean);
+
+  if (detailStrings.length === 0) return base;
+
+  const detailText = detailStrings.join("; ");
+
+  const baseHasField = deriveMissingKey(base) !== undefined;
+  const trimmedBase = base.trim();
+  const baseLacksDetail = trimmedBase === "" || trimmedBase.endsWith(":");
+
+  if (baseHasField) return `${base} (${detailText})`;
+  if (baseLacksDetail) return `${base}${detailText}`;
+  return `${base} ${detailText}`;
+}
+
 export function mapGa4Error(err: unknown): MappedGa4Error {
-  const msg = err instanceof Error ? err.message : String(err);
+  const msg = enrichMessage(err);
 
   if (msg.includes("INVALID_ARGUMENT")) {
     const missingKey = deriveMissingKey(msg);

--- a/packages/payload-plugin-analytics/src/endpoints/journeys.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/journeys.ts
@@ -1,6 +1,8 @@
 import type { Endpoint } from "payload";
 import { ANALYTICS_ENDPOINT_PATHS } from "../constants/endpoints";
 import { getJourneys } from "../services/queries/getJourneys";
+import { getResolvedPagesConfig } from "../config";
+import { buildPageFilterContext } from "../services/pageFilter/buildPageFilterContext";
 import { JourneysQuerySchema, formatZodIssues } from "./validateBody";
 import { mapGa4Error } from "./errorMapping";
 import { withAccess } from "./withAccess";
@@ -25,7 +27,8 @@ export function buildJourneysEndpoint(config: AnalyticsPluginConfig): Endpoint {
       }
 
       try {
-        const result = await getJourneys(config.ga4.propertyId, parsed.data);
+        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const result = await getJourneys(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);
       } catch (err) {

--- a/packages/payload-plugin-analytics/src/endpoints/journeys.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/journeys.ts
@@ -27,7 +27,7 @@ export function buildJourneysEndpoint(config: AnalyticsPluginConfig): Endpoint {
       }
 
       try {
-        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const pageFilter = await buildPageFilterContext(req, getResolvedPagesConfig());
         const result = await getJourneys(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);

--- a/packages/payload-plugin-analytics/src/endpoints/kpis.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/kpis.ts
@@ -1,6 +1,8 @@
 import type { Endpoint } from "payload";
 import { ANALYTICS_ENDPOINT_PATHS } from "../constants/endpoints";
 import { getKpis } from "../services/queries/getKpis";
+import { getResolvedPagesConfig } from "../config";
+import { buildPageFilterContext } from "../services/pageFilter/buildPageFilterContext";
 import { AnalyticsQuerySchema, formatZodIssues } from "./validateBody";
 import { mapGa4Error } from "./errorMapping";
 import { withAccess } from "./withAccess";
@@ -25,7 +27,8 @@ export function buildKpisEndpoint(config: AnalyticsPluginConfig): Endpoint {
       }
 
       try {
-        const result = await getKpis(config.ga4.propertyId, parsed.data);
+        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const result = await getKpis(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);
       } catch (err) {

--- a/packages/payload-plugin-analytics/src/endpoints/kpis.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/kpis.ts
@@ -27,7 +27,7 @@ export function buildKpisEndpoint(config: AnalyticsPluginConfig): Endpoint {
       }
 
       try {
-        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const pageFilter = await buildPageFilterContext(req, getResolvedPagesConfig());
         const result = await getKpis(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);

--- a/packages/payload-plugin-analytics/src/endpoints/leadActions.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/leadActions.ts
@@ -1,6 +1,8 @@
 import type { Endpoint } from "payload";
 import { ANALYTICS_ENDPOINT_PATHS } from "../constants/endpoints";
 import { getLeadActions } from "../services/queries/getLeadActions";
+import { getResolvedPagesConfig } from "../config";
+import { buildPageFilterContext } from "../services/pageFilter/buildPageFilterContext";
 import { AnalyticsQuerySchema, formatZodIssues } from "./validateBody";
 import { mapGa4Error } from "./errorMapping";
 import { withAccess } from "./withAccess";
@@ -25,7 +27,8 @@ export function buildLeadActionsEndpoint(config: AnalyticsPluginConfig): Endpoin
       }
 
       try {
-        const result = await getLeadActions(config.ga4.propertyId, parsed.data);
+        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const result = await getLeadActions(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);
       } catch (err) {

--- a/packages/payload-plugin-analytics/src/endpoints/leadActions.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/leadActions.ts
@@ -27,7 +27,7 @@ export function buildLeadActionsEndpoint(config: AnalyticsPluginConfig): Endpoin
       }
 
       try {
-        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const pageFilter = await buildPageFilterContext(req, getResolvedPagesConfig());
         const result = await getLeadActions(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);

--- a/packages/payload-plugin-analytics/src/endpoints/sessionDetail.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/sessionDetail.ts
@@ -43,7 +43,7 @@ export function buildSessionDetailEndpoint(config: AnalyticsPluginConfig): Endpo
       }
 
       try {
-        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const pageFilter = await buildPageFilterContext(req, getResolvedPagesConfig());
         const result = await getSessionDetail(config.ga4.propertyId, sessionId, parsed.data, pageFilter);
 
         return Response.json(result);

--- a/packages/payload-plugin-analytics/src/endpoints/sessionDetail.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/sessionDetail.ts
@@ -1,6 +1,8 @@
 import type { Endpoint, PayloadRequest } from "payload";
 import { ANALYTICS_ENDPOINT_PATHS } from "../constants/endpoints";
 import { getSessionDetail } from "../services/queries/getSessionDetail";
+import { getResolvedPagesConfig } from "../config";
+import { buildPageFilterContext } from "../services/pageFilter/buildPageFilterContext";
 import { AnalyticsQuerySchema, formatZodIssues } from "./validateBody";
 import { mapGa4Error } from "./errorMapping";
 import { withAccess } from "./withAccess";
@@ -41,7 +43,8 @@ export function buildSessionDetailEndpoint(config: AnalyticsPluginConfig): Endpo
       }
 
       try {
-        const result = await getSessionDetail(config.ga4.propertyId, sessionId, parsed.data);
+        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const result = await getSessionDetail(config.ga4.propertyId, sessionId, parsed.data, pageFilter);
 
         return Response.json(result);
       } catch (err) {

--- a/packages/payload-plugin-analytics/src/endpoints/sessions.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/sessions.ts
@@ -27,7 +27,7 @@ export function buildSessionsEndpoint(config: AnalyticsPluginConfig): Endpoint {
       }
 
       try {
-        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const pageFilter = await buildPageFilterContext(req, getResolvedPagesConfig());
         const result = await listSessions(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);

--- a/packages/payload-plugin-analytics/src/endpoints/sessions.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/sessions.ts
@@ -1,6 +1,8 @@
 import type { Endpoint } from "payload";
 import { ANALYTICS_ENDPOINT_PATHS } from "../constants/endpoints";
 import { listSessions } from "../services/queries/listSessions";
+import { getResolvedPagesConfig } from "../config";
+import { buildPageFilterContext } from "../services/pageFilter/buildPageFilterContext";
 import { SessionsListQuerySchema, formatZodIssues } from "./validateBody";
 import { mapGa4Error } from "./errorMapping";
 import { withAccess } from "./withAccess";
@@ -25,7 +27,8 @@ export function buildSessionsEndpoint(config: AnalyticsPluginConfig): Endpoint {
       }
 
       try {
-        const result = await listSessions(config.ga4.propertyId, parsed.data);
+        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const result = await listSessions(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);
       } catch (err) {

--- a/packages/payload-plugin-analytics/src/endpoints/topCountries.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/topCountries.ts
@@ -1,6 +1,8 @@
 import type { Endpoint } from "payload";
 import { ANALYTICS_ENDPOINT_PATHS } from "../constants/endpoints";
 import { getTopCountries } from "../services/queries/getTopCountries";
+import { getResolvedPagesConfig } from "../config";
+import { buildPageFilterContext } from "../services/pageFilter/buildPageFilterContext";
 import { TopCountriesQuerySchema, formatZodIssues } from "./validateBody";
 import { mapGa4Error } from "./errorMapping";
 import { withAccess } from "./withAccess";
@@ -25,7 +27,8 @@ export function buildTopCountriesEndpoint(config: AnalyticsPluginConfig): Endpoi
       }
 
       try {
-        const result = await getTopCountries(config.ga4.propertyId, parsed.data);
+        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const result = await getTopCountries(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);
       } catch (err) {

--- a/packages/payload-plugin-analytics/src/endpoints/topCountries.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/topCountries.ts
@@ -27,7 +27,7 @@ export function buildTopCountriesEndpoint(config: AnalyticsPluginConfig): Endpoi
       }
 
       try {
-        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const pageFilter = await buildPageFilterContext(req, getResolvedPagesConfig());
         const result = await getTopCountries(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);

--- a/packages/payload-plugin-analytics/src/endpoints/topDevices.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/topDevices.ts
@@ -27,7 +27,7 @@ export function buildTopDevicesEndpoint(config: AnalyticsPluginConfig): Endpoint
       }
 
       try {
-        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const pageFilter = await buildPageFilterContext(req, getResolvedPagesConfig());
         const result = await getTopDevices(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);

--- a/packages/payload-plugin-analytics/src/endpoints/topDevices.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/topDevices.ts
@@ -1,6 +1,8 @@
 import type { Endpoint } from "payload";
 import { ANALYTICS_ENDPOINT_PATHS } from "../constants/endpoints";
 import { getTopDevices } from "../services/queries/getTopDevices";
+import { getResolvedPagesConfig } from "../config";
+import { buildPageFilterContext } from "../services/pageFilter/buildPageFilterContext";
 import { TopNQuerySchema, formatZodIssues } from "./validateBody";
 import { mapGa4Error } from "./errorMapping";
 import { withAccess } from "./withAccess";
@@ -25,7 +27,8 @@ export function buildTopDevicesEndpoint(config: AnalyticsPluginConfig): Endpoint
       }
 
       try {
-        const result = await getTopDevices(config.ga4.propertyId, parsed.data);
+        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const result = await getTopDevices(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);
       } catch (err) {

--- a/packages/payload-plugin-analytics/src/endpoints/topEvents.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/topEvents.ts
@@ -1,6 +1,8 @@
 import type { Endpoint } from "payload";
 import { ANALYTICS_ENDPOINT_PATHS } from "../constants/endpoints";
 import { getTopEvents } from "../services/queries/getTopEvents";
+import { getResolvedPagesConfig } from "../config";
+import { buildPageFilterContext } from "../services/pageFilter/buildPageFilterContext";
 import { TopNQuerySchema, formatZodIssues } from "./validateBody";
 import { mapGa4Error } from "./errorMapping";
 import { withAccess } from "./withAccess";
@@ -25,7 +27,8 @@ export function buildTopEventsEndpoint(config: AnalyticsPluginConfig): Endpoint 
       }
 
       try {
-        const result = await getTopEvents(config.ga4.propertyId, parsed.data);
+        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const result = await getTopEvents(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);
       } catch (err) {

--- a/packages/payload-plugin-analytics/src/endpoints/topEvents.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/topEvents.ts
@@ -27,7 +27,7 @@ export function buildTopEventsEndpoint(config: AnalyticsPluginConfig): Endpoint 
       }
 
       try {
-        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const pageFilter = await buildPageFilterContext(req, getResolvedPagesConfig());
         const result = await getTopEvents(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);

--- a/packages/payload-plugin-analytics/src/endpoints/topPages.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/topPages.ts
@@ -1,6 +1,8 @@
 import type { Endpoint } from "payload";
 import { ANALYTICS_ENDPOINT_PATHS } from "../constants/endpoints";
 import { getTopPages } from "../services/queries/getTopPages";
+import { getResolvedPagesConfig } from "../config";
+import { buildPageFilterContext } from "../services/pageFilter/buildPageFilterContext";
 import { TopNQuerySchema, formatZodIssues } from "./validateBody";
 import { mapGa4Error } from "./errorMapping";
 import { withAccess } from "./withAccess";
@@ -25,7 +27,8 @@ export function buildTopPagesEndpoint(config: AnalyticsPluginConfig): Endpoint {
       }
 
       try {
-        const result = await getTopPages(config.ga4.propertyId, parsed.data);
+        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const result = await getTopPages(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);
       } catch (err) {

--- a/packages/payload-plugin-analytics/src/endpoints/topPages.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/topPages.ts
@@ -27,7 +27,7 @@ export function buildTopPagesEndpoint(config: AnalyticsPluginConfig): Endpoint {
       }
 
       try {
-        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const pageFilter = await buildPageFilterContext(req, getResolvedPagesConfig());
         const result = await getTopPages(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);

--- a/packages/payload-plugin-analytics/src/endpoints/topSources.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/topSources.ts
@@ -1,6 +1,8 @@
 import type { Endpoint } from "payload";
 import { ANALYTICS_ENDPOINT_PATHS } from "../constants/endpoints";
 import { getTopSources } from "../services/queries/getTopSources";
+import { getResolvedPagesConfig } from "../config";
+import { buildPageFilterContext } from "../services/pageFilter/buildPageFilterContext";
 import { TopNQuerySchema, formatZodIssues } from "./validateBody";
 import { mapGa4Error } from "./errorMapping";
 import { withAccess } from "./withAccess";
@@ -25,7 +27,8 @@ export function buildTopSourcesEndpoint(config: AnalyticsPluginConfig): Endpoint
       }
 
       try {
-        const result = await getTopSources(config.ga4.propertyId, parsed.data);
+        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const result = await getTopSources(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);
       } catch (err) {

--- a/packages/payload-plugin-analytics/src/endpoints/topSources.ts
+++ b/packages/payload-plugin-analytics/src/endpoints/topSources.ts
@@ -27,7 +27,7 @@ export function buildTopSourcesEndpoint(config: AnalyticsPluginConfig): Endpoint
       }
 
       try {
-        const pageFilter = await buildPageFilterContext(req.payload, getResolvedPagesConfig());
+        const pageFilter = await buildPageFilterContext(req, getResolvedPagesConfig());
         const result = await getTopSources(config.ga4.propertyId, parsed.data, pageFilter);
 
         return Response.json(result);

--- a/packages/payload-plugin-analytics/src/providers/ga4Provider/pushEvent.ts
+++ b/packages/payload-plugin-analytics/src/providers/ga4Provider/pushEvent.ts
@@ -1,10 +1,13 @@
 import { SESSION_PARAM_KEYS } from "../../constants/session";
+import { PAGE_PARAM_KEYS } from "../../constants/page";
 import { getSessionContext } from "../../client/session";
+import { getPageContext } from "../../client/pageContext/store";
 
 export function pushEvent(name: string, params: Record<string, unknown> = {}) {
   if (typeof window === "undefined" || !window.gtag) return;
 
   const ctx = getSessionContext();
+  const page = getPageContext();
 
   window.gtag("event", name, {
     ...params,
@@ -12,5 +15,6 @@ export function pushEvent(name: string, params: Record<string, unknown> = {}) {
     [SESSION_PARAM_KEYS.eventSeq]: ctx.eventSeq,
     [SESSION_PARAM_KEYS.elapsedMs]: ctx.elapsedMs,
     [SESSION_PARAM_KEYS.sessionStart]: ctx.startedAtIso,
+    ...(page ? { [PAGE_PARAM_KEYS.pageRef]: page.pageRef, [PAGE_PARAM_KEYS.contentLocale]: page.locale } : {}),
   });
 }

--- a/packages/payload-plugin-analytics/src/providers/ga4Provider/pushPageView.ts
+++ b/packages/payload-plugin-analytics/src/providers/ga4Provider/pushPageView.ts
@@ -1,11 +1,14 @@
 import { TRAFFIC_EVENTS } from "../../constants/events";
 import { SESSION_PARAM_KEYS } from "../../constants/session";
+import { PAGE_PARAM_KEYS } from "../../constants/page";
 import { getSessionContext } from "../../client/session";
+import { getPageContext } from "../../client/pageContext/store";
 
 export function pushPageView(path: string, title: string, location: string): void {
   if (typeof window === "undefined" || !window.gtag) return;
 
   const ctx = getSessionContext();
+  const page = getPageContext();
 
   window.gtag("event", TRAFFIC_EVENTS.PAGE_VIEW, {
     page_path: path,
@@ -15,5 +18,6 @@ export function pushPageView(path: string, title: string, location: string): voi
     [SESSION_PARAM_KEYS.eventSeq]: ctx.eventSeq,
     [SESSION_PARAM_KEYS.elapsedMs]: ctx.elapsedMs,
     [SESSION_PARAM_KEYS.sessionStart]: ctx.startedAtIso,
+    ...(page ? { [PAGE_PARAM_KEYS.pageRef]: page.pageRef, [PAGE_PARAM_KEYS.contentLocale]: page.locale } : {}),
   });
 }

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/filterAndReaggregate.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/filterAndReaggregate.ts
@@ -1,0 +1,38 @@
+import type { MockRow } from "./ga4RowBuilder";
+
+interface Options {
+  /** Index of the ref dimension within each input row's dimensionValues. */
+  refIndex: number;
+  /** Indices of the dimensions to KEEP (display dims), in output order. */
+  keepDimIndices: number[];
+  /** Allowed refs; null = keep all (no filtering). */
+  allowed: Set<string> | null;
+}
+
+function dimVal(r: MockRow, i: number): string {
+  return r.dimensionValues[i]?.value ?? "";
+}
+
+export function filterAndReaggregate(rows: MockRow[], { refIndex, keepDimIndices, allowed }: Options): MockRow[] {
+  const groups = new Map<string, { dims: string[]; metrics: number[] }>();
+
+  for (const r of rows) {
+    if (allowed && !allowed.has(dimVal(r, refIndex))) continue;
+
+    const dims = keepDimIndices.map((i) => dimVal(r, i));
+    const key = dims.join(" ");
+    const metrics = r.metricValues.map((m) => Number(m.value ?? "0"));
+
+    const existing = groups.get(key);
+    if (existing) {
+      for (let i = 0; i < metrics.length; i++) existing.metrics[i] = (existing.metrics[i] ?? 0) + (metrics[i] ?? 0);
+    } else {
+      groups.set(key, { dims, metrics });
+    }
+  }
+
+  return [...groups.values()].map((g) => ({
+    dimensionValues: g.dims.map((value) => ({ value })),
+    metricValues: g.metrics.map((n) => ({ value: String(n) })),
+  }));
+}

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/ga4RowBuilder.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/ga4RowBuilder.ts
@@ -1,0 +1,19 @@
+export interface MockRow {
+  dimensionValues: Array<{ value: string }>;
+  metricValues: Array<{ value: string }>;
+}
+
+export function row(dims: string[], metrics: string[]): MockRow {
+  return {
+    dimensionValues: dims.map((value) => ({ value })),
+    metricValues: metrics.map((value) => ({ value })),
+  };
+}
+
+export function response(rows: MockRow[]): { rows: MockRow[]; rowCount: number } {
+  return { rows, rowCount: rows.length };
+}
+
+export function batch(reports: ReturnType<typeof response>[]): { reports: ReturnType<typeof response>[] } {
+  return { reports };
+}

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/index.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/index.ts
@@ -6,6 +6,7 @@ import { topSourcesMock } from "./topSources";
 import { topDevicesMock } from "./topDevices";
 import { topCountriesMock } from "./topCountries";
 import { sessionsMock } from "./sessions";
+import { sessionLandingRefsMock } from "./sessionLandingRefs";
 import { sessionDetailMock } from "./sessionDetail";
 import { journeysMock } from "./journeys";
 import { leadActionsMock } from "./leadActions";
@@ -20,6 +21,7 @@ export const defaultMocks: AnalyticsMockMap = {
     topCountries: topCountriesMock,
     sessionDetail: sessionDetailMock,
     journeys: journeysMock,
+    sessionLandingRefs: sessionLandingRefsMock,
   },
   batchRunReports: {
     leadActions: leadActionsMock,

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/journeys.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/journeys.ts
@@ -1,4 +1,17 @@
 import type { RunReportMockFn } from "../mockRegistry";
-import journeys from "../../../../__fixtures__/ga4/journeys.basic.json";
+import { pickMockRefs } from "./mockRefs";
+import { row, response } from "./ga4RowBuilder";
+import { pathFor } from "./pathFor";
 
-export const journeysMock: RunReportMockFn = () => journeys as never;
+export const journeysMock: RunReportMockFn = () => {
+  const { existing, missing } = pickMockRefs();
+  const refs = [...existing, missing];
+
+  return response(
+    refs.flatMap((ref, i) => {
+      const sid = `s${i}`;
+      const p = pathFor(ref);
+      return [row([sid, "page_view", p, "202606171400", "1", "", ref], ["1"]), row([sid, "lead_action", p, "202606171401", "2", "phone_click", ref], ["1"])];
+    })
+  ) as never;
+};

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/kpis.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/kpis.ts
@@ -1,9 +1,26 @@
 import type { RunReportMockFn } from "../mockRegistry";
-import kpisCurrent from "../../../../__fixtures__/ga4/kpis.current.json";
-import kpisBoth from "../../../../__fixtures__/ga4/kpis.currentAndPrevious.json";
+import { pickMockRefs } from "./mockRefs";
+import { row, response } from "./ga4RowBuilder";
 
 export const kpisMock: RunReportMockFn = (request) => {
+  const { existing, missing } = pickMockRefs();
+  const refs = [...existing, missing];
+  const date = "20260617";
   const hasComparison = (request.dateRanges?.length ?? 0) >= 2;
 
-  return (hasComparison ? kpisBoth : kpisCurrent) as never;
+  const buildRows = (rangeName: "current" | "previous") =>
+    refs.flatMap((ref, i) => {
+      const sid = `${rangeName}-s${i}`;
+      const big = ref === missing;
+      const baseMinute = 1400;
+      const pvCount = big ? 50 : 3;
+      return Array.from({ length: pvCount }, (_, k) => {
+        const dhm = `${date}${String(baseMinute + k).padStart(4, "0")}`;
+        const dims = [sid, date, ref, "page_view", dhm];
+        return row(hasComparison ? [...dims, rangeName] : dims, ["1"]);
+      });
+    });
+
+  const rows = hasComparison ? [...buildRows("current"), ...buildRows("previous")] : buildRows("current");
+  return response(rows) as never;
 };

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/leadActions.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/leadActions.ts
@@ -1,4 +1,29 @@
 import type { BatchRunReportsMockFn } from "../mockRegistry";
-import leadActionsBatch from "../../../../__fixtures__/ga4/leadActions.batch.json";
+import { pickMockRefs } from "./mockRefs";
+import { row, response, batch } from "./ga4RowBuilder";
+import { refInListFromRequest } from "./refInListFromRequest";
+import { filterAndReaggregate } from "./filterAndReaggregate";
 
-export const leadActionsMock: BatchRunReportsMockFn = () => leadActionsBatch as never;
+const PAGE_REF_DIM = "customEvent:fr_page_ref";
+const LEAD_TYPES = ["phone_click", "email_click"];
+
+export const leadActionsMock: BatchRunReportsMockFn = (requests) => {
+  const { existing, missing } = pickMockRefs();
+  const refs = [...existing, missing];
+
+  const eventsTagged = refs.flatMap((ref) =>
+    LEAD_TYPES.map((t, ti) => {
+      const big = ref === missing;
+      const count = big ? 44444 : 40 - ti * 10;
+      return row([t, ref], [String(count), "1200"]);
+    })
+  );
+  const eventsAllowed = refInListFromRequest(requests[0] as never, PAGE_REF_DIM);
+  const eventsOut = filterAndReaggregate(eventsTagged, { refIndex: 1, keepDimIndices: [0, 1], allowed: eventsAllowed ? new Set(eventsAllowed) : null });
+
+  const sessionsTagged = refs.map((ref) => row([ref], [ref === missing ? "90000" : "300"]));
+  const sessAllowed = refInListFromRequest(requests[1] as never, PAGE_REF_DIM);
+  const sessFiltered = filterAndReaggregate(sessionsTagged, { refIndex: 0, keepDimIndices: [], allowed: sessAllowed ? new Set(sessAllowed) : null });
+
+  return batch([response(eventsOut), response(sessFiltered)]) as never;
+};

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/mockRefs.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/mockRefs.ts
@@ -1,0 +1,13 @@
+import { getActiveExistingRefs } from "../../pageFilter/activeRefsHolder";
+
+export const MOCK_MISSING_REF = "pages:__mock_deleted__";
+
+const FALLBACK_EXISTING_REF = "__home";
+
+const MAX_EXISTING = 3;
+
+export function pickMockRefs(): { existing: string[]; missing: string } {
+  const live = getActiveExistingRefs().filter((r) => r !== MOCK_MISSING_REF);
+  const existing = live.length > 0 ? live.slice(0, MAX_EXISTING) : [FALLBACK_EXISTING_REF];
+  return { existing, missing: MOCK_MISSING_REF };
+}

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/pathFor.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/pathFor.ts
@@ -1,0 +1,4 @@
+export function pathFor(ref: string): string {
+  if (ref === "__home") return "/";
+  return `/${ref.split(":")[1] ?? ref}`;
+}

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/refInListFromRequest.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/refInListFromRequest.ts
@@ -1,0 +1,20 @@
+interface Expr {
+  filter?: { fieldName?: string; inListFilter?: { values?: string[] } };
+  andGroup?: { expressions?: Expr[] };
+}
+
+function find(expr: Expr | undefined, dim: string): string[] | null {
+  if (!expr) return null;
+  if (expr.filter?.fieldName === dim && expr.filter.inListFilter?.values) {
+    return expr.filter.inListFilter.values;
+  }
+  for (const child of expr.andGroup?.expressions ?? []) {
+    const hit = find(child, dim);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+export function refInListFromRequest(request: { dimensionFilter?: Expr }, pageRefDim: string): string[] | null {
+  return find(request.dimensionFilter, pageRefDim);
+}

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/sessionDetail.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/sessionDetail.ts
@@ -1,4 +1,12 @@
 import type { RunReportMockFn } from "../mockRegistry";
-import sessionDetail from "../../../../__fixtures__/ga4/sessionDetail.json";
+import { pickMockRefs } from "./mockRefs";
+import { row, response } from "./ga4RowBuilder";
+import { pathFor } from "./pathFor";
 
-export const sessionDetailMock: RunReportMockFn = () => sessionDetail as never;
+export const sessionDetailMock: RunReportMockFn = () => {
+  const { existing } = pickMockRefs();
+  const ref = existing[0] ?? "__home";
+  const path = pathFor(ref);
+
+  return response([row(["page_view", path, "202606171400", "1", "", ref], ["1"]), row(["lead_action", path, "202606171401", "2", "phone_click", ref], ["1"])]) as never;
+};

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/sessionLandingRefs.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/sessionLandingRefs.ts
@@ -1,0 +1,12 @@
+import type { RunReportMockFn } from "../mockRegistry";
+import { pickMockRefs } from "./mockRefs";
+import { row, response } from "./ga4RowBuilder";
+
+export const sessionLandingRefsMock: RunReportMockFn = () => {
+  const { existing, missing } = pickMockRefs();
+  const refs = [...existing, missing];
+
+  const rows = refs.map((ref, i) => row([`s${i}`, ref, "202606171400", "1"], ["1"]));
+
+  return response(rows) as never;
+};

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/sessions.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/sessions.ts
@@ -1,4 +1,19 @@
 import type { BatchRunReportsMockFn } from "../mockRegistry";
-import sessionsBatch from "../../../../__fixtures__/ga4/sessions.batch.json";
+import { pickMockRefs } from "./mockRefs";
+import { row, response, batch } from "./ga4RowBuilder";
+import { pathFor } from "./pathFor";
 
-export const sessionsMock: BatchRunReportsMockFn = () => sessionsBatch as never;
+export const sessionsMock: BatchRunReportsMockFn = () => {
+  const { existing, missing } = pickMockRefs();
+  const refs = [...existing, missing];
+
+  const rows = refs.map((ref, i) => {
+    const big = ref === missing;
+    const sid = `s${i}`;
+    return row([sid, pathFor(ref), "google", "desktop", "United States", "2026-06-17T14:00:00.000Z", ref], [big ? "9999" : "12"]);
+  });
+
+  const leadRows = refs.slice(0, 1).map((_ref, i) => row([`s${i}`], ["3"]));
+
+  return batch([response(rows), response(leadRows)]) as never;
+};

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/topCountries.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/topCountries.ts
@@ -1,13 +1,27 @@
 import type { RunReportMockFn } from "../mockRegistry";
-import topCountries from "../../../../__fixtures__/ga4/topCountries.json";
-import topCities from "../../../../__fixtures__/ga4/topCities.json";
+import { pickMockRefs } from "./mockRefs";
+import { row, response } from "./ga4RowBuilder";
+import { refInListFromRequest } from "./refInListFromRequest";
+import { filterAndReaggregate } from "./filterAndReaggregate";
+
+const PAGE_REF_DIM = "customEvent:fr_page_ref";
+const COUNTRIES = [["United States"], ["Germany"]];
 
 export const topCountriesMock: RunReportMockFn = (request) => {
-  const firstDimension = request.dimensions?.[0]?.name;
-
-  if (firstDimension === "city") {
-    return topCities as never;
-  }
-
-  return topCountries as never;
+  const { existing, missing } = pickMockRefs();
+  const refs = [...existing, missing];
+  const tagged = refs.flatMap((ref) =>
+    COUNTRIES.map((c, ci) => {
+      const big = ref === missing;
+      const sessions = big ? 66666 : 120 - ci * 30;
+      return row([...c, ref], [String(sessions), String(Math.round(sessions * 0.8))]);
+    })
+  );
+  const allowedList = refInListFromRequest(request as never, PAGE_REF_DIM);
+  const out = filterAndReaggregate(tagged, {
+    refIndex: 1,
+    keepDimIndices: [0],
+    allowed: allowedList ? new Set(allowedList) : null,
+  });
+  return response(out) as never;
 };

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/topDevices.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/topDevices.ts
@@ -1,4 +1,26 @@
 import type { RunReportMockFn } from "../mockRegistry";
-import topDevices from "../../../../__fixtures__/ga4/topDevices.json";
+import { pickMockRefs } from "./mockRefs";
+import { row, response } from "./ga4RowBuilder";
+import { refInListFromRequest } from "./refInListFromRequest";
+import { filterAndReaggregate } from "./filterAndReaggregate";
 
-export const topDevicesMock: RunReportMockFn = () => topDevices as never;
+const PAGE_REF_DIM = "customEvent:fr_page_ref";
+const DEVICES = [
+  ["desktop", "Chrome", "macOS"],
+  ["mobile", "Safari", "iOS"],
+];
+
+export const topDevicesMock: RunReportMockFn = (request) => {
+  const { existing, missing } = pickMockRefs();
+  const refs = [...existing, missing];
+  const tagged = refs.flatMap((ref) =>
+    DEVICES.map((d, di) => {
+      const big = ref === missing;
+      const sessions = big ? 77777 : 150 - di * 40;
+      return row([...d, ref], [String(sessions), String(Math.round(sessions * 0.8))]);
+    })
+  );
+  const allowedList = refInListFromRequest(request as never, PAGE_REF_DIM);
+  const out = filterAndReaggregate(tagged, { refIndex: 3, keepDimIndices: [0, 1, 2], allowed: allowedList ? new Set(allowedList) : null });
+  return response(out) as never;
+};

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/topEvents.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/topEvents.ts
@@ -1,4 +1,23 @@
 import type { RunReportMockFn } from "../mockRegistry";
-import topEvents from "../../../../__fixtures__/ga4/topEvents.json";
+import { pickMockRefs } from "./mockRefs";
+import { row, response } from "./ga4RowBuilder";
+import { refInListFromRequest } from "./refInListFromRequest";
+import { filterAndReaggregate } from "./filterAndReaggregate";
 
-export const topEventsMock: RunReportMockFn = () => topEvents as never;
+const PAGE_REF_DIM = "customEvent:fr_page_ref";
+const EVENTS = ["page_view", "scroll", "click"];
+
+export const topEventsMock: RunReportMockFn = (request) => {
+  const { existing, missing } = pickMockRefs();
+  const refs = [...existing, missing];
+  const tagged = refs.flatMap((ref) =>
+    EVENTS.map((e, ei) => {
+      const big = ref === missing;
+      const count = big ? 55555 : 300 - ei * 90;
+      return row([e, ref], [String(count), "1.5"]);
+    })
+  );
+  const allowedList = refInListFromRequest(request as never, PAGE_REF_DIM);
+  const out = filterAndReaggregate(tagged, { refIndex: 1, keepDimIndices: [0], allowed: allowedList ? new Set(allowedList) : null });
+  return response(out) as never;
+};

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/topPages.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/topPages.ts
@@ -1,4 +1,24 @@
 import type { RunReportMockFn } from "../mockRegistry";
-import topPages from "../../../../__fixtures__/ga4/topPages.json";
+import { pickMockRefs } from "./mockRefs";
+import { row, response } from "./ga4RowBuilder";
+import { refInListFromRequest } from "./refInListFromRequest";
+import { filterAndReaggregate } from "./filterAndReaggregate";
 
-export const topPagesMock: RunReportMockFn = () => topPages as never;
+const PAGE_REF_DIM = "customEvent:fr_page_ref";
+
+export const topPagesMock: RunReportMockFn = (request) => {
+  const { existing, missing } = pickMockRefs();
+  const refs = [...existing, missing];
+
+  const tagged = refs.map((ref, i) => {
+    const isMissing = ref === missing;
+    const views = isMissing ? 99999 : 500 - i * 80;
+    return row([ref], [String(views), String(Math.round(views * 0.7)), "75.0"]);
+  });
+
+  const allowedList = refInListFromRequest(request as never, PAGE_REF_DIM);
+  const allowed = allowedList ? new Set(allowedList) : null;
+
+  const out = filterAndReaggregate(tagged, { refIndex: 0, keepDimIndices: [0], allowed });
+  return response(out) as never;
+};

--- a/packages/payload-plugin-analytics/src/services/analyticsService/mocks/topSources.ts
+++ b/packages/payload-plugin-analytics/src/services/analyticsService/mocks/topSources.ts
@@ -1,4 +1,26 @@
 import type { RunReportMockFn } from "../mockRegistry";
-import topSources from "../../../../__fixtures__/ga4/topSources.json";
+import { pickMockRefs } from "./mockRefs";
+import { row, response } from "./ga4RowBuilder";
+import { refInListFromRequest } from "./refInListFromRequest";
+import { filterAndReaggregate } from "./filterAndReaggregate";
 
-export const topSourcesMock: RunReportMockFn = () => topSources as never;
+const PAGE_REF_DIM = "customEvent:fr_page_ref";
+const SOURCES = [
+  ["google", "organic", "Organic Search"],
+  ["direct", "(none)", "Direct"],
+];
+
+export const topSourcesMock: RunReportMockFn = (request) => {
+  const { existing, missing } = pickMockRefs();
+  const refs = [...existing, missing];
+  const tagged = refs.flatMap((ref) =>
+    SOURCES.map((s, si) => {
+      const big = ref === missing;
+      const sessions = big ? 88888 : 200 - si * 50;
+      return row([...s, ref], [String(sessions), String(Math.round(sessions * 0.8))]);
+    })
+  );
+  const allowedList = refInListFromRequest(request as never, PAGE_REF_DIM);
+  const out = filterAndReaggregate(tagged, { refIndex: 3, keepDimIndices: [0, 1, 2], allowed: allowedList ? new Set(allowedList) : null });
+  return response(out) as never;
+};

--- a/packages/payload-plugin-analytics/src/services/pageFilter/activeRefsHolder.ts
+++ b/packages/payload-plugin-analytics/src/services/pageFilter/activeRefsHolder.ts
@@ -1,0 +1,13 @@
+let active: string[] = [];
+
+export function setActiveExistingRefs(refs: string[]): void {
+  active = refs;
+}
+
+export function getActiveExistingRefs(): string[] {
+  return active;
+}
+
+export function __clearActiveExistingRefs(): void {
+  active = [];
+}

--- a/packages/payload-plugin-analytics/src/services/pageFilter/buildPageFilterContext.ts
+++ b/packages/payload-plugin-analytics/src/services/pageFilter/buildPageFilterContext.ts
@@ -1,0 +1,19 @@
+import type { Payload } from "payload";
+import type { ResolvedPagesConfig } from "../../config/resolvePagesConfig";
+import type { PageFilterContext } from "./types";
+import { getExistingPageRefs } from "./getExistingPageRefs";
+import { getCachedExistingRefs } from "./existingRefsCache";
+
+export async function buildPageFilterContext(payload: Payload, config: ResolvedPagesConfig | null): Promise<PageFilterContext | null> {
+  if (!config) return null;
+
+  const key = config.collections.map(({ slug, publishedOnly }) => `${slug}:${publishedOnly}`).join(",") + "|" + config.syntheticRefs.join(",");
+
+  const refs = await getCachedExistingRefs(key, () => getExistingPageRefs(payload, config));
+
+  return {
+    refs: [...refs],
+    pageRefDim: config.dimensions.pageRef,
+    contentLocaleDim: config.dimensions.contentLocale,
+  };
+}

--- a/packages/payload-plugin-analytics/src/services/pageFilter/buildPageFilterContext.ts
+++ b/packages/payload-plugin-analytics/src/services/pageFilter/buildPageFilterContext.ts
@@ -1,19 +1,30 @@
-import type { Payload } from "payload";
+import type { PayloadRequest } from "payload";
 import type { ResolvedPagesConfig } from "../../config/resolvePagesConfig";
 import type { PageFilterContext } from "./types";
 import { getExistingPageRefs } from "./getExistingPageRefs";
 import { getCachedExistingRefs } from "./existingRefsCache";
+import { getCachedPageLabels } from "./pageLabelsCache";
+import { resolvePageLabels } from "./resolvePageLabels";
+import { setActiveExistingRefs } from "./activeRefsHolder";
 
-export async function buildPageFilterContext(payload: Payload, config: ResolvedPagesConfig | null): Promise<PageFilterContext | null> {
+export async function buildPageFilterContext(req: PayloadRequest, config: ResolvedPagesConfig | null): Promise<PageFilterContext | null> {
   if (!config) return null;
 
-  const key = config.collections.map(({ slug, publishedOnly }) => `${slug}:${publishedOnly}`).join(",") + "|" + config.syntheticRefs.join(",");
+  const key = config.collections.map((c) => `${c.slug}:${c.publishedOnly}`).join(",") + "|" + config.syntheticRefs.join(",");
+  const refs = await getCachedExistingRefs(key, () => getExistingPageRefs(req.payload, config));
+  const refList = [...refs];
 
-  const refs = await getCachedExistingRefs(key, () => getExistingPageRefs(payload, config));
+  setActiveExistingRefs(refList);
+
+  const resolveLabels = async (wanted: string[]) => {
+    const labelKey = key + "|labels:" + [...wanted].sort().join(",");
+    return getCachedPageLabels(labelKey, () => resolvePageLabels(req, config, wanted));
+  };
 
   return {
-    refs: [...refs],
+    refs: refList,
     pageRefDim: config.dimensions.pageRef,
     contentLocaleDim: config.dimensions.contentLocale,
+    resolveLabels,
   };
 }

--- a/packages/payload-plugin-analytics/src/services/pageFilter/excludeDeletedSessions.ts
+++ b/packages/payload-plugin-analytics/src/services/pageFilter/excludeDeletedSessions.ts
@@ -1,0 +1,20 @@
+/**
+ * Strict exclusion: a session survives only if EVERY ref it touched is in the
+ * existing set. Any deleted/empty ref drops the whole session.
+ */
+export function excludeDeletedSessions(sessionRefs: Map<string, Set<string>>, existing: Set<string>): Set<string> {
+  const allowed = new Set<string>();
+
+  for (const [sessionId, refs] of sessionRefs) {
+    let ok = refs.size > 0;
+    for (const ref of refs) {
+      if (!existing.has(ref)) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) allowed.add(sessionId);
+  }
+
+  return allowed;
+}

--- a/packages/payload-plugin-analytics/src/services/pageFilter/existingRefsCache.ts
+++ b/packages/payload-plugin-analytics/src/services/pageFilter/existingRefsCache.ts
@@ -1,0 +1,30 @@
+const TTL_MS = 60_000;
+
+interface Entry {
+  value: Set<string>;
+  expiresAt: number;
+}
+
+const cache = new Map<string, Entry>();
+let nowFn: () => number = () => Date.now();
+
+export function __setNowForTests(ms: number): void {
+  nowFn = () => ms;
+}
+
+export function __clearExistingRefsCache(): void {
+  cache.clear();
+}
+
+export async function getCachedExistingRefs(key: string, loader: () => Promise<Set<string>>): Promise<Set<string>> {
+  const now = nowFn();
+  const hit = cache.get(key);
+
+  if (hit && hit.expiresAt > now) return hit.value;
+
+  const value = await loader();
+
+  cache.set(key, { value, expiresAt: now + TTL_MS });
+
+  return value;
+}

--- a/packages/payload-plugin-analytics/src/services/pageFilter/getExistingPageRefs.ts
+++ b/packages/payload-plugin-analytics/src/services/pageFilter/getExistingPageRefs.ts
@@ -1,0 +1,53 @@
+import type { Payload } from "payload";
+import type { ResolvedPagesConfig } from "../../config/resolvePagesConfig";
+import { formatPageRef } from "../../utils/page/formatPageRef";
+
+interface Page {
+  id: string | number;
+}
+
+async function findIds(payload: Payload, slug: string, publishedOnly: boolean): Promise<Page[]> {
+  const base = {
+    collection: slug,
+    depth: 0,
+    pagination: false as const,
+    select: { id: true },
+    overrideAccess: true,
+  };
+
+  if (!publishedOnly) {
+    const res = await payload.find(base as never);
+
+    return res.docs as Page[];
+  }
+
+  try {
+    const res = await payload.find({
+      ...base,
+      where: {
+        _status: { equals: "published" },
+      },
+    } as never);
+
+    return res.docs as Page[];
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!(/_status/u.test(msg) || /not a valid/iu.test(msg))) throw err;
+
+    const res = await payload.find(base as never);
+
+    return res.docs as Array<{ id: string | number }>;
+  }
+}
+
+export async function getExistingPageRefs(payload: Payload, config: ResolvedPagesConfig): Promise<Set<string>> {
+  const refs = new Set<string>(config.syntheticRefs);
+
+  for (const { slug, publishedOnly } of config.collections) {
+    const docs = await findIds(payload, slug, publishedOnly);
+
+    for (const doc of docs) refs.add(formatPageRef(slug, doc.id));
+  }
+
+  return refs;
+}

--- a/packages/payload-plugin-analytics/src/services/pageFilter/pageLabelsCache.ts
+++ b/packages/payload-plugin-analytics/src/services/pageFilter/pageLabelsCache.ts
@@ -1,0 +1,32 @@
+import type { PageLabel } from "./resolvePageLabels";
+
+const TTL_MS = 60_000;
+
+interface Entry {
+  value: Map<string, PageLabel>;
+  expiresAt: number;
+}
+
+const cache = new Map<string, Entry>();
+let nowFn: () => number = () => Date.now();
+
+export function __setNowForTests(ms: number): void {
+  nowFn = () => ms;
+}
+
+export function __clearPageLabelsCache(): void {
+  cache.clear();
+}
+
+export async function getCachedPageLabels(key: string, loader: () => Promise<Map<string, PageLabel>>): Promise<Map<string, PageLabel>> {
+  const now = nowFn();
+  const hit = cache.get(key);
+
+  if (hit && hit.expiresAt > now) return hit.value;
+
+  const value = await loader();
+
+  cache.set(key, { value, expiresAt: now + TTL_MS });
+
+  return value;
+}

--- a/packages/payload-plugin-analytics/src/services/pageFilter/resolvePageLabels.ts
+++ b/packages/payload-plugin-analytics/src/services/pageFilter/resolvePageLabels.ts
@@ -1,0 +1,87 @@
+import type { PayloadRequest } from "payload";
+import type { ResolvedPagesConfig } from "../../config/resolvePagesConfig";
+
+export interface PageLabel {
+  path: string;
+  title: string;
+}
+
+function parseRef(ref: string) {
+  const idx = ref.indexOf(":");
+
+  if (idx <= 0) return null;
+
+  return {
+    collection: ref.slice(0, idx),
+    id: ref.slice(idx + 1),
+  };
+}
+
+export async function resolvePageLabels(req: PayloadRequest, config: ResolvedPagesConfig, refs: string[]): Promise<Map<string, PageLabel>> {
+  const unique = [...new Set(refs)];
+  const result = new Map<string, PageLabel>();
+  const byCollection = new Map<string, string[]>();
+  const defaultLocale = (req.payload.config.localization && req.payload.config.localization.defaultLocale) || undefined;
+
+  for (const ref of unique) {
+    const parsed = parseRef(ref);
+
+    if (parsed && config.collections.some((c) => c.slug === parsed.collection)) {
+      const list = byCollection.get(parsed.collection) ?? [];
+
+      list.push(parsed.id);
+      byCollection.set(parsed.collection, list);
+    }
+  }
+
+  const titleByRef = new Map<string, string>();
+
+  for (const [collection, ids] of byCollection) {
+    const titleField = config.collections.find((c) => c.slug === collection)?.titleField ?? "title";
+
+    try {
+      const res = await req.payload.find({
+        collection,
+        locale: defaultLocale,
+        where: {
+          id: {
+            in: ids.map((id) => (Number.isNaN(Number(id)) ? id : Number(id))),
+          },
+        },
+        select: {
+          [titleField]: true,
+        },
+        depth: 0,
+        pagination: false,
+        overrideAccess: true,
+      } as never);
+
+      for (const doc of res.docs as Array<Record<string, unknown>>) {
+        const title = doc[titleField];
+        if (typeof title === "string" && title) titleByRef.set(`${collection}:${doc.id}`, title);
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  for (const ref of unique) {
+    let path = "";
+
+    if (config.resolvePagePath) {
+      try {
+        path = (await config.resolvePagePath(ref, req)) || "";
+      } catch {
+        path = "";
+      }
+    }
+
+    if (!path) path = ref;
+
+    const title = titleByRef.get(ref) ?? (path !== ref ? path : ref);
+
+    result.set(ref, { path, title });
+  }
+
+  return result;
+}

--- a/packages/payload-plugin-analytics/src/services/pageFilter/types.ts
+++ b/packages/payload-plugin-analytics/src/services/pageFilter/types.ts
@@ -1,0 +1,8 @@
+export interface PageFilterContext {
+  /** Currently-existing refs ("collection:id" + synthetic). */
+  refs: string[];
+  /** GA4 dimension api name for page ref (e.g. "customEvent:fr_page_ref"). */
+  pageRefDim: string;
+  /** GA4 dimension api name for content locale. */
+  contentLocaleDim: string;
+}

--- a/packages/payload-plugin-analytics/src/services/pageFilter/types.ts
+++ b/packages/payload-plugin-analytics/src/services/pageFilter/types.ts
@@ -1,3 +1,5 @@
+import type { PageLabel } from "./resolvePageLabels";
+
 export interface PageFilterContext {
   /** Currently-existing refs ("collection:id" + synthetic). */
   refs: string[];
@@ -5,4 +7,6 @@ export interface PageFilterContext {
   pageRefDim: string;
   /** GA4 dimension api name for content locale. */
   contentLocaleDim: string;
+  /** Resolve display labels (path + title) for the given refs. */
+  resolveLabels: (refs: string[]) => Promise<Map<string, PageLabel>>;
 }

--- a/packages/payload-plugin-analytics/src/services/queries/getJourneys.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getJourneys.ts
@@ -1,7 +1,9 @@
 import type { JourneyResponse, JourneyRow, JourneyStep, JourneysQuery, Row } from "../../types/query";
+import type { PageFilterContext } from "../pageFilter/types";
 import { LEAD_ACTION_EVENT_NAME } from "../../constants/events";
 import { resolveDateRange } from "../../utils/date/resolveDateRange";
 import { dateRangesFor, deriveMissing, withRowLimit } from "../../utils/ga4";
+import { excludeDeletedSessions } from "../pageFilter/excludeDeletedSessions";
 import { mapGa4Error } from "../../endpoints/errorMapping";
 import { runQuery } from "../analyticsService/runQuery";
 
@@ -12,9 +14,10 @@ interface OrderedRow {
   dhm: string;
   eventSeq: number;
   leadType: string;
+  pageRef: string;
 }
 
-function parseRow(row: Row): OrderedRow {
+function parseRow(row: Row, pageRefDimIndex: number): OrderedRow {
   const dim = row.dimensionValues ?? [];
   const seqRaw = dim[4]?.value ?? "";
   const seq = Number.parseInt(seqRaw, 10);
@@ -26,6 +29,7 @@ function parseRow(row: Row): OrderedRow {
     dhm: dim[3]?.value ?? "",
     eventSeq: Number.isFinite(seq) ? seq : Number.MAX_SAFE_INTEGER,
     leadType: dim[5]?.value ?? "",
+    pageRef: pageRefDimIndex >= 0 ? (dim[pageRefDimIndex]?.value ?? "") : "",
   };
 }
 
@@ -66,24 +70,35 @@ function groupBySession(rows: OrderedRow[]): Map<string, OrderedRow[]> {
   return rowsMap;
 }
 
-export async function getJourneys(propertyId: string, query: JourneysQuery): Promise<JourneyResponse> {
+export async function getJourneys(propertyId: string, query: JourneysQuery, pageFilter?: PageFilterContext | null): Promise<JourneyResponse> {
   const dateRange = resolveDateRange(query.dateRange);
   const limit = query.limit ?? 20;
   const maxSteps = query.maxSteps;
   const sampleLimit = query.sampleLimit ?? 50_000;
+  const filterRefs = pageFilter?.refs ?? [];
+  const pageFilterActive = filterRefs.length > 0;
+
+  const dimensions = [
+    { name: "customEvent:fr_session_id" },
+    { name: "eventName" },
+    { name: "pagePath" },
+    { name: "dateHourMinute" },
+    { name: "customEvent:fr_event_seq" },
+    { name: "customEvent:fr_lead_type" },
+  ];
+
+  let pageRefDimIndex = -1;
+
+  if (pageFilterActive && pageFilter) {
+    pageRefDimIndex = dimensions.length;
+    dimensions.push({ name: pageFilter.pageRefDim });
+  }
 
   const request = withRowLimit(
     {
       dateRanges: dateRangesFor(dateRange),
       metrics: [{ name: "eventCount" }],
-      dimensions: [
-        { name: "customEvent:fr_session_id" },
-        { name: "eventName" },
-        { name: "pagePath" },
-        { name: "dateHourMinute" },
-        { name: "customEvent:fr_event_seq" },
-        { name: "customEvent:fr_lead_type" },
-      ],
+      dimensions,
       orderBys: [{ dimension: { dimensionName: "customEvent:fr_session_id" } }, { dimension: { dimensionName: "dateHourMinute" } }, { dimension: { dimensionName: "customEvent:fr_event_seq" } }],
     },
     sampleLimit
@@ -97,7 +112,7 @@ export async function getJourneys(propertyId: string, query: JourneysQuery): Pro
     if (mapped.setupRequired) {
       return {
         setupRequired: true,
-        missing: deriveMissing({ message: mapped.message }, ["fr_session_id", "fr_event_seq", "fr_lead_type"]),
+        missing: deriveMissing({ message: mapped.message }, ["fr_session_id", "fr_event_seq", "fr_lead_type", "fr_page_ref"]),
         rows: [],
         sessionsConsidered: 0,
         truncated: false,
@@ -106,13 +121,25 @@ export async function getJourneys(propertyId: string, query: JourneysQuery): Pro
     throw err;
   }
 
-  const rows = ((raw.rows ?? []) as Row[]).map(parseRow);
+  const rows = ((raw.rows ?? []) as Row[]).map((row) => parseRow(row, pageRefDimIndex));
   const rowsMapBySession = groupBySession(rows);
+
+  let allowedSessions: Set<string> | null = null;
+  if (pageFilterActive) {
+    const refsBySession = new Map<string, Set<string>>();
+    for (const [sessionId, sessionRows] of rowsMapBySession) {
+      const refs = new Set<string>();
+      for (const row of sessionRows) refs.add(row.pageRef);
+      refsBySession.set(sessionId, refs);
+    }
+    allowedSessions = excludeDeletedSessions(refsBySession, new Set(filterRefs));
+  }
 
   const journeysMapByPath = new Map<string, { path: JourneyStep[]; count: number }>();
   let sessionsConsidered = 0;
 
-  for (const sessionRows of rowsMapBySession.values()) {
+  for (const [sessionId, sessionRows] of rowsMapBySession) {
+    if (allowedSessions && !allowedSessions.has(sessionId)) continue;
     if (!sessionRows.some((row) => row.eventName === LEAD_ACTION_EVENT_NAME)) continue;
 
     sessionsConsidered += 1;

--- a/packages/payload-plugin-analytics/src/services/queries/getJourneys.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getJourneys.ts
@@ -33,7 +33,7 @@ function parseRow(row: Row, pageRefDimIndex: number): OrderedRow {
   };
 }
 
-function sessionRowToJourneyStep(row: OrderedRow): JourneyStep {
+function sessionRowToJourneyStep(row: OrderedRow, labels: Map<string, { path: string }> | null): JourneyStep {
   if (row.eventName === LEAD_ACTION_EVENT_NAME && row.leadType) {
     return {
       kind: "leadAction",
@@ -42,7 +42,7 @@ function sessionRowToJourneyStep(row: OrderedRow): JourneyStep {
   }
   return {
     kind: "page",
-    value: row.pagePath,
+    value: labels?.get(row.pageRef)?.path ?? row.pagePath,
   };
 }
 
@@ -135,6 +135,20 @@ export async function getJourneys(propertyId: string, query: JourneysQuery, page
     allowedSessions = excludeDeletedSessions(refsBySession, new Set(filterRefs));
   }
 
+  // Resolve page-step labels by ref across all allowed sessions, so differing historical
+  // pagePaths for the same ref collapse to one CMS-resolved path.
+  let labels: Map<string, { path: string }> | null = null;
+  if (pageFilterActive && pageFilter) {
+    const pageStepRefs = new Set<string>();
+    for (const [sessionId, sessionRows] of rowsMapBySession) {
+      if (allowedSessions && !allowedSessions.has(sessionId)) continue;
+      for (const row of sessionRows) {
+        if (row.eventName !== LEAD_ACTION_EVENT_NAME && row.pageRef) pageStepRefs.add(row.pageRef);
+      }
+    }
+    labels = await pageFilter.resolveLabels([...pageStepRefs]);
+  }
+
   const journeysMapByPath = new Map<string, { path: JourneyStep[]; count: number }>();
   let sessionsConsidered = 0;
 
@@ -144,7 +158,7 @@ export async function getJourneys(propertyId: string, query: JourneysQuery, page
 
     sessionsConsidered += 1;
 
-    const journeySteps = collapseJourneyStepDuplicates(sessionRows.map(sessionRowToJourneyStep));
+    const journeySteps = collapseJourneyStepDuplicates(sessionRows.map((row) => sessionRowToJourneyStep(row, labels)));
     const path = maxSteps === undefined ? journeySteps : journeySteps.slice(0, maxSteps);
     const pathKey = JSON.stringify(path);
     const existing = journeysMapByPath.get(pathKey);

--- a/packages/payload-plugin-analytics/src/services/queries/getKpis.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getKpis.ts
@@ -1,16 +1,13 @@
 import type { AnalyticsQuery, KpiCurrent, KpiResponse, KpiSeriesPoint, Row } from "../../types/query";
+import type { PageFilterContext } from "../pageFilter/types";
 import { resolveDateRange } from "../../utils/date/resolveDateRange";
 import { resolveComparison } from "../../utils/date/resolveComparison";
-import { dateRangesFor, bucketByDateRange, convertMetricToNumber, computeWeightedValuesAverage } from "../../utils/ga4";
+import { dateRangesFor, bucketByDateRange, convertMetricToNumber, computeWeightedValuesAverage, dim, isoFromGa4Date } from "../../utils/ga4";
 import { runQuery } from "../analyticsService/runQuery";
+import { aggregateSessions } from './kpiRecompute/aggregateSessions';
+import type { KpiSessionEventRow } from './kpiRecompute/aggregateSessions';
 
 const METRICS = [{ name: "sessions" }, { name: "totalUsers" }, { name: "screenPageViews" }, { name: "bounceRate" }, { name: "averageSessionDuration" }];
-
-function isoFromGa4Date(yyyymmdd: string | null | undefined) {
-  if (!yyyymmdd || yyyymmdd.length !== 8) return "";
-
-  return `${yyyymmdd.slice(0, 4)}-${yyyymmdd.slice(4, 6)}-${yyyymmdd.slice(6, 8)}`;
-}
 
 function aggregate(rows: Row[]): KpiCurrent {
   let pageViews = 0,
@@ -62,7 +59,7 @@ function buildSeries(rows: Row[]): KpiSeriesPoint[] {
   return points;
 }
 
-export async function getKpis(propertyId: string, query: AnalyticsQuery): Promise<KpiResponse> {
+async function getKpisNative(propertyId: string, query: AnalyticsQuery): Promise<KpiResponse> {
   const dateRange = resolveDateRange(query.dateRange);
   const previousDateRange = query.comparison?.kind === "previous-period" ? resolveComparison(dateRange) : undefined;
   const dateRanges = dateRangesFor(dateRange, previousDateRange);
@@ -87,4 +84,57 @@ export async function getKpis(propertyId: string, query: AnalyticsQuery): Promis
     series: buildSeries(buckets.current),
     comparisonSeries: buildSeries(buckets.previous),
   };
+}
+
+function decodeSessionRows(rows: Row[], pageRefIndex: number, eventNameIndex: number, dhmIndex: number): KpiSessionEventRow[] {
+  return rows.map((row) => ({
+    sessionId: dim(row, 0),
+    date: dim(row, 1),
+    pageRef: dim(row, pageRefIndex),
+    eventName: dim(row, eventNameIndex),
+    dhm: dim(row, dhmIndex),
+  }));
+}
+
+async function getKpisRecomputed(propertyId: string, query: AnalyticsQuery, pageFilter: PageFilterContext): Promise<KpiResponse> {
+  const dateRange = resolveDateRange(query.dateRange);
+  const previousDateRange = query.comparison?.kind === "previous-period" ? resolveComparison(dateRange) : undefined;
+  const dateRanges = dateRangesFor(dateRange, previousDateRange);
+  const existing = new Set(pageFilter.refs);
+
+  const dimensions: Array<{ name: string }> = [{ name: "customEvent:fr_session_id" }, { name: "date" }];
+  const pageRefIndex = dimensions.length;
+  dimensions.push({ name: pageFilter.pageRefDim });
+  const eventNameIndex = dimensions.length;
+  dimensions.push({ name: "eventName" });
+  const dhmIndex = dimensions.length;
+  dimensions.push({ name: "dateHourMinute" });
+
+  const raw = await runQuery.runReport(propertyId, { dateRanges, metrics: [{ name: "eventCount" }], dimensions }, "kpis");
+  const rows = (raw.rows ?? []) as Row[];
+
+  if (!previousDateRange) {
+    const { current, series } = aggregateSessions(decodeSessionRows(rows, pageRefIndex, eventNameIndex, dhmIndex), existing);
+
+    return { current, series };
+  }
+
+  const buckets = bucketByDateRange(rows, ["current", "previous"]);
+  const currentAgg = aggregateSessions(decodeSessionRows(buckets.current, pageRefIndex, eventNameIndex, dhmIndex), existing);
+  const previousAgg = aggregateSessions(decodeSessionRows(buckets.previous, pageRefIndex, eventNameIndex, dhmIndex), existing);
+
+  return {
+    current: currentAgg.current,
+    comparison: previousAgg.current,
+    series: currentAgg.series,
+    comparisonSeries: previousAgg.series,
+  };
+}
+
+export async function getKpis(propertyId: string, query: AnalyticsQuery, pageFilter?: PageFilterContext | null): Promise<KpiResponse> {
+  if (!pageFilter || pageFilter.refs.length === 0) {
+    return getKpisNative(propertyId, query);
+  }
+
+  return getKpisRecomputed(propertyId, query, pageFilter);
 }

--- a/packages/payload-plugin-analytics/src/services/queries/getLeadActions.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getLeadActions.ts
@@ -14,7 +14,12 @@ function buildEmptyCurrent(): LeadActionsCurrent {
   return { totals: {}, conversionRate: {}, perPage: [], avgTimeToAction: 0 };
 }
 
-function aggregate(eventRows: Row[], totalSessions: number, elapsedMsAvailable: boolean): LeadActionsCurrent {
+interface AggregateResult {
+  current: LeadActionsCurrent;
+  perPageByKey: Map<string, Record<string, number>>;
+}
+
+function aggregate(eventRows: Row[], totalSessions: number, elapsedMsAvailable: boolean): AggregateResult {
   const current = buildEmptyCurrent();
   const countsByPage = new Map<string, Record<string, number>>();
 
@@ -26,7 +31,7 @@ function aggregate(eventRows: Row[], totalSessions: number, elapsedMsAvailable: 
     const metricValues = row.metricValues ?? [];
 
     const leadType = dimensionValues[0]?.value;
-    const pagePath = dimensionValues[1]?.value ?? "";
+    const pageKey = dimensionValues[1]?.value ?? "";
     const eventCount = convertMetricToNumber(metricValues[0]?.value);
     const avgElapsedMs = elapsedMsAvailable ? convertMetricToNumber(metricValues[1]?.value) : 0;
 
@@ -36,9 +41,9 @@ function aggregate(eventRows: Row[], totalSessions: number, elapsedMsAvailable: 
     totalEventCount += eventCount;
     weightedSum += avgElapsedMs * eventCount;
 
-    const pageCounts = countsByPage.get(pagePath) ?? {};
+    const pageCounts = countsByPage.get(pageKey) ?? {};
     pageCounts[leadType] = (pageCounts[leadType] ?? 0) + eventCount;
-    countsByPage.set(pagePath, pageCounts);
+    countsByPage.set(pageKey, pageCounts);
   }
 
   for (const [leadType, total] of Object.entries(current.totals)) {
@@ -46,7 +51,18 @@ function aggregate(eventRows: Row[], totalSessions: number, elapsedMsAvailable: 
   }
 
   current.avgTimeToAction = !elapsedMsAvailable ? null : totalEventCount > 0 ? weightedSum / totalEventCount / 1000 : 0;
-  current.perPage = Array.from(countsByPage.entries()).map(([pagePath, counts]) => ({ pagePath, counts }));
+
+  return { current, perPageByKey: countsByPage };
+}
+
+async function fillPerPage(result: AggregateResult, pageFilter?: PageFilterContext | null): Promise<LeadActionsCurrent> {
+  const { current, perPageByKey } = result;
+  const labels = pageFilter ? await pageFilter.resolveLabels([...perPageByKey.keys()]) : null;
+
+  current.perPage = Array.from(perPageByKey.entries()).map(([key, counts]) => ({
+    pagePath: labels?.get(key)?.path ?? key,
+    counts,
+  }));
 
   return current;
 }
@@ -58,13 +74,15 @@ export async function getLeadActions(propertyId: string, query: AnalyticsQuery, 
   const types = resolveLeadActionTypes(getPluginConfig().leadActions?.types);
 
   const refs = pageFilter?.refs ?? [];
+  const pageFilterActive = Boolean(pageFilter) && refs.length > 0;
   const pageRefDim = pageFilter?.pageRefDim ?? DEFAULT_PAGE_DIMENSIONS.pageRef;
+  const pageDimension = pageFilterActive ? pageRefDim : "pagePath";
 
   const eventsRequest = withPageRefFilter(
     {
       dateRanges,
       metrics: [{ name: "eventCount" }, { name: "averageCustomEvent:fr_elapsed_ms" }],
-      dimensions: [{ name: "customEvent:fr_lead_type" }, { name: "pagePath" }],
+      dimensions: [{ name: "customEvent:fr_lead_type" }, { name: pageDimension }],
       dimensionFilter: leadActionFilter(types),
     },
     pageRefDim,
@@ -111,9 +129,13 @@ export async function getLeadActions(propertyId: string, query: AnalyticsQuery, 
 
   let response: LeadActionsResponse;
 
+  const filterForLabels = pageFilterActive ? pageFilter : null;
+
   if (!previousDateRange) {
     const totalSessions = convertMetricToNumber(sessionsRows[0]?.metricValues?.[0]?.value);
-    response = { current: aggregate(eventsRows, totalSessions, elapsedMsAvailable) };
+    response = {
+      current: await fillPerPage(aggregate(eventsRows, totalSessions, elapsedMsAvailable), filterForLabels),
+    };
   } else {
     const eventsBuckets = bucketByDateRange(eventsRows, ["current", "previous"]);
     const sessionsBuckets = bucketByDateRange(sessionsRows, ["current", "previous"]);
@@ -121,8 +143,8 @@ export async function getLeadActions(propertyId: string, query: AnalyticsQuery, 
     const previousSessions = convertMetricToNumber(sessionsBuckets.previous[0]?.metricValues?.[0]?.value);
 
     response = {
-      current: aggregate(eventsBuckets.current, currentSessions, elapsedMsAvailable),
-      comparison: aggregate(eventsBuckets.previous, previousSessions, elapsedMsAvailable),
+      current: await fillPerPage(aggregate(eventsBuckets.current, currentSessions, elapsedMsAvailable), filterForLabels),
+      comparison: await fillPerPage(aggregate(eventsBuckets.previous, previousSessions, elapsedMsAvailable), filterForLabels),
     };
   }
 

--- a/packages/payload-plugin-analytics/src/services/queries/getLeadActions.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getLeadActions.ts
@@ -1,8 +1,11 @@
 import type { AnalyticsQuery, LeadActionsCurrent, LeadActionsResponse, Row } from "../../types/query";
+import type { PageFilterContext } from "../pageFilter/types";
 import { getPluginConfig } from "../../config";
 import { resolveDateRange } from "../../utils/date/resolveDateRange";
 import { resolveComparison } from "../../utils/date/resolveComparison";
 import { bucketByDateRange, convertMetricToNumber, dateRangesFor, deriveMissing, leadActionFilter } from "../../utils/ga4";
+import { DEFAULT_PAGE_DIMENSIONS } from "../../constants/page";
+import { withPageRefFilter } from "../../utils/ga4/withPageRefFilter";
 import { resolveLeadActionTypes } from "../../utils/leadActions/resolveLeadActionTypes";
 import { mapGa4Error } from "../../endpoints/errorMapping";
 import { runQuery } from "../analyticsService/runQuery";
@@ -48,23 +51,34 @@ function aggregate(eventRows: Row[], totalSessions: number, elapsedMsAvailable: 
   return current;
 }
 
-export async function getLeadActions(propertyId: string, query: AnalyticsQuery): Promise<LeadActionsResponse> {
+export async function getLeadActions(propertyId: string, query: AnalyticsQuery, pageFilter?: PageFilterContext | null): Promise<LeadActionsResponse> {
   const dateRange = resolveDateRange(query.dateRange);
   const previousDateRange = query.comparison?.kind === "previous-period" ? resolveComparison(dateRange) : undefined;
   const dateRanges = dateRangesFor(dateRange, previousDateRange);
   const types = resolveLeadActionTypes(getPluginConfig().leadActions?.types);
 
-  const eventsRequest = {
-    dateRanges,
-    metrics: [{ name: "eventCount" }, { name: "averageCustomEvent:fr_elapsed_ms" }],
-    dimensions: [{ name: "customEvent:fr_lead_type" }, { name: "pagePath" }],
-    dimensionFilter: leadActionFilter(types),
-  };
-  const sessionsRequest = {
-    dateRanges,
-    metrics: [{ name: "sessions" }],
-    dimensions: [],
-  };
+  const refs = pageFilter?.refs ?? [];
+  const pageRefDim = pageFilter?.pageRefDim ?? DEFAULT_PAGE_DIMENSIONS.pageRef;
+
+  const eventsRequest = withPageRefFilter(
+    {
+      dateRanges,
+      metrics: [{ name: "eventCount" }, { name: "averageCustomEvent:fr_elapsed_ms" }],
+      dimensions: [{ name: "customEvent:fr_lead_type" }, { name: "pagePath" }],
+      dimensionFilter: leadActionFilter(types),
+    },
+    pageRefDim,
+    refs
+  );
+  const sessionsRequest = withPageRefFilter(
+    {
+      dateRanges,
+      metrics: [{ name: "sessions" }],
+      dimensions: [],
+    },
+    pageRefDim,
+    refs
+  );
 
   let elapsedMsAvailable = true;
   let batch;

--- a/packages/payload-plugin-analytics/src/services/queries/getSessionDetail.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getSessionDetail.ts
@@ -12,17 +12,21 @@ function convertDateHourMinuteToIso(value: string | null | undefined): string {
   return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}T${value.slice(8, 10)}:${value.slice(10, 12)}:00.000Z`;
 }
 
-function convertRowToSessionDetailEvent(row: Row): SessionDetailEvent {
+function convertRowToSessionDetailEvent(row: Row, pageRefIndex: number, labels: Map<string, { path: string }> | null): SessionDetailEvent {
   const dimensionValues = row.dimensionValues ?? [];
   const leadType = dimensionValues[4]?.value ?? "";
   const params: Record<string, unknown> = {};
 
   if (leadType) params[FR_LEAD_TYPE_PARAM] = leadType;
 
+  const rawPagePath = dimensionValues[1]?.value ?? undefined;
+  const rowRef = pageRefIndex >= 0 ? (dimensionValues[pageRefIndex]?.value ?? "") : "";
+  const pagePath = labels?.get(rowRef)?.path ?? rawPagePath;
+
   return {
     timestamp: convertDateHourMinuteToIso(dimensionValues[2]?.value),
     eventName: dimensionValues[0]?.value ?? "",
-    pagePath: dimensionValues[1]?.value ?? undefined,
+    pagePath,
     params,
   };
 }
@@ -49,6 +53,16 @@ function buildRequest(sessionId: string, dateRange: ReturnType<typeof resolveDat
   };
 
   return { request, pageRefIndex };
+}
+
+async function resolveRowLabels(rows: Row[], pageRefIndex: number, pageFilter: PageFilterContext): Promise<Map<string, { path: string }>> {
+  const refs = new Set<string>();
+  for (const row of rows) {
+    const ref = pageRefIndex >= 0 ? (row.dimensionValues?.[pageRefIndex]?.value ?? "") : "";
+    if (ref) refs.add(ref);
+  }
+
+  return pageFilter.resolveLabels([...refs]);
 }
 
 function sessionRefsAllExisting(rows: Row[], pageRefIndex: number, existing: Set<string>): boolean {
@@ -79,7 +93,9 @@ export async function getSessionDetail(propertyId: string, sessionId: string, qu
       return { sessionId, events: [] };
     }
 
-    return { sessionId, events: rows.map(convertRowToSessionDetailEvent) };
+    const labels = pageFilterActive && pageFilter ? await resolveRowLabels(rows, pageRefIndex, pageFilter) : null;
+
+    return { sessionId, events: rows.map((row) => convertRowToSessionDetailEvent(row, pageRefIndex, labels)) };
   } catch (err) {
     const mapped = mapGa4Error(err);
 
@@ -97,7 +113,9 @@ export async function getSessionDetail(propertyId: string, sessionId: string, qu
           return { sessionId, events: [], missing };
         }
 
-        return { sessionId, events: rows.map(convertRowToSessionDetailEvent), missing };
+        const labels = pageFilterActive && pageFilter ? await resolveRowLabels(rows, pageRefIndex, pageFilter) : null;
+
+        return { sessionId, events: rows.map((row) => convertRowToSessionDetailEvent(row, pageRefIndex, labels)), missing };
       } catch {
         // why: if the lead-type-less retry also fails, intentionally fall through
         // to the setupRequired return below rather than rethrowing.

--- a/packages/payload-plugin-analytics/src/services/queries/getSessionDetail.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getSessionDetail.ts
@@ -1,4 +1,5 @@
 import type { AnalyticsQuery, Row, SessionDetailEvent, SessionDetailResponse } from "../../types/query";
+import type { PageFilterContext } from "../pageFilter/types";
 import { FR_LEAD_TYPE_PARAM } from "../../constants/events";
 import { resolveDateRange } from "../../utils/date/resolveDateRange";
 import { dateRangesFor, deriveMissing } from "../../utils/ga4";
@@ -26,12 +27,18 @@ function convertRowToSessionDetailEvent(row: Row): SessionDetailEvent {
   };
 }
 
-function buildRequest(sessionId: string, dateRange: ReturnType<typeof resolveDateRange>, includeLeadType: boolean) {
+function buildRequest(sessionId: string, dateRange: ReturnType<typeof resolveDateRange>, includeLeadType: boolean, pageRefDim?: string) {
   const dimensions: Array<{ name: string }> = [{ name: "eventName" }, { name: "pagePath" }, { name: "dateHourMinute" }, { name: "customEvent:fr_event_seq" }];
 
   if (includeLeadType) dimensions.push({ name: "customEvent:fr_lead_type" });
 
-  return {
+  let pageRefIndex = -1;
+  if (pageRefDim) {
+    pageRefIndex = dimensions.length;
+    dimensions.push({ name: pageRefDim });
+  }
+
+  const request = {
     dateRanges: dateRangesFor(dateRange),
     metrics: [{ name: "eventCount" }],
     dimensions,
@@ -40,15 +47,37 @@ function buildRequest(sessionId: string, dateRange: ReturnType<typeof resolveDat
     },
     orderBys: [{ dimension: { dimensionName: "dateHourMinute" } }, { dimension: { dimensionName: "customEvent:fr_event_seq" } }],
   };
+
+  return { request, pageRefIndex };
 }
 
-export async function getSessionDetail(propertyId: string, sessionId: string, query: AnalyticsQuery): Promise<SessionDetailResponse> {
+function sessionRefsAllExisting(rows: Row[], pageRefIndex: number, existing: Set<string>): boolean {
+  const refs = new Set<string>();
+  for (const row of rows) refs.add(row.dimensionValues?.[pageRefIndex]?.value ?? "");
+
+  if (refs.size === 0) return false;
+  for (const ref of refs) {
+    if (!existing.has(ref)) return false;
+  }
+
+  return true;
+}
+
+export async function getSessionDetail(propertyId: string, sessionId: string, query: AnalyticsQuery, pageFilter?: PageFilterContext | null): Promise<SessionDetailResponse> {
   const dateRange = resolveDateRange(query.dateRange);
+  const filterRefs = pageFilter?.refs ?? [];
+  const pageFilterActive = filterRefs.length > 0;
+  const pageRefDim = pageFilterActive && pageFilter ? pageFilter.pageRefDim : undefined;
+  const existingRefs = new Set(filterRefs);
 
   try {
-    const request = buildRequest(sessionId, dateRange, true);
+    const { request, pageRefIndex } = buildRequest(sessionId, dateRange, true, pageRefDim);
     const raw = await runQuery.runReport(propertyId, request as Parameters<typeof runQuery.runReport>[1], "sessionDetail");
     const rows = (raw.rows ?? []) as Row[];
+
+    if (pageFilterActive && !sessionRefsAllExisting(rows, pageRefIndex, existingRefs)) {
+      return { sessionId, events: [] };
+    }
 
     return { sessionId, events: rows.map(convertRowToSessionDetailEvent) };
   } catch (err) {
@@ -56,16 +85,23 @@ export async function getSessionDetail(propertyId: string, sessionId: string, qu
 
     if (!mapped.setupRequired) throw err;
 
-    const missing = deriveMissing({ message: mapped.message }, ["fr_session_id", "fr_event_seq", "fr_lead_type"]);
+    const missing = deriveMissing({ message: mapped.message }, ["fr_session_id", "fr_event_seq", "fr_lead_type", "fr_page_ref"]);
 
     if (missing.length === 1 && missing[0] === "fr_lead_type") {
       try {
-        const fallbackRequest = buildRequest(sessionId, dateRange, false);
+        const { request: fallbackRequest, pageRefIndex } = buildRequest(sessionId, dateRange, false, pageRefDim);
         const raw = await runQuery.runReport(propertyId, fallbackRequest as Parameters<typeof runQuery.runReport>[1], "sessionDetail");
         const rows = (raw.rows ?? []) as Row[];
 
+        if (pageFilterActive && !sessionRefsAllExisting(rows, pageRefIndex, existingRefs)) {
+          return { sessionId, events: [], missing };
+        }
+
         return { sessionId, events: rows.map(convertRowToSessionDetailEvent), missing };
-      } catch {}
+      } catch {
+        // why: if the lead-type-less retry also fails, intentionally fall through
+        // to the setupRequired return below rather than rethrowing.
+      }
     }
 
     return {

--- a/packages/payload-plugin-analytics/src/services/queries/getTopCountries.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getTopCountries.ts
@@ -1,7 +1,10 @@
 import type { Row, TopCountriesQuery, TopCountriesResponse, TopCountriesRow } from "../../types/query";
+import type { PageFilterContext } from "../pageFilter/types";
 import { resolveDateRange } from "../../utils/date/resolveDateRange";
 import { resolveComparison } from "../../utils/date/resolveComparison";
 import { bucketByDateRange, convertMetricToNumber, dateRangesFor, withRowLimit } from "../../utils/ga4";
+import { DEFAULT_PAGE_DIMENSIONS } from "../../constants/page";
+import { withPageRefFilter } from "../../utils/ga4/withPageRefFilter";
 import { runQuery } from "../analyticsService/runQuery";
 
 const METRICS = [{ name: "sessions" }, { name: "totalUsers" }];
@@ -37,7 +40,7 @@ function dimensionsFor(dimension: "country" | "city") {
   return dimension === "city" ? [{ name: "city" }, { name: "country" }] : [{ name: "country" }];
 }
 
-export async function getTopCountries(propertyId: string, query: TopCountriesQuery): Promise<TopCountriesResponse> {
+export async function getTopCountries(propertyId: string, query: TopCountriesQuery, pageFilter?: PageFilterContext | null): Promise<TopCountriesResponse> {
   const dimension: "country" | "city" = query.dimension ?? "country";
   const dateRange = resolveDateRange(query.dateRange);
   const previousDateRange = query.comparison?.kind === "previous-period" ? resolveComparison(dateRange) : undefined;
@@ -46,7 +49,9 @@ export async function getTopCountries(propertyId: string, query: TopCountriesQue
   const dimensions = dimensionsFor(dimension);
 
   const request = withRowLimit({ dateRanges, metrics: METRICS, dimensions }, query.limit);
-  const raw = await runQuery.runReport(propertyId, request as Parameters<typeof runQuery.runReport>[1], "topCountries");
+  const refs = pageFilter?.refs ?? [];
+  const filtered = withPageRefFilter(request, pageFilter?.pageRefDim ?? DEFAULT_PAGE_DIMENSIONS.pageRef, refs);
+  const raw = await runQuery.runReport(propertyId, filtered as Parameters<typeof runQuery.runReport>[1], "topCountries");
   const rows = (raw.rows ?? []) as Row[];
 
   if (!previousDateRange) {

--- a/packages/payload-plugin-analytics/src/services/queries/getTopDevices.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getTopDevices.ts
@@ -1,7 +1,10 @@
 import type { DeviceCategory, Row, TopDevicesResponse, TopDevicesRow, TopNQuery } from "../../types/query";
+import type { PageFilterContext } from "../pageFilter/types";
 import { resolveDateRange } from "../../utils/date/resolveDateRange";
 import { resolveComparison } from "../../utils/date/resolveComparison";
 import { bucketByDateRange, convertMetricToNumber, dateRangesFor, withRowLimit } from "../../utils/ga4";
+import { DEFAULT_PAGE_DIMENSIONS } from "../../constants/page";
+import { withPageRefFilter } from "../../utils/ga4/withPageRefFilter";
 import { runQuery } from "../analyticsService/runQuery";
 
 const METRICS = [{ name: "sessions" }, { name: "totalUsers" }];
@@ -31,7 +34,7 @@ function buildDeviceKey(row: TopDevicesRow): string {
   return `${row.deviceCategory}|${row.browser}|${row.os}`;
 }
 
-export async function getTopDevices(propertyId: string, query: TopNQuery): Promise<TopDevicesResponse> {
+export async function getTopDevices(propertyId: string, query: TopNQuery, pageFilter?: PageFilterContext | null): Promise<TopDevicesResponse> {
   const dateRange = resolveDateRange(query.dateRange);
   const previousDateRange = query.comparison?.kind === "previous-period" ? resolveComparison(dateRange) : undefined;
   const dateRanges = dateRangesFor(dateRange, previousDateRange);
@@ -39,7 +42,9 @@ export async function getTopDevices(propertyId: string, query: TopNQuery): Promi
   const dimensions = [{ name: "deviceCategory" }, { name: "browser" }, { name: "operatingSystem" }];
 
   const request = withRowLimit({ dateRanges, metrics: METRICS, dimensions }, query.limit);
-  const raw = await runQuery.runReport(propertyId, request as Parameters<typeof runQuery.runReport>[1], "topDevices");
+  const refs = pageFilter?.refs ?? [];
+  const filtered = withPageRefFilter(request, pageFilter?.pageRefDim ?? DEFAULT_PAGE_DIMENSIONS.pageRef, refs);
+  const raw = await runQuery.runReport(propertyId, filtered as Parameters<typeof runQuery.runReport>[1], "topDevices");
   const rows = (raw.rows ?? []) as Row[];
 
   if (!previousDateRange) {

--- a/packages/payload-plugin-analytics/src/services/queries/getTopEvents.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getTopEvents.ts
@@ -1,7 +1,10 @@
 import type { Row, TopEventsResponse, TopEventsRow, TopNQuery } from "../../types/query";
+import type { PageFilterContext } from "../pageFilter/types";
 import { resolveDateRange } from "../../utils/date/resolveDateRange";
 import { resolveComparison } from "../../utils/date/resolveComparison";
 import { bucketByDateRange, convertMetricToNumber, dateRangesFor, withRowLimit } from "../../utils/ga4";
+import { DEFAULT_PAGE_DIMENSIONS } from "../../constants/page";
+import { withPageRefFilter } from "../../utils/ga4/withPageRefFilter";
 import { runQuery } from "../analyticsService/runQuery";
 
 const METRICS = [{ name: "eventCount" }, { name: "eventCountPerUser" }];
@@ -17,7 +20,7 @@ function convertRowToTopEventsRow(row: Row): TopEventsRow {
   };
 }
 
-export async function getTopEvents(propertyId: string, query: TopNQuery): Promise<TopEventsResponse> {
+export async function getTopEvents(propertyId: string, query: TopNQuery, pageFilter?: PageFilterContext | null): Promise<TopEventsResponse> {
   const dateRange = resolveDateRange(query.dateRange);
   const previousDateRange = query.comparison?.kind === "previous-period" ? resolveComparison(dateRange) : undefined;
   const dateRanges = dateRangesFor(dateRange, previousDateRange);
@@ -25,7 +28,9 @@ export async function getTopEvents(propertyId: string, query: TopNQuery): Promis
   const dimensions = [{ name: "eventName" }];
 
   const request = withRowLimit({ dateRanges, metrics: METRICS, dimensions }, query.limit);
-  const raw = await runQuery.runReport(propertyId, request as Parameters<typeof runQuery.runReport>[1], "topEvents");
+  const refs = pageFilter?.refs ?? [];
+  const filtered = withPageRefFilter(request, pageFilter?.pageRefDim ?? DEFAULT_PAGE_DIMENSIONS.pageRef, refs);
+  const raw = await runQuery.runReport(propertyId, filtered as Parameters<typeof runQuery.runReport>[1], "topEvents");
   const rows = (raw.rows ?? []) as Row[];
 
   if (!previousDateRange) {

--- a/packages/payload-plugin-analytics/src/services/queries/getTopPages.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getTopPages.ts
@@ -2,9 +2,8 @@ import type { Row, TopNQuery, TopPagesResponse, TopPagesRow } from "../../types/
 import type { PageFilterContext } from "../pageFilter/types";
 import { resolveDateRange } from "../../utils/date/resolveDateRange";
 import { resolveComparison } from "../../utils/date/resolveComparison";
-import { bucketByDateRange, convertMetricToNumber, dateRangesFor, withRowLimit } from "../../utils/ga4";
-import { DEFAULT_PAGE_DIMENSIONS } from "../../constants/page";
-import { withPageRefFilter } from "../../utils/ga4/withPageRefFilter";
+import { bucketByDateRange, convertMetricToNumber, dateRangesFor, withInListFilter, withRowLimit } from "../../utils/ga4";
+import { aggregateByRef } from "../../utils/ga4/aggregateByRef";
 import { runQuery } from "../analyticsService/runQuery";
 
 const METRICS = [{ name: "screenPageViews" }, { name: "sessions" }, { name: "averageSessionDuration" }];
@@ -26,17 +25,9 @@ function sumPageViews(rows: TopPagesRow[]): number {
   return rows.reduce((sum, row) => sum + row.pageViews, 0);
 }
 
-export async function getTopPages(propertyId: string, query: TopNQuery, pageFilter?: PageFilterContext | null): Promise<TopPagesResponse> {
-  const dateRange = resolveDateRange(query.dateRange);
-  const previousDateRange = query.comparison?.kind === "previous-period" ? resolveComparison(dateRange) : undefined;
-  const dateRanges = dateRangesFor(dateRange, previousDateRange);
-
-  const dimensions = [{ name: "pagePath" }, { name: "pageTitle" }];
-
-  const request = withRowLimit({ dateRanges, metrics: METRICS, dimensions }, query.limit);
-  const refs = pageFilter?.refs ?? [];
-  const filtered = withPageRefFilter(request, pageFilter?.pageRefDim ?? DEFAULT_PAGE_DIMENSIONS.pageRef, refs);
-  const raw = await runQuery.runReport(propertyId, filtered as Parameters<typeof runQuery.runReport>[1], "topPages");
+async function getTopPagesLegacy(propertyId: string, query: TopNQuery, dateRanges: ReturnType<typeof dateRangesFor>, previousDateRange: unknown): Promise<TopPagesResponse> {
+  const request = withRowLimit({ dateRanges, metrics: METRICS, dimensions: [{ name: "pagePath" }, { name: "pageTitle" }] }, query.limit);
+  const raw = await runQuery.runReport(propertyId, request as Parameters<typeof runQuery.runReport>[1], "topPages");
   const rows = (raw.rows ?? []) as Row[];
 
   if (!previousDateRange) {
@@ -53,6 +44,59 @@ export async function getTopPages(propertyId: string, query: TopNQuery, pageFilt
     previousRowsByPath.set(row.pagePath, row);
   }
 
+  const comparisonRows = currentRows.map((row) => previousRowsByPath.get(row.pagePath)).filter((row): row is TopPagesRow => row !== undefined);
+
+  return {
+    rows: currentRows,
+    total: sumPageViews(currentRows),
+    comparison: {
+      rows: comparisonRows,
+      total: sumPageViews(comparisonRows),
+    },
+  };
+}
+
+async function rowsByRefToTopPages(refMetrics: Map<string, number[]>, pageFilter: PageFilterContext): Promise<TopPagesRow[]> {
+  const refs = [...refMetrics.keys()];
+  const labels = await pageFilter.resolveLabels(refs);
+
+  return refs.map((ref) => {
+    const [views = 0, sessions = 0, durSum = 0] = refMetrics.get(ref) ?? [];
+    const label = labels.get(ref);
+
+    return {
+      pagePath: label?.path ?? ref,
+      pageTitle: label?.title ?? ref,
+      pageViews: views,
+      sessions,
+      avgTime: durSum,
+    };
+  });
+}
+
+export async function getTopPages(propertyId: string, query: TopNQuery, pageFilter?: PageFilterContext | null): Promise<TopPagesResponse> {
+  const dateRange = resolveDateRange(query.dateRange);
+  const previousDateRange = query.comparison?.kind === "previous-period" ? resolveComparison(dateRange) : undefined;
+  const dateRanges = dateRangesFor(dateRange, previousDateRange);
+
+  if (!pageFilter || pageFilter.refs.length === 0) {
+    return getTopPagesLegacy(propertyId, query, dateRanges, previousDateRange);
+  }
+
+  const request = withInListFilter(withRowLimit({ dateRanges, metrics: METRICS, dimensions: [{ name: pageFilter.pageRefDim }] }, query.limit), pageFilter.pageRefDim, pageFilter.refs);
+  const raw = await runQuery.runReport(propertyId, request as Parameters<typeof runQuery.runReport>[1], "topPages");
+  const rows = (raw.rows ?? []) as Row[];
+
+  if (!previousDateRange) {
+    const currentRows = await rowsByRefToTopPages(aggregateByRef(rows, 0, 3), pageFilter);
+
+    return { rows: currentRows, total: sumPageViews(currentRows) };
+  }
+
+  const buckets = bucketByDateRange(rows, ["current", "previous"]);
+  const currentRows = await rowsByRefToTopPages(aggregateByRef(buckets.current, 0, 3), pageFilter);
+  const previousRows = await rowsByRefToTopPages(aggregateByRef(buckets.previous, 0, 3), pageFilter);
+  const previousRowsByPath = new Map(previousRows.map((row) => [row.pagePath, row]));
   const comparisonRows = currentRows.map((row) => previousRowsByPath.get(row.pagePath)).filter((row): row is TopPagesRow => row !== undefined);
 
   return {

--- a/packages/payload-plugin-analytics/src/services/queries/getTopPages.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getTopPages.ts
@@ -1,7 +1,10 @@
 import type { Row, TopNQuery, TopPagesResponse, TopPagesRow } from "../../types/query";
+import type { PageFilterContext } from "../pageFilter/types";
 import { resolveDateRange } from "../../utils/date/resolveDateRange";
 import { resolveComparison } from "../../utils/date/resolveComparison";
 import { bucketByDateRange, convertMetricToNumber, dateRangesFor, withRowLimit } from "../../utils/ga4";
+import { DEFAULT_PAGE_DIMENSIONS } from "../../constants/page";
+import { withPageRefFilter } from "../../utils/ga4/withPageRefFilter";
 import { runQuery } from "../analyticsService/runQuery";
 
 const METRICS = [{ name: "screenPageViews" }, { name: "sessions" }, { name: "averageSessionDuration" }];
@@ -23,7 +26,7 @@ function sumPageViews(rows: TopPagesRow[]): number {
   return rows.reduce((sum, row) => sum + row.pageViews, 0);
 }
 
-export async function getTopPages(propertyId: string, query: TopNQuery): Promise<TopPagesResponse> {
+export async function getTopPages(propertyId: string, query: TopNQuery, pageFilter?: PageFilterContext | null): Promise<TopPagesResponse> {
   const dateRange = resolveDateRange(query.dateRange);
   const previousDateRange = query.comparison?.kind === "previous-period" ? resolveComparison(dateRange) : undefined;
   const dateRanges = dateRangesFor(dateRange, previousDateRange);
@@ -31,7 +34,9 @@ export async function getTopPages(propertyId: string, query: TopNQuery): Promise
   const dimensions = [{ name: "pagePath" }, { name: "pageTitle" }];
 
   const request = withRowLimit({ dateRanges, metrics: METRICS, dimensions }, query.limit);
-  const raw = await runQuery.runReport(propertyId, request as Parameters<typeof runQuery.runReport>[1], "topPages");
+  const refs = pageFilter?.refs ?? [];
+  const filtered = withPageRefFilter(request, pageFilter?.pageRefDim ?? DEFAULT_PAGE_DIMENSIONS.pageRef, refs);
+  const raw = await runQuery.runReport(propertyId, filtered as Parameters<typeof runQuery.runReport>[1], "topPages");
   const rows = (raw.rows ?? []) as Row[];
 
   if (!previousDateRange) {

--- a/packages/payload-plugin-analytics/src/services/queries/getTopSources.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/getTopSources.ts
@@ -1,7 +1,10 @@
 import type { Row, TopNQuery, TopSourcesResponse, TopSourcesRow } from "../../types/query";
+import type { PageFilterContext } from "../pageFilter/types";
 import { resolveDateRange } from "../../utils/date/resolveDateRange";
 import { resolveComparison } from "../../utils/date/resolveComparison";
 import { bucketByDateRange, convertMetricToNumber, dateRangesFor, withRowLimit } from "../../utils/ga4";
+import { DEFAULT_PAGE_DIMENSIONS } from "../../constants/page";
+import { withPageRefFilter } from "../../utils/ga4/withPageRefFilter";
 import { runQuery } from "../analyticsService/runQuery";
 
 const METRICS = [{ name: "sessions" }, { name: "totalUsers" }];
@@ -23,7 +26,7 @@ function buildSourceKey(row: TopSourcesRow): string {
   return `${row.source}|${row.medium}|${row.channel}`;
 }
 
-export async function getTopSources(propertyId: string, query: TopNQuery): Promise<TopSourcesResponse> {
+export async function getTopSources(propertyId: string, query: TopNQuery, pageFilter?: PageFilterContext | null): Promise<TopSourcesResponse> {
   const dateRange = resolveDateRange(query.dateRange);
   const previousDateRange = query.comparison?.kind === "previous-period" ? resolveComparison(dateRange) : undefined;
   const dateRanges = dateRangesFor(dateRange, previousDateRange);
@@ -31,7 +34,9 @@ export async function getTopSources(propertyId: string, query: TopNQuery): Promi
   const dimensions = [{ name: "sessionSource" }, { name: "sessionMedium" }, { name: "sessionDefaultChannelGroup" }];
 
   const request = withRowLimit({ dateRanges, metrics: METRICS, dimensions }, query.limit);
-  const raw = await runQuery.runReport(propertyId, request as Parameters<typeof runQuery.runReport>[1], "topSources");
+  const refs = pageFilter?.refs ?? [];
+  const filtered = withPageRefFilter(request, pageFilter?.pageRefDim ?? DEFAULT_PAGE_DIMENSIONS.pageRef, refs);
+  const raw = await runQuery.runReport(propertyId, filtered as Parameters<typeof runQuery.runReport>[1], "topSources");
   const rows = (raw.rows ?? []) as Row[];
 
   if (!previousDateRange) {

--- a/packages/payload-plugin-analytics/src/services/queries/kpiRecompute/aggregateSessions.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/kpiRecompute/aggregateSessions.ts
@@ -1,0 +1,130 @@
+import type { KpiCurrent, KpiSeriesPoint } from "../../../types/query";
+import { TRAFFIC_EVENTS } from "../../../constants/events";
+import { excludeDeletedSessions } from "../../pageFilter/excludeDeletedSessions";
+import { isoFromGa4Date } from "../../../utils/ga4/isoFromGa4Date";
+
+export interface KpiSessionEventRow {
+  sessionId: string;
+  /** GA4 "date" dim, yyyymmdd. */
+  date: string;
+  /** Value of fr_page_ref for this event ("" if absent). */
+  pageRef: string;
+  /** GA4 eventName. */
+  eventName: string;
+  /** GA4 "dateHourMinute" dim value, "YYYYMMDDHHMM" (12 digits; "" if absent). */
+  dhm: string;
+}
+
+function dhmToEpochSeconds(dhm: string): number | null {
+  if (dhm.length !== 12) return null;
+
+  const year = Number(dhm.slice(0, 4));
+  const month = Number(dhm.slice(4, 6));
+  const day = Number(dhm.slice(6, 8));
+  const hour = Number(dhm.slice(8, 10));
+  const minute = Number(dhm.slice(10, 12));
+
+  if ([year, month, day, hour, minute].some((n) => Number.isNaN(n))) return null;
+
+  const ms = Date.UTC(year, month - 1, day, hour, minute);
+  if (Number.isNaN(ms)) return null;
+
+  return ms / 1000;
+}
+
+interface SessionAccumulator {
+  refs: Set<string>;
+  pageViews: number;
+  minDhm: string;
+  maxDhm: string;
+  /** MIN date across the session's rows — its first-seen day. */
+  date: string;
+}
+
+function sessionDurationSeconds(s: SessionAccumulator): number {
+  if (s.minDhm === "" || s.maxDhm === "") return 0;
+  const min = dhmToEpochSeconds(s.minDhm);
+  const max = dhmToEpochSeconds(s.maxDhm);
+  if (min === null || max === null) return 0;
+  return Math.max(0, max - min);
+}
+
+function emptyCurrent(): KpiCurrent {
+  return { sessions: 0, users: 0, pageViews: 0, bounceRate: 0, avgSessionDuration: 0 };
+}
+
+function summarise(sessions: SessionAccumulator[]): KpiCurrent {
+  const count = sessions.length;
+  if (count === 0) return emptyCurrent();
+
+  let pageViews = 0;
+  let bounced = 0;
+  let durationSum = 0;
+
+  for (const s of sessions) {
+    pageViews += s.pageViews;
+    if (s.pageViews <= 1) bounced += 1;
+    durationSum += sessionDurationSeconds(s);
+  }
+
+  return {
+    sessions: count,
+    users: count,
+    pageViews,
+    bounceRate: bounced / count,
+    avgSessionDuration: durationSum / count,
+  };
+}
+
+export function aggregateSessions(rows: KpiSessionEventRow[], existing: Set<string>): { current: KpiCurrent; series: KpiSeriesPoint[] } {
+  const bySession = new Map<string, SessionAccumulator>();
+
+  for (const row of rows) {
+    const acc = bySession.get(row.sessionId);
+
+    if (acc) {
+      acc.refs.add(row.pageRef);
+      if (row.eventName === TRAFFIC_EVENTS.PAGE_VIEW) acc.pageViews += 1;
+      if (row.dhm.length === 12) {
+        if (acc.minDhm === "" || row.dhm < acc.minDhm) acc.minDhm = row.dhm;
+        if (acc.maxDhm === "" || row.dhm > acc.maxDhm) acc.maxDhm = row.dhm;
+      }
+      if (row.date < acc.date) acc.date = row.date;
+    } else {
+      const validDhm = row.dhm.length === 12 ? row.dhm : "";
+      bySession.set(row.sessionId, {
+        refs: new Set([row.pageRef]),
+        pageViews: row.eventName === TRAFFIC_EVENTS.PAGE_VIEW ? 1 : 0,
+        minDhm: validDhm,
+        maxDhm: validDhm,
+        date: row.date,
+      });
+    }
+  }
+
+  const refsBySession = new Map<string, Set<string>>();
+  for (const [sessionId, acc] of bySession) refsBySession.set(sessionId, acc.refs);
+
+  const allowedIds = excludeDeletedSessions(refsBySession, existing);
+
+  const allowed: SessionAccumulator[] = [];
+  for (const [sessionId, acc] of bySession) {
+    if (allowedIds.has(sessionId)) allowed.push(acc);
+  }
+
+  const current = summarise(allowed);
+
+  const byDate = new Map<string, SessionAccumulator[]>();
+  for (const acc of allowed) {
+    const bucket = byDate.get(acc.date);
+    if (bucket) bucket.push(acc);
+    else byDate.set(acc.date, [acc]);
+  }
+
+  const series: KpiSeriesPoint[] = [...byDate.entries()]
+    .map(([date, sessions]) => ({ date: isoFromGa4Date(date), ...summarise(sessions) }))
+    .filter((p) => p.date !== "")
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  return { current, series };
+}

--- a/packages/payload-plugin-analytics/src/services/queries/listSessions.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/listSessions.ts
@@ -1,6 +1,8 @@
 import type { DeviceCategory, Row, SessionsListQuery, SessionsResponse, SessionsRow } from "../../types/query";
+import type { PageFilterContext } from "../pageFilter/types";
 import { resolveDateRange } from "../../utils/date/resolveDateRange";
 import { convertMetricToNumber, dateRangesFor, deriveMissing, leadActionFilter, withRowLimit } from "../../utils/ga4";
+import { excludeDeletedSessions } from "../pageFilter/excludeDeletedSessions";
 import { mapGa4Error } from "../../endpoints/errorMapping";
 import { runQuery } from "../analyticsService/runQuery";
 
@@ -69,10 +71,12 @@ interface MergedSession {
   eventCount: number;
 }
 
-export async function listSessions(propertyId: string, query: SessionsListQuery): Promise<SessionsResponse> {
+export async function listSessions(propertyId: string, query: SessionsListQuery, pageFilter?: PageFilterContext | null): Promise<SessionsResponse> {
   const dateRange = resolveDateRange(query.dateRange);
   const offset = decodeCursor(query.cursor);
   const limit = query.limit ?? DEFAULT_PAGE_SIZE;
+  const filterRefs = pageFilter?.refs ?? [];
+  const pageFilterActive = filterRefs.length > 0;
 
   const dimensions = [
     { name: "customEvent:fr_session_id" },
@@ -82,6 +86,13 @@ export async function listSessions(propertyId: string, query: SessionsListQuery)
     { name: "country" },
     { name: "customEvent:fr_session_start" },
   ];
+
+  let pageRefDimIndex = -1;
+
+  if (pageFilterActive && pageFilter) {
+    pageRefDimIndex = dimensions.length;
+    dimensions.push({ name: pageFilter.pageRefDim });
+  }
 
   let sessionsRequest: Record<string, unknown> = withRowLimit(
     {
@@ -130,6 +141,7 @@ export async function listSessions(propertyId: string, query: SessionsListQuery)
     }
 
     const merged = new Map<string, MergedSession>();
+    const refsBySession = new Map<string, Set<string>>();
 
     for (const row of rows) {
       const dv = row.dimensionValues ?? [];
@@ -141,6 +153,13 @@ export async function listSessions(propertyId: string, query: SessionsListQuery)
       const country = dv[4]?.value ?? "";
       const events = convertMetricToNumber(mv[0]?.value);
       const startedAt = dv[5]?.value ?? "";
+
+      if (pageFilterActive) {
+        const ref = dv[pageRefDimIndex]?.value ?? "";
+        const set = refsBySession.get(id) ?? new Set<string>();
+        set.add(ref);
+        refsBySession.set(id, set);
+      }
 
       const existing = merged.get(id);
       if (existing) {
@@ -167,18 +186,23 @@ export async function listSessions(propertyId: string, query: SessionsListQuery)
       }
     }
 
-    const sessionsRows: SessionsRow[] = Array.from(merged.values())
-      .slice(0, limit)
-      .map((m) => ({
-        sessionId: m.sessionId,
-        landingPage: m.landingPage,
-        source: m.source,
-        deviceCategory: Array.from(m.devices),
-        country: Array.from(m.countries),
-        startedAt: m.startedAt,
-        eventCount: m.eventCount,
-        hadLeadAction: leadSessionIds.has(m.sessionId),
-      }));
+    let mergedSessions = Array.from(merged.values());
+
+    if (pageFilterActive) {
+      const allowed = excludeDeletedSessions(refsBySession, new Set(filterRefs));
+      mergedSessions = mergedSessions.filter((m) => allowed.has(m.sessionId));
+    }
+
+    const sessionsRows: SessionsRow[] = mergedSessions.map((m) => ({
+      sessionId: m.sessionId,
+      landingPage: m.landingPage,
+      source: m.source,
+      deviceCategory: Array.from(m.devices),
+      country: Array.from(m.countries),
+      startedAt: m.startedAt,
+      eventCount: m.eventCount,
+      hadLeadAction: leadSessionIds.has(m.sessionId),
+    }));
 
     const totalRows = sessionsReport?.rowCount ?? rows.length;
     const nextOffset = offset + rows.length;
@@ -197,7 +221,7 @@ export async function listSessions(propertyId: string, query: SessionsListQuery)
     if (mapped.setupRequired) {
       return {
         setupRequired: true,
-        missing: deriveMissing({ message: mapped.message }, ["fr_session_id", "fr_session_start"]),
+        missing: deriveMissing({ message: mapped.message }, ["fr_session_id", "fr_session_start", "fr_page_ref"]),
         rows: [],
         pagination: { cursor: null, hasMore: false },
       };

--- a/packages/payload-plugin-analytics/src/services/queries/listSessions.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/listSessions.ts
@@ -5,6 +5,7 @@ import { convertMetricToNumber, dateRangesFor, deriveMissing, leadActionFilter, 
 import { excludeDeletedSessions } from "../pageFilter/excludeDeletedSessions";
 import { mapGa4Error } from "../../endpoints/errorMapping";
 import { runQuery } from "../analyticsService/runQuery";
+import { TRAFFIC_EVENTS } from "../../constants/events";
 
 const DEFAULT_PAGE_SIZE = 50;
 
@@ -69,6 +70,66 @@ interface MergedSession {
   devices: Set<DeviceCategory>;
   countries: Set<string>;
   eventCount: number;
+}
+
+/**
+ * Resolve the landing (first) page_view ref per session to its current CMS path.
+ *
+ * The session-aggregated query cannot tell which of a multi-page session's refs
+ * is the LANDING ref, so we run a supplementary ordered event-level query and
+ * take the FIRST page_view row per session as its landing event.
+ *
+ * why: a failing landing-ref query must not blank the sessions list — on ANY
+ * error we return an empty Map and the caller falls back to the raw GA4
+ * landingPagePlusQueryString.
+ */
+async function resolveLandingPaths(propertyId: string, dateRange: ReturnType<typeof resolveDateRange>, pageFilter: PageFilterContext, sessionIds: string[]): Promise<Map<string, string>> {
+  try {
+    const request = {
+      dateRanges: dateRangesFor(dateRange),
+      metrics: [{ name: "eventCount" }],
+      dimensions: [{ name: "customEvent:fr_session_id" }, { name: pageFilter.pageRefDim }, { name: "dateHourMinute" }, { name: "customEvent:fr_event_seq" }],
+      dimensionFilter: {
+        andGroup: {
+          expressions: [
+            { filter: { fieldName: "eventName", stringFilter: { value: TRAFFIC_EVENTS.PAGE_VIEW } } },
+            { filter: { fieldName: "customEvent:fr_session_id", inListFilter: { values: sessionIds } } },
+          ],
+        },
+      },
+      orderBys: [{ dimension: { dimensionName: "customEvent:fr_session_id" } }, { dimension: { dimensionName: "dateHourMinute" } }, { dimension: { dimensionName: "customEvent:fr_event_seq" } }],
+    };
+
+    const report = await runQuery.runReport(propertyId, request as Parameters<typeof runQuery.runReport>[1], "sessionLandingRefs");
+    const rows = (report.rows ?? []) as Row[];
+
+    const landingRefBySession = new Map<string, string>();
+
+    for (const row of rows) {
+      const dv = row.dimensionValues ?? [];
+      const id = dv[0]?.value ?? "";
+      const ref = dv[1]?.value ?? "";
+
+      if (!id || !ref) continue;
+      // First row seen for a session (rows are ordered) is its landing event.
+      if (!landingRefBySession.has(id)) landingRefBySession.set(id, ref);
+    }
+
+    const landingRefs = Array.from(landingRefBySession.values());
+    const labels = await pageFilter.resolveLabels([...new Set(landingRefs)]);
+
+    const pathBySession = new Map<string, string>();
+
+    for (const [id, ref] of landingRefBySession) {
+      const path = labels.get(ref)?.path;
+
+      if (path) pathBySession.set(id, path);
+    }
+
+    return pathBySession;
+  } catch {
+    return new Map<string, string>();
+  }
 }
 
 export async function listSessions(propertyId: string, query: SessionsListQuery, pageFilter?: PageFilterContext | null): Promise<SessionsResponse> {
@@ -193,9 +254,19 @@ export async function listSessions(propertyId: string, query: SessionsListQuery,
       mergedSessions = mergedSessions.filter((m) => allowed.has(m.sessionId));
     }
 
+    let landingPathBySession = new Map<string, string>();
+
+    if (pageFilterActive && pageFilter) {
+      const sessionIds = mergedSessions.map((m) => m.sessionId);
+
+      if (sessionIds.length > 0) {
+        landingPathBySession = await resolveLandingPaths(propertyId, dateRange, pageFilter, sessionIds);
+      }
+    }
+
     const sessionsRows: SessionsRow[] = mergedSessions.map((m) => ({
       sessionId: m.sessionId,
-      landingPage: m.landingPage,
+      landingPage: landingPathBySession.get(m.sessionId) ?? m.landingPage,
       source: m.source,
       deviceCategory: Array.from(m.devices),
       country: Array.from(m.countries),

--- a/packages/payload-plugin-analytics/src/services/queries/listSessions.ts
+++ b/packages/payload-plugin-analytics/src/services/queries/listSessions.ts
@@ -83,22 +83,27 @@ interface MergedSession {
  * error we return an empty Map and the caller falls back to the raw GA4
  * landingPagePlusQueryString.
  */
+const LANDING_REF_ROW_LIMIT = 50_000;
+
 async function resolveLandingPaths(propertyId: string, dateRange: ReturnType<typeof resolveDateRange>, pageFilter: PageFilterContext, sessionIds: string[]): Promise<Map<string, string>> {
   try {
-    const request = {
-      dateRanges: dateRangesFor(dateRange),
-      metrics: [{ name: "eventCount" }],
-      dimensions: [{ name: "customEvent:fr_session_id" }, { name: pageFilter.pageRefDim }, { name: "dateHourMinute" }, { name: "customEvent:fr_event_seq" }],
-      dimensionFilter: {
-        andGroup: {
-          expressions: [
-            { filter: { fieldName: "eventName", stringFilter: { value: TRAFFIC_EVENTS.PAGE_VIEW } } },
-            { filter: { fieldName: "customEvent:fr_session_id", inListFilter: { values: sessionIds } } },
-          ],
+    const request = withRowLimit(
+      {
+        dateRanges: dateRangesFor(dateRange),
+        metrics: [{ name: "eventCount" }],
+        dimensions: [{ name: "customEvent:fr_session_id" }, { name: pageFilter.pageRefDim }, { name: "dateHourMinute" }, { name: "customEvent:fr_event_seq" }],
+        dimensionFilter: {
+          andGroup: {
+            expressions: [
+              { filter: { fieldName: "eventName", stringFilter: { value: TRAFFIC_EVENTS.PAGE_VIEW } } },
+              { filter: { fieldName: "customEvent:fr_session_id", inListFilter: { values: sessionIds } } },
+            ],
+          },
         },
+        orderBys: [{ dimension: { dimensionName: "customEvent:fr_session_id" } }, { dimension: { dimensionName: "dateHourMinute" } }, { dimension: { dimensionName: "customEvent:fr_event_seq" } }],
       },
-      orderBys: [{ dimension: { dimensionName: "customEvent:fr_session_id" } }, { dimension: { dimensionName: "dateHourMinute" } }, { dimension: { dimensionName: "customEvent:fr_event_seq" } }],
-    };
+      LANDING_REF_ROW_LIMIT
+    );
 
     const report = await runQuery.runReport(propertyId, request as Parameters<typeof runQuery.runReport>[1], "sessionLandingRefs");
     const rows = (report.rows ?? []) as Row[];

--- a/packages/payload-plugin-analytics/src/types/config.ts
+++ b/packages/payload-plugin-analytics/src/types/config.ts
@@ -72,4 +72,23 @@ export interface AnalyticsPluginConfig {
    * collection + fr_ab_* GA4 dimensions.
    */
   ab?: AbIntegrationConfig;
+  pages?: PagesAnalyticsConfig;
+}
+
+export interface PagesCollectionConfig {
+  slug: string;
+  /** Enumerate only published docs (where _status = 'published'). Default true. */
+  publishedOnly?: boolean;
+}
+
+export interface PagesAnalyticsConfig {
+  /** Collections whose docs are public pages. String shorthand = { slug, publishedOnly:true }. */
+  collections: Array<string | PagesCollectionConfig>;
+  /** Stable refs for non-CMS routes (e.g. '__home'); always treated as existing. */
+  syntheticRefs?: string[];
+  /** Override GA4 custom-dimension api names. */
+  dimensions?: {
+    pageRef?: string;
+    contentLocale?: string;
+  };
 }

--- a/packages/payload-plugin-analytics/src/types/config.ts
+++ b/packages/payload-plugin-analytics/src/types/config.ts
@@ -79,6 +79,8 @@ export interface PagesCollectionConfig {
   slug: string;
   /** Enumerate only published docs (where _status = 'published'). Default true. */
   publishedOnly?: boolean;
+  /** Doc field used as the display title (read at the default locale). Default "title". */
+  titleField?: string;
 }
 
 export interface PagesAnalyticsConfig {
@@ -91,4 +93,6 @@ export interface PagesAnalyticsConfig {
     pageRef?: string;
     contentLocale?: string;
   };
+  /** Resolve a display path for a page ref ("collection:id" or a synthetic ref like "__home"). */
+  resolvePagePath?: (ref: string, req: PayloadRequest) => string | Promise<string>;
 }

--- a/packages/payload-plugin-analytics/src/types/query.ts
+++ b/packages/payload-plugin-analytics/src/types/query.ts
@@ -1,4 +1,4 @@
-export type CustomRegistrationKey = "fr_session_id" | "fr_event_seq" | "fr_elapsed_ms" | "fr_session_start" | "fr_lead_type";
+export type CustomRegistrationKey = "fr_session_id" | "fr_event_seq" | "fr_elapsed_ms" | "fr_session_start" | "fr_lead_type" | "fr_page_ref" | "fr_content_locale";
 
 export interface SetupGate {
   setupRequired: true;

--- a/packages/payload-plugin-analytics/src/utils/ga4/aggregateByRef.ts
+++ b/packages/payload-plugin-analytics/src/utils/ga4/aggregateByRef.ts
@@ -1,0 +1,21 @@
+import type { Row } from "../../types/query";
+
+export function aggregateByRef(rows: Row[], refIndex: number, metricArity: number): Map<string, number[]> {
+  const out = new Map<string, number[]>();
+
+  for (const row of rows) {
+    const ref = row.dimensionValues?.[refIndex]?.value ?? "";
+    if (!ref) continue;
+
+    const acc = out.get(ref) ?? new Array(metricArity).fill(0);
+
+    for (let i = 0; i < metricArity; i++) {
+      const v = Number(row.metricValues?.[i]?.value ?? "0");
+      acc[i] += Number.isFinite(v) ? v : 0;
+    }
+
+    out.set(ref, acc);
+  }
+
+  return out;
+}

--- a/packages/payload-plugin-analytics/src/utils/ga4/deriveMissing.ts
+++ b/packages/payload-plugin-analytics/src/utils/ga4/deriveMissing.ts
@@ -1,11 +1,13 @@
 import type { CustomRegistrationKey } from "../../types/query";
 
-const CUSTOM_KEY_PATTERNS: Array<{ key: CustomRegistrationKey; regex: RegExp }> = [
+export const CUSTOM_KEY_PATTERNS: Array<{ key: CustomRegistrationKey; regex: RegExp }> = [
   { key: "fr_session_id", regex: /customEvent:fr_session_id/u },
   { key: "fr_event_seq", regex: /customEvent:fr_event_seq/u },
   { key: "fr_elapsed_ms", regex: /(?:average)?[cC]ustomEvent:fr_elapsed_ms/u },
   { key: "fr_session_start", regex: /customEvent:fr_session_start/u },
   { key: "fr_lead_type", regex: /customEvent:fr_lead_type/u },
+  { key: "fr_page_ref", regex: /customEvent:fr_page_ref/u },
+  { key: "fr_content_locale", regex: /customEvent:fr_content_locale/u },
 ];
 
 export interface DerivableError {

--- a/packages/payload-plugin-analytics/src/utils/ga4/index.ts
+++ b/packages/payload-plugin-analytics/src/utils/ga4/index.ts
@@ -8,8 +8,22 @@ import { leadActionFilter } from "./leadActionFilter";
 import { deriveMissing } from "./deriveMissing";
 import { dim, metricInt } from "./rows";
 import { exact } from "./filterExpression";
+import { isoFromGa4Date } from "./isoFromGa4Date";
 
 export type { DerivableError } from "./deriveMissing";
 export type { Ga4Row } from "./rows";
 export type { AbFilterExpression } from "./filterExpression";
-export { convertMetricToNumber, computeWeightedValuesAverage, bucketByDateRange, withRowLimit, withInListFilter, dateRangesFor, leadActionFilter, deriveMissing, dim, metricInt, exact };
+export {
+  convertMetricToNumber,
+  computeWeightedValuesAverage,
+  bucketByDateRange,
+  withRowLimit,
+  withInListFilter,
+  dateRangesFor,
+  leadActionFilter,
+  deriveMissing,
+  dim,
+  metricInt,
+  exact,
+  isoFromGa4Date,
+};

--- a/packages/payload-plugin-analytics/src/utils/ga4/isoFromGa4Date.ts
+++ b/packages/payload-plugin-analytics/src/utils/ga4/isoFromGa4Date.ts
@@ -1,0 +1,5 @@
+export function isoFromGa4Date(date: string | null | undefined): string {
+  if (!date || date.length !== 8) return "";
+
+  return `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`;
+}

--- a/packages/payload-plugin-analytics/src/utils/ga4/withPageRefFilter.ts
+++ b/packages/payload-plugin-analytics/src/utils/ga4/withPageRefFilter.ts
@@ -1,0 +1,17 @@
+import type { AbFilterExpression } from "./filterExpression";
+
+export function withPageRefFilter<R extends object & { dimensionFilter?: AbFilterExpression }>(req: R, pageRefDim: string, refs: string[]): R & { dimensionFilter?: AbFilterExpression } {
+  if (refs.length === 0) return req;
+
+  const inList: AbFilterExpression = {
+    filter: {
+      fieldName: pageRefDim,
+      inListFilter: { values: refs },
+    },
+  };
+  const existing = req.dimensionFilter;
+
+  const dimensionFilter: AbFilterExpression = existing ? { andGroup: { expressions: [existing, inList] } } : inList;
+
+  return { ...req, dimensionFilter };
+}

--- a/packages/payload-plugin-analytics/src/utils/page/formatPageRef.ts
+++ b/packages/payload-plugin-analytics/src/utils/page/formatPageRef.ts
@@ -1,0 +1,3 @@
+export function formatPageRef(collection: string, id: string | number): string {
+  return `${collection}:${id}`;
+}

--- a/packages/payload-plugin-analytics/tests/client/Track/TrackPage.test.tsx
+++ b/packages/payload-plugin-analytics/tests/client/Track/TrackPage.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { AnalyticsProvider } from "../../../src/client/AnalyticsProvider";
+import { TrackPage } from "../../../src/client/Track/TrackPage";
+import { getPageContext, clearPageContext } from "../../../src/client/pageContext/store";
+import type { AnalyticsProvider as Adapter } from "../../../src/types/provider";
+
+function makeProvider(): Adapter & { pageView: ReturnType<typeof vi.fn> } {
+  return {
+    name: "test",
+    Scripts: () => null,
+    trackEvent: vi.fn(),
+    pageView: vi.fn(),
+  };
+}
+
+describe("TrackPage", () => {
+  beforeEach(() => clearPageContext());
+  afterEach(() => clearPageContext());
+
+  it("sets ambient page context then fires a pageView with the current path", () => {
+    const provider = makeProvider();
+    render(
+      <AnalyticsProvider provider={provider} trackRouteChanges={false}>
+        <TrackPage pageRef="page:42" locale="en" path="/about" />
+      </AnalyticsProvider>
+    );
+    expect(getPageContext()).toEqual({ pageRef: "page:42", locale: "en" });
+    expect(provider.pageView).toHaveBeenCalledWith("/about");
+  });
+
+  it("derives the ref from collection + id", () => {
+    const provider = makeProvider();
+    render(
+      <AnalyticsProvider provider={provider} trackRouteChanges={false}>
+        <TrackPage collection="posts" id={7} locale="es" path="/es/blog/x" />
+      </AnalyticsProvider>
+    );
+    expect(getPageContext()).toEqual({ pageRef: "posts:7", locale: "es" });
+  });
+
+  it("does nothing when enabled=false (draft/preview)", () => {
+    const provider = makeProvider();
+    render(
+      <AnalyticsProvider provider={provider} trackRouteChanges={false}>
+        <TrackPage pageRef="page:42" locale="en" path="/about" enabled={false} />
+      </AnalyticsProvider>
+    );
+    expect(getPageContext()).toBeNull();
+    expect(provider.pageView).not.toHaveBeenCalled();
+  });
+});

--- a/packages/payload-plugin-analytics/tests/client/exports.test.ts
+++ b/packages/payload-plugin-analytics/tests/client/exports.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import * as client from "../../src/client";
+
+describe("client entrypoint exports", () => {
+  it("exports TrackPage", () => {
+    expect(typeof client.TrackPage).toBe("function");
+  });
+});

--- a/packages/payload-plugin-analytics/tests/client/pageContext/store.test.ts
+++ b/packages/payload-plugin-analytics/tests/client/pageContext/store.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { setPageContext, getPageContext, clearPageContext } from "../../../src/client/pageContext/store";
+
+describe("pageContext store", () => {
+  beforeEach(() => clearPageContext());
+
+  it("returns null context before any set", () => {
+    expect(getPageContext()).toBeNull();
+  });
+
+  it("stores and returns the current page ref + locale", () => {
+    setPageContext({ pageRef: "page:42", locale: "en" });
+    expect(getPageContext()).toEqual({ pageRef: "page:42", locale: "en" });
+  });
+
+  it("overwrites on navigation", () => {
+    setPageContext({ pageRef: "page:42", locale: "en" });
+    setPageContext({ pageRef: "posts:7", locale: "es" });
+    expect(getPageContext()).toEqual({ pageRef: "posts:7", locale: "es" });
+  });
+
+  it("clear resets to null", () => {
+    setPageContext({ pageRef: "page:42", locale: "en" });
+    clearPageContext();
+    expect(getPageContext()).toBeNull();
+  });
+});

--- a/packages/payload-plugin-analytics/tests/config/getResolvedPagesConfig.test.ts
+++ b/packages/payload-plugin-analytics/tests/config/getResolvedPagesConfig.test.ts
@@ -1,0 +1,18 @@
+// tests/config/getResolvedPagesConfig.test.ts
+import { describe, expect, it } from "vitest";
+import { setPluginConfig, getResolvedPagesConfig } from "../../src/config";
+
+describe("getResolvedPagesConfig", () => {
+  it("returns null when no pages config set", () => {
+    setPluginConfig({ ga4: { propertyId: "1", measurementId: "G-X", serviceAccount: { clientEmail: "", privateKey: "" } } });
+    expect(getResolvedPagesConfig()).toBeNull();
+  });
+
+  it("returns resolved pages config when present", () => {
+    setPluginConfig({
+      ga4: { propertyId: "1", measurementId: "G-X", serviceAccount: { clientEmail: "", privateKey: "" } },
+      pages: { collections: ["page"] },
+    });
+    expect(getResolvedPagesConfig()?.collections).toEqual([{ slug: "page", publishedOnly: true }]);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/config/getResolvedPagesConfig.test.ts
+++ b/packages/payload-plugin-analytics/tests/config/getResolvedPagesConfig.test.ts
@@ -13,6 +13,6 @@ describe("getResolvedPagesConfig", () => {
       ga4: { propertyId: "1", measurementId: "G-X", serviceAccount: { clientEmail: "", privateKey: "" } },
       pages: { collections: ["page"] },
     });
-    expect(getResolvedPagesConfig()?.collections).toEqual([{ slug: "page", publishedOnly: true }]);
+    expect(getResolvedPagesConfig()?.collections).toEqual([{ slug: "page", publishedOnly: true, titleField: "title" }]);
   });
 });

--- a/packages/payload-plugin-analytics/tests/config/resolvePagesConfig.labels.test.ts
+++ b/packages/payload-plugin-analytics/tests/config/resolvePagesConfig.labels.test.ts
@@ -1,0 +1,21 @@
+// tests/config/resolvePagesConfig.labels.test.ts
+import { describe, expect, it } from "vitest";
+import { resolvePagesConfig } from "../../src/config/resolvePagesConfig";
+
+describe("resolvePagesConfig — label options", () => {
+  it("defaults titleField to 'title' per collection and resolvePagePath to undefined", () => {
+    const r = resolvePagesConfig({ collections: ["pages", { slug: "posts" }] });
+    expect(r?.collections).toEqual([
+      { slug: "pages", publishedOnly: true, titleField: "title" },
+      { slug: "posts", publishedOnly: true, titleField: "title" },
+    ]);
+    expect(r?.resolvePagePath).toBeUndefined();
+  });
+
+  it("carries an explicit titleField and resolvePagePath", () => {
+    const fn = (ref: string) => `/x/${ref}`;
+    const r = resolvePagesConfig({ collections: [{ slug: "posts", titleField: "name" }], resolvePagePath: fn });
+    expect(r?.collections[0]).toEqual({ slug: "posts", publishedOnly: true, titleField: "name" });
+    expect(r?.resolvePagePath).toBe(fn);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/config/resolvePagesConfig.test.ts
+++ b/packages/payload-plugin-analytics/tests/config/resolvePagesConfig.test.ts
@@ -10,8 +10,8 @@ describe("resolvePagesConfig", () => {
   it("normalizes string collections to { slug, publishedOnly:true }", () => {
     const r = resolvePagesConfig({ collections: ["page", "posts"] });
     expect(r?.collections).toEqual([
-      { slug: "page", publishedOnly: true },
-      { slug: "posts", publishedOnly: true },
+      { slug: "page", publishedOnly: true, titleField: "title" },
+      { slug: "posts", publishedOnly: true, titleField: "title" },
     ]);
   });
 
@@ -21,8 +21,8 @@ describe("resolvePagesConfig", () => {
       syntheticRefs: ["__home"],
     });
     expect(r?.collections).toEqual([
-      { slug: "page", publishedOnly: true },
-      { slug: "events", publishedOnly: false },
+      { slug: "page", publishedOnly: true, titleField: "title" },
+      { slug: "events", publishedOnly: false, titleField: "title" },
     ]);
     expect(r?.syntheticRefs).toEqual(["__home"]);
     expect(r?.dimensions).toEqual({

--- a/packages/payload-plugin-analytics/tests/config/resolvePagesConfig.test.ts
+++ b/packages/payload-plugin-analytics/tests/config/resolvePagesConfig.test.ts
@@ -1,0 +1,39 @@
+// tests/config/resolvePagesConfig.test.ts
+import { describe, expect, it } from "vitest";
+import { resolvePagesConfig } from "../../src/config/resolvePagesConfig";
+
+describe("resolvePagesConfig", () => {
+  it("returns null when pages config is absent", () => {
+    expect(resolvePagesConfig(undefined)).toBeNull();
+  });
+
+  it("normalizes string collections to { slug, publishedOnly:true }", () => {
+    const r = resolvePagesConfig({ collections: ["page", "posts"] });
+    expect(r?.collections).toEqual([
+      { slug: "page", publishedOnly: true },
+      { slug: "posts", publishedOnly: true },
+    ]);
+  });
+
+  it("preserves explicit publishedOnly + synthetic refs + default dim names", () => {
+    const r = resolvePagesConfig({
+      collections: [{ slug: "page" }, { slug: "events", publishedOnly: false }],
+      syntheticRefs: ["__home"],
+    });
+    expect(r?.collections).toEqual([
+      { slug: "page", publishedOnly: true },
+      { slug: "events", publishedOnly: false },
+    ]);
+    expect(r?.syntheticRefs).toEqual(["__home"]);
+    expect(r?.dimensions).toEqual({
+      pageRef: "customEvent:fr_page_ref",
+      contentLocale: "customEvent:fr_content_locale",
+    });
+  });
+
+  it("allows overriding dimension api names", () => {
+    const r = resolvePagesConfig({ collections: ["page"], dimensions: { pageRef: "customEvent:my_ref" } });
+    expect(r?.dimensions.pageRef).toBe("customEvent:my_ref");
+    expect(r?.dimensions.contentLocale).toBe("customEvent:fr_content_locale");
+  });
+});

--- a/packages/payload-plugin-analytics/tests/constants/page.test.ts
+++ b/packages/payload-plugin-analytics/tests/constants/page.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { PAGE_PARAM_KEYS, SYNTHETIC_REF_PREFIX, DEFAULT_PAGE_DIMENSIONS } from "../../src/constants/page";
+
+describe("page constants", () => {
+  it("exposes stable gtag param keys", () => {
+    expect(PAGE_PARAM_KEYS).toEqual({ pageRef: "fr_page_ref", contentLocale: "fr_content_locale" });
+  });
+
+  it("synthetic refs use the __ prefix", () => {
+    expect(SYNTHETIC_REF_PREFIX).toBe("__");
+  });
+
+  it("default GA4 dimension api names match the fr_* precedent", () => {
+    expect(DEFAULT_PAGE_DIMENSIONS).toEqual({
+      pageRef: "customEvent:fr_page_ref",
+      contentLocale: "customEvent:fr_content_locale",
+    });
+  });
+});

--- a/packages/payload-plugin-analytics/tests/endpoints/errorMapping.pageref.test.ts
+++ b/packages/payload-plugin-analytics/tests/endpoints/errorMapping.pageref.test.ts
@@ -1,0 +1,18 @@
+// tests/endpoints/errorMapping.pageref.test.ts
+import { describe, expect, it } from "vitest";
+import { mapGa4Error } from "../../src/endpoints/errorMapping";
+
+describe("mapGa4Error — page identity dims", () => {
+  it("flags fr_page_ref as a missing registration", () => {
+    const err = new Error("INVALID_ARGUMENT: Field customEvent:fr_page_ref is not a valid dimension.");
+    const mapped = mapGa4Error(err);
+    expect(mapped.setupRequired).toBe(true);
+    expect(mapped.missingKey).toBe("fr_page_ref");
+  });
+
+  it("flags fr_content_locale as a missing registration", () => {
+    const err = new Error("INVALID_ARGUMENT: Field customEvent:fr_content_locale is not a valid dimension.");
+    const mapped = mapGa4Error(err);
+    expect(mapped.missingKey).toBe("fr_content_locale");
+  });
+});

--- a/packages/payload-plugin-analytics/tests/endpoints/errorMapping.test.ts
+++ b/packages/payload-plugin-analytics/tests/endpoints/errorMapping.test.ts
@@ -71,4 +71,15 @@ describe("mapGa4Error setupRequired derivation", () => {
     expect(m.setupRequired).toBe(true);
     expect(m.missingKey).toBe("fr_lead_type");
   });
+
+  it("surfaces GA4 detail from err.details when err.message is empty", () => {
+    const err = Object.assign(new Error("3 INVALID_ARGUMENT: "), {
+      details: "Field customEvent:fr_page_ref is not a valid dimension",
+    });
+    const m = mapGa4Error(err);
+    expect(m.status).toBe(400);
+    expect(m.message).toContain("Field customEvent:fr_page_ref is not a valid dimension");
+    expect(m.missingKey).toBe("fr_page_ref");
+    expect(m.setupRequired).toBe(true);
+  });
 });

--- a/packages/payload-plugin-analytics/tests/endpoints/journeys.test.ts
+++ b/packages/payload-plugin-analytics/tests/endpoints/journeys.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildJourneysEndpoint } from "../../src/endpoints/journeys";
 import { __setGa4ClientForTests } from "../../src/services/ga4DataClient";
+import { setPluginConfig } from "../../src/config";
 import { makePayloadRequest } from "../../__fixtures__/http/payloadRequest";
 import basic from "../../__fixtures__/ga4/journeys.basic.json";
 import type { AnalyticsPluginConfig } from "../../src/types/config";
 
 const cfg = { ga4: { propertyId: "12345", measurementId: "G-X", serviceAccount: { clientEmail: "x", privateKey: "y" } } } as AnalyticsPluginConfig;
+
+// The handler builds a PageFilterContext via getResolvedPagesConfig() → getPluginConfig();
+// seed a config with no `pages` so the resolved config is null (feature off, no filter).
+beforeEach(() => {
+  setPluginConfig(cfg);
+});
 
 function callHandler(ep: { handler: unknown }, req: unknown): Promise<Response> {
   return (ep.handler as (r: unknown) => Promise<Response>)(req);

--- a/packages/payload-plugin-analytics/tests/endpoints/kpis.test.ts
+++ b/packages/payload-plugin-analytics/tests/endpoints/kpis.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildKpisEndpoint } from "../../src/endpoints/kpis";
 import { __setGa4ClientForTests } from "../../src/services/ga4DataClient";
+import { setPluginConfig } from "../../src/config";
 import { makePayloadRequest } from "../../__fixtures__/http/payloadRequest";
 import kpisCurrent from "../../__fixtures__/ga4/kpis.current.json";
 import type { AnalyticsPluginConfig } from "../../src/types/config";
 
 const cfg = { ga4: { propertyId: "12345", measurementId: "G-X", serviceAccount: { clientEmail: "x", privateKey: "y" } } } as AnalyticsPluginConfig;
+
+// The handler builds a PageFilterContext via getResolvedPagesConfig() → getPluginConfig();
+// seed a config with no `pages` so the resolved config is null (feature off, no filter).
+beforeEach(() => {
+  setPluginConfig(cfg);
+});
 
 function callHandler(ep: { handler: unknown }, req: unknown): Promise<Response> {
   // PayloadHandler signature accepts extra positional args (request, args). For tests we only need req.

--- a/packages/payload-plugin-analytics/tests/endpoints/sessionDetail.test.ts
+++ b/packages/payload-plugin-analytics/tests/endpoints/sessionDetail.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildSessionDetailEndpoint } from "../../src/endpoints/sessionDetail";
 import { __setGa4ClientForTests } from "../../src/services/ga4DataClient";
+import { setPluginConfig } from "../../src/config";
 import { makePayloadRequest } from "../../__fixtures__/http/payloadRequest";
 import sessionDetail from "../../__fixtures__/ga4/sessionDetail.frSessionId.json";
 import type { AnalyticsPluginConfig } from "../../src/types/config";
 
 const cfg = { ga4: { propertyId: "12345", measurementId: "G-X", serviceAccount: { clientEmail: "x", privateKey: "y" } } } as AnalyticsPluginConfig;
+
+// The handler builds a PageFilterContext via getResolvedPagesConfig() → getPluginConfig();
+// seed a config with no `pages` so the resolved config is null (feature off, no filter).
+beforeEach(() => {
+  setPluginConfig(cfg);
+});
 
 function callHandler(ep: { handler: unknown }, req: unknown): Promise<Response> {
   return (ep.handler as (r: unknown) => Promise<Response>)(req);

--- a/packages/payload-plugin-analytics/tests/endpoints/sessions.test.ts
+++ b/packages/payload-plugin-analytics/tests/endpoints/sessions.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildSessionsEndpoint } from "../../src/endpoints/sessions";
 import { __setGa4ClientForTests } from "../../src/services/ga4DataClient";
+import { setPluginConfig } from "../../src/config";
 import { makePayloadRequest } from "../../__fixtures__/http/payloadRequest";
 import sessions from "../../__fixtures__/ga4/sessions.frSessionId.json";
 import type { AnalyticsPluginConfig } from "../../src/types/config";
 
 const cfg = { ga4: { propertyId: "12345", measurementId: "G-X", serviceAccount: { clientEmail: "x", privateKey: "y" } } } as AnalyticsPluginConfig;
+
+// The handler builds a PageFilterContext via getResolvedPagesConfig() → getPluginConfig();
+// seed a config with no `pages` so the resolved config is null (feature off, no filter).
+beforeEach(() => {
+  setPluginConfig(cfg);
+});
 
 function callHandler(ep: { handler: unknown }, req: unknown): Promise<Response> {
   return (ep.handler as (r: unknown) => Promise<Response>)(req);

--- a/packages/payload-plugin-analytics/tests/endpoints/topCountries.test.ts
+++ b/packages/payload-plugin-analytics/tests/endpoints/topCountries.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTopCountriesEndpoint } from "../../src/endpoints/topCountries";
 import { __setGa4ClientForTests } from "../../src/services/ga4DataClient";
+import { setPluginConfig } from "../../src/config";
 import { makePayloadRequest } from "../../__fixtures__/http/payloadRequest";
 import topCountries from "../../__fixtures__/ga4/topCountries.json";
 import type { AnalyticsPluginConfig } from "../../src/types/config";
 
 const cfg = { ga4: { propertyId: "12345", measurementId: "G-X", serviceAccount: { clientEmail: "x", privateKey: "y" } } } as AnalyticsPluginConfig;
+
+// The handler builds a PageFilterContext via getResolvedPagesConfig() → getPluginConfig();
+// seed a config with no `pages` so the resolved config is null (feature off, no filter).
+beforeEach(() => {
+  setPluginConfig(cfg);
+});
 
 function callHandler(ep: { handler: unknown }, req: unknown): Promise<Response> {
   return (ep.handler as (r: unknown) => Promise<Response>)(req);

--- a/packages/payload-plugin-analytics/tests/endpoints/topDevices.test.ts
+++ b/packages/payload-plugin-analytics/tests/endpoints/topDevices.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTopDevicesEndpoint } from "../../src/endpoints/topDevices";
 import { __setGa4ClientForTests } from "../../src/services/ga4DataClient";
+import { setPluginConfig } from "../../src/config";
 import { makePayloadRequest } from "../../__fixtures__/http/payloadRequest";
 import topDevices from "../../__fixtures__/ga4/topDevices.json";
 import type { AnalyticsPluginConfig } from "../../src/types/config";
 
 const cfg = { ga4: { propertyId: "12345", measurementId: "G-X", serviceAccount: { clientEmail: "x", privateKey: "y" } } } as AnalyticsPluginConfig;
+
+// The handler builds a PageFilterContext via getResolvedPagesConfig() → getPluginConfig();
+// seed a config with no `pages` so the resolved config is null (feature off, no filter).
+beforeEach(() => {
+  setPluginConfig(cfg);
+});
 
 function callHandler(ep: { handler: unknown }, req: unknown): Promise<Response> {
   return (ep.handler as (r: unknown) => Promise<Response>)(req);

--- a/packages/payload-plugin-analytics/tests/endpoints/topEvents.test.ts
+++ b/packages/payload-plugin-analytics/tests/endpoints/topEvents.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTopEventsEndpoint } from "../../src/endpoints/topEvents";
 import { __setGa4ClientForTests } from "../../src/services/ga4DataClient";
+import { setPluginConfig } from "../../src/config";
 import { makePayloadRequest } from "../../__fixtures__/http/payloadRequest";
 import topEvents from "../../__fixtures__/ga4/topEvents.json";
 import type { AnalyticsPluginConfig } from "../../src/types/config";
 
 const cfg = { ga4: { propertyId: "12345", measurementId: "G-X", serviceAccount: { clientEmail: "x", privateKey: "y" } } } as AnalyticsPluginConfig;
+
+// The handler builds a PageFilterContext via getResolvedPagesConfig() → getPluginConfig();
+// seed a config with no `pages` so the resolved config is null (feature off, no filter).
+beforeEach(() => {
+  setPluginConfig(cfg);
+});
 
 function callHandler(ep: { handler: unknown }, req: unknown): Promise<Response> {
   return (ep.handler as (r: unknown) => Promise<Response>)(req);

--- a/packages/payload-plugin-analytics/tests/endpoints/topPages.test.ts
+++ b/packages/payload-plugin-analytics/tests/endpoints/topPages.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTopPagesEndpoint } from "../../src/endpoints/topPages";
 import { __setGa4ClientForTests } from "../../src/services/ga4DataClient";
+import { setPluginConfig } from "../../src/config";
 import { makePayloadRequest } from "../../__fixtures__/http/payloadRequest";
 import topPages from "../../__fixtures__/ga4/topPages.json";
 import type { AnalyticsPluginConfig } from "../../src/types/config";
 
 const cfg = { ga4: { propertyId: "12345", measurementId: "G-X", serviceAccount: { clientEmail: "x", privateKey: "y" } } } as AnalyticsPluginConfig;
+
+// The handler builds a PageFilterContext via getResolvedPagesConfig() → getPluginConfig();
+// seed a config with no `pages` so the resolved config is null (feature off, no filter).
+beforeEach(() => {
+  setPluginConfig(cfg);
+});
 
 function callHandler(ep: { handler: unknown }, req: unknown): Promise<Response> {
   return (ep.handler as (r: unknown) => Promise<Response>)(req);

--- a/packages/payload-plugin-analytics/tests/endpoints/topSources.test.ts
+++ b/packages/payload-plugin-analytics/tests/endpoints/topSources.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTopSourcesEndpoint } from "../../src/endpoints/topSources";
 import { __setGa4ClientForTests } from "../../src/services/ga4DataClient";
+import { setPluginConfig } from "../../src/config";
 import { makePayloadRequest } from "../../__fixtures__/http/payloadRequest";
 import topSources from "../../__fixtures__/ga4/topSources.json";
 import type { AnalyticsPluginConfig } from "../../src/types/config";
 
 const cfg = { ga4: { propertyId: "12345", measurementId: "G-X", serviceAccount: { clientEmail: "x", privateKey: "y" } } } as AnalyticsPluginConfig;
+
+// The handler builds a PageFilterContext via getResolvedPagesConfig() → getPluginConfig();
+// seed a config with no `pages` so the resolved config is null (feature off, no filter).
+beforeEach(() => {
+  setPluginConfig(cfg);
+});
 
 function callHandler(ep: { handler: unknown }, req: unknown): Promise<Response> {
   return (ep.handler as (r: unknown) => Promise<Response>)(req);

--- a/packages/payload-plugin-analytics/tests/providers/ga4Provider/pushEvent.test.ts
+++ b/packages/payload-plugin-analytics/tests/providers/ga4Provider/pushEvent.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { pushEvent } from "../../../src/providers/ga4Provider/pushEvent";
 import { pushPageView } from "../../../src/providers/ga4Provider/pushPageView";
 import { __resetInMemoryStore } from "../../../src/client/session/store";
+import { setPageContext, clearPageContext } from "../../../src/client/pageContext/store";
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -77,5 +78,33 @@ describe("pushPageView", () => {
   it("no-ops when gtag is undefined", () => {
     delete window.gtag;
     expect(() => pushPageView("/x", "X", "https://x")).not.toThrow();
+  });
+});
+
+describe("pushEvent page-context stamping", () => {
+  beforeEach(() => {
+    clearPageContext();
+    (globalThis as { gtag?: unknown }).gtag = vi.fn();
+  });
+  afterEach(() => {
+    clearPageContext();
+    delete (globalThis as { gtag?: unknown }).gtag;
+  });
+
+  it("stamps page context onto a lead_action event", () => {
+    setPageContext({ pageRef: "posts:7", locale: "es" });
+    pushEvent("lead_action", { fr_lead_type: "phone_click" });
+    const gtag = (globalThis as { gtag: ReturnType<typeof vi.fn> }).gtag;
+    const params = gtag.mock.calls[0][2];
+    expect(params.fr_page_ref).toBe("posts:7");
+    expect(params.fr_content_locale).toBe("es");
+    expect(params.fr_lead_type).toBe("phone_click");
+  });
+
+  it("omits page params when context is unset", () => {
+    pushEvent("lead_action", { fr_lead_type: "phone_click" });
+    const gtag = (globalThis as { gtag: ReturnType<typeof vi.fn> }).gtag;
+    const params = gtag.mock.calls[0][2];
+    expect(params.fr_page_ref).toBeUndefined();
   });
 });

--- a/packages/payload-plugin-analytics/tests/providers/ga4Provider/pushPageView.test.ts
+++ b/packages/payload-plugin-analytics/tests/providers/ga4Provider/pushPageView.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { pushPageView } from "../../../src/providers/ga4Provider/pushPageView";
+import { setPageContext, clearPageContext } from "../../../src/client/pageContext/store";
+
+describe("pushPageView page-context stamping", () => {
+  beforeEach(() => {
+    clearPageContext();
+    (globalThis as { gtag?: unknown }).gtag = vi.fn();
+  });
+  afterEach(() => {
+    clearPageContext();
+    delete (globalThis as { gtag?: unknown }).gtag;
+  });
+
+  it("stamps fr_page_ref and fr_content_locale when context is set", () => {
+    setPageContext({ pageRef: "page:42", locale: "en" });
+    pushPageView("/about", "About", "https://x/about");
+    const gtag = (globalThis as { gtag: ReturnType<typeof vi.fn> }).gtag;
+    const params = gtag.mock.calls[0][2];
+    expect(params.fr_page_ref).toBe("page:42");
+    expect(params.fr_content_locale).toBe("en");
+    expect(params.page_path).toBe("/about");
+  });
+
+  it("omits page params when no context is set", () => {
+    pushPageView("/about", "About", "https://x/about");
+    const gtag = (globalThis as { gtag: ReturnType<typeof vi.fn> }).gtag;
+    const params = gtag.mock.calls[0][2];
+    expect(params.fr_page_ref).toBeUndefined();
+    expect(params.fr_content_locale).toBeUndefined();
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/filterAndReaggregate.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/filterAndReaggregate.test.ts
@@ -1,0 +1,41 @@
+// tests/services/analyticsService/mocks/filterAndReaggregate.test.ts
+import { describe, expect, it } from "vitest";
+import { filterAndReaggregate } from "../../../../src/services/analyticsService/mocks/filterAndReaggregate";
+import { row } from "../../../../src/services/analyticsService/mocks/ga4RowBuilder";
+
+// Internal ref-tagged rows: dims = [source, ref], metrics = [sessions, users].
+// refIndex = 1, keepDimIndices = [0].
+const ROWS = [
+  row(["google", "pages:1"], ["100", "80"]),
+  row(["google", "pages:__mock_deleted__"], ["999", "999"]), // missing → dropped
+  row(["direct", "pages:1"], ["50", "40"]),
+];
+
+describe("filterAndReaggregate", () => {
+  it("drops rows whose ref is not allowed and re-aggregates by kept dims (ref stripped)", () => {
+    const out = filterAndReaggregate(ROWS, { refIndex: 1, keepDimIndices: [0], allowed: new Set(["pages:1", "__home"]) });
+    // google = 100/80 (missing 999/999 dropped), direct = 50/40
+    expect(out).toEqual([
+      { dimensionValues: [{ value: "google" }], metricValues: [{ value: "100" }, { value: "80" }] },
+      { dimensionValues: [{ value: "direct" }], metricValues: [{ value: "50" }, { value: "40" }] },
+    ]);
+  });
+
+  it("sums metrics across rows that collapse to the same kept-dim tuple", () => {
+    const rows = [row(["google", "pages:1"], ["100", "80"]), row(["google", "pages:2"], ["10", "5"])];
+    const out = filterAndReaggregate(rows, { refIndex: 1, keepDimIndices: [0], allowed: new Set(["pages:1", "pages:2"]) });
+    expect(out).toEqual([{ dimensionValues: [{ value: "google" }], metricValues: [{ value: "110" }, { value: "85" }] }]);
+  });
+
+  it("when allowed is null (no filter), keeps all rows but still strips the ref dim + re-aggregates", () => {
+    const out = filterAndReaggregate(ROWS, { refIndex: 1, keepDimIndices: [0], allowed: null });
+    expect(out).toEqual([
+      { dimensionValues: [{ value: "google" }], metricValues: [{ value: "1099" }, { value: "1079" }] },
+      { dimensionValues: [{ value: "direct" }], metricValues: [{ value: "50" }, { value: "40" }] },
+    ]);
+  });
+
+  it("collapses all allowed rows into a single grand-total row when keepDimIndices is empty", () => {
+    expect(filterAndReaggregate(ROWS, { refIndex: 1, keepDimIndices: [], allowed: new Set(["pages:1"]) })).toEqual([{ dimensionValues: [], metricValues: [{ value: "150" }, { value: "120" }] }]);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/ga4RowBuilder.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/ga4RowBuilder.test.ts
@@ -1,0 +1,22 @@
+// tests/services/analyticsService/mocks/ga4RowBuilder.test.ts
+import { describe, expect, it } from "vitest";
+import { row, response, batch } from "../../../../src/services/analyticsService/mocks/ga4RowBuilder";
+
+describe("ga4RowBuilder", () => {
+  it("row builds dimensionValues/metricValues from string arrays", () => {
+    expect(row(["/a", "A"], ["10", "5"])).toEqual({
+      dimensionValues: [{ value: "/a" }, { value: "A" }],
+      metricValues: [{ value: "10" }, { value: "5" }],
+    });
+  });
+
+  it("response wraps rows + rowCount", () => {
+    const r = response([row(["/a"], ["1"])]);
+    expect(r.rows).toHaveLength(1);
+    expect(r.rowCount).toBe(1);
+  });
+
+  it("batch wraps multiple reports", () => {
+    expect(batch([response([]), response([])]).reports).toHaveLength(2);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/journeys.mock.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/journeys.mock.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { journeysMock } from "../../../../src/services/analyticsService/mocks/journeys";
+import { setActiveExistingRefs, __clearActiveExistingRefs } from "../../../../src/services/pageFilter/activeRefsHolder";
+import { MOCK_MISSING_REF } from "../../../../src/services/analyticsService/mocks/mockRefs";
+
+describe("journeysMock (ref-tagged)", () => {
+  beforeEach(() => {
+    __clearActiveExistingRefs();
+    setActiveExistingRefs(["pages:1"]);
+  });
+
+  it("emits rows with fr_page_ref at index 6 incl. a missing-ref session that also has a lead_action", () => {
+    const res = journeysMock({} as never) as { rows: Array<{ dimensionValues: Array<{ value: string }> }> };
+    const refs = res.rows.map((r) => r.dimensionValues[6]?.value);
+    expect(refs).toContain(MOCK_MISSING_REF);
+    expect(refs).toContain("pages:1");
+    // journeys only counts sessions containing a lead_action event
+    expect(res.rows.some((r) => r.dimensionValues[1].value === "lead_action")).toBe(true);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/kpis.mock.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/kpis.mock.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { kpisMock } from "../../../../src/services/analyticsService/mocks/kpis";
+import { aggregateSessions } from '../../../../src/services/queries/kpiRecompute/aggregateSessions';
+import type { KpiSessionEventRow } from '../../../../src/services/queries/kpiRecompute/aggregateSessions';
+import { setActiveExistingRefs, __clearActiveExistingRefs } from "../../../../src/services/pageFilter/activeRefsHolder";
+import { MOCK_MISSING_REF } from "../../../../src/services/analyticsService/mocks/mockRefs";
+
+function decode(rows: Array<{ dimensionValues: Array<{ value: string }> }>): KpiSessionEventRow[] {
+  return rows.map((r) => ({
+    sessionId: r.dimensionValues[0].value,
+    date: r.dimensionValues[1].value,
+    pageRef: r.dimensionValues[2].value,
+    eventName: r.dimensionValues[3].value,
+    dhm: r.dimensionValues[4].value,
+  }));
+}
+
+describe("kpisMock (session-level, recompute shape)", () => {
+  beforeEach(() => {
+    __clearActiveExistingRefs();
+    setActiveExistingRefs(["pages:1"]);
+  });
+
+  it("emits 5-dimension session rows including a missing-ref session", () => {
+    const res = kpisMock({ dateRanges: [{}] } as never) as { rows: Array<{ dimensionValues: Array<{ value: string }> }> };
+    expect(res.rows[0].dimensionValues).toHaveLength(5);
+    expect(res.rows.some((r) => r.dimensionValues[2].value === MOCK_MISSING_REF)).toBe(true);
+  });
+
+  it("feeding the rows through aggregateSessions excludes the missing-ref session from totals", () => {
+    const res = kpisMock({ dateRanges: [{}] } as never) as { rows: Array<{ dimensionValues: Array<{ value: string }> }> };
+    const { current } = aggregateSessions(decode(res.rows), new Set(["pages:1", "__home"]));
+    // Missing session dropped → sessions count excludes it.
+    const all = aggregateSessions(decode(res.rows), new Set(["pages:1", "__home", MOCK_MISSING_REF]));
+    expect(current.sessions).toBeLessThan(all.current.sessions);
+    expect(current.sessions).toBeGreaterThan(0);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/kpis.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/kpis.test.ts
@@ -1,23 +1,33 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest";
 import { kpisMock } from "../../../../src/services/analyticsService/mocks/kpis";
-import kpisCurrent from "../../../../__fixtures__/ga4/kpis.current.json";
-import kpisBoth from "../../../../__fixtures__/ga4/kpis.currentAndPrevious.json";
+import { setActiveExistingRefs, __clearActiveExistingRefs } from "../../../../src/services/pageFilter/activeRefsHolder";
+
+// The kpis mock is now a session-level recompute-shape generator (see kpis.mock.test.ts
+// for the filtering behavior). This file keeps the dateRange comparison-shape contract.
+type Res = { rows: Array<{ dimensionValues: Array<{ value: string }> }> };
 
 describe("kpisMock", () => {
-  it("returns single-period fixture when request has one dateRange", async () => {
-    const result = await kpisMock({
-      dateRanges: [{ startDate: "2026-05-04", endDate: "2026-05-06" }],
-    });
-    expect(result).toEqual(kpisCurrent);
+  beforeEach(() => {
+    __clearActiveExistingRefs();
+    setActiveExistingRefs(["pages:1"]);
   });
 
-  it("returns comparison fixture when request has two dateRanges", async () => {
-    const result = await kpisMock({
+  it("emits single-period session rows when request has one dateRange (5 dims, no range tag)", async () => {
+    const result = (await kpisMock({
+      dateRanges: [{ startDate: "2026-05-04", endDate: "2026-05-06" }],
+    })) as unknown as Res;
+    expect(result.rows[0].dimensionValues).toHaveLength(5);
+  });
+
+  it("appends a trailing dateRange dim when request has two dateRanges", async () => {
+    const result = (await kpisMock({
       dateRanges: [
         { startDate: "2026-05-04", endDate: "2026-05-06", name: "current" },
         { startDate: "2026-05-01", endDate: "2026-05-03", name: "previous" },
       ],
-    });
-    expect(result).toEqual(kpisBoth);
+    })) as unknown as Res;
+    expect(result.rows[0].dimensionValues).toHaveLength(6);
+    const rangeTags = new Set(result.rows.map((r) => r.dimensionValues[5].value));
+    expect(rangeTags).toEqual(new Set(["current", "previous"]));
   });
 });

--- a/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/leadActions.mock.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/leadActions.mock.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { leadActionsMock } from "../../../../src/services/analyticsService/mocks/leadActions";
+import { setActiveExistingRefs, __clearActiveExistingRefs } from "../../../../src/services/pageFilter/activeRefsHolder";
+import { MOCK_MISSING_REF } from "../../../../src/services/analyticsService/mocks/mockRefs";
+
+const DIM = "customEvent:fr_page_ref";
+const filt = { filter: { fieldName: DIM, inListFilter: { values: ["pages:1"] } } };
+const eventsReq = { dimensionFilter: { andGroup: { expressions: [{ filter: { fieldName: "eventName", stringFilter: { value: "lead_action" } } }, filt] } } };
+const sessionsReq = { dimensionFilter: filt };
+
+type BatchRes = { reports: Array<{ rows: Array<{ dimensionValues: Array<{ value: string }>; metricValues: Array<{ value: string }> }> }> };
+
+describe("leadActionsMock (filter-aware, ref-grouped)", () => {
+  beforeEach(() => {
+    __clearActiveExistingRefs();
+    setActiveExistingRefs(["pages:1"]);
+  });
+
+  it("the events report (report[0]) carries the ref at dim index 1 and excludes the missing ref under filter", () => {
+    const res = leadActionsMock([eventsReq, sessionsReq] as never) as BatchRes;
+    const refs = res.reports[0].rows.map((r) => r.dimensionValues[1].value);
+    expect(refs).not.toContain(MOCK_MISSING_REF);
+    expect(refs.length).toBeGreaterThan(0);
+  });
+
+  it("the events report DID emit the missing ref when unfiltered", () => {
+    const res = leadActionsMock([{}, {}] as never) as BatchRes;
+    const refs = res.reports[0].rows.map((r) => r.dimensionValues[1].value);
+    expect(refs).toContain(MOCK_MISSING_REF);
+  });
+
+  it("the sessions denominator (report[1]) shrinks under filter (no missing-page sessions)", () => {
+    const filteredTotal = Number((leadActionsMock([eventsReq, sessionsReq] as never) as BatchRes).reports[1].rows[0].metricValues[0].value);
+    const unfilteredTotal = Number((leadActionsMock([{}, {}] as never) as BatchRes).reports[1].rows[0].metricValues[0].value);
+    expect(filteredTotal).toBeLessThan(unfilteredTotal);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/leadActions.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/leadActions.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest";
 import { leadActionsMock } from "../../../../src/services/analyticsService/mocks/leadActions";
-import leadActionsBatch from "../../../../__fixtures__/ga4/leadActions.batch.json";
+import { setActiveExistingRefs, __clearActiveExistingRefs } from "../../../../src/services/pageFilter/activeRefsHolder";
 
+// The leadActions mock is now a filter-aware generator (see leadActions.mock.test.ts
+// for the filtering behavior). This file keeps the structural batch-shape contract.
 describe("leadActionsMock", () => {
-  it("returns the canonical batch fixture", async () => {
-    const result = await leadActionsMock([{ dateRanges: [{ startDate: "2026-05-04", endDate: "2026-05-06" }] }, { dateRanges: [{ startDate: "2026-05-04", endDate: "2026-05-06" }] }]);
-    expect(result).toEqual(leadActionsBatch);
+  beforeEach(() => {
+    __clearActiveExistingRefs();
+    setActiveExistingRefs(["pages:1"]);
   });
 
   it("has two reports in the batch (events + sessions)", async () => {

--- a/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/mockRefs.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/mockRefs.test.ts
@@ -1,0 +1,26 @@
+// tests/services/analyticsService/mocks/mockRefs.test.ts
+import { describe, expect, it, beforeEach } from "vitest";
+import { pickMockRefs, MOCK_MISSING_REF } from "../../../../src/services/analyticsService/mocks/mockRefs";
+import { setActiveExistingRefs, __clearActiveExistingRefs } from "../../../../src/services/pageFilter/activeRefsHolder";
+
+describe("pickMockRefs", () => {
+  beforeEach(() => __clearActiveExistingRefs());
+
+  it("uses up to 3 live existing refs + the fabricated missing ref", () => {
+    setActiveExistingRefs(["__home", "pages:1", "pages:2", "pages:3", "pages:4"]);
+    const { existing, missing } = pickMockRefs();
+    expect(existing).toEqual(["__home", "pages:1", "pages:2"]);
+    expect(missing).toBe(MOCK_MISSING_REF);
+    expect(existing).not.toContain(MOCK_MISSING_REF);
+  });
+
+  it("falls back to a synthetic existing ref when the holder is empty", () => {
+    const { existing, missing } = pickMockRefs();
+    expect(existing).toEqual(["__home"]);
+    expect(missing).toBe(MOCK_MISSING_REF);
+  });
+
+  it("the missing ref is an obviously-fake sentinel that cannot collide with a real id", () => {
+    expect(MOCK_MISSING_REF).toBe("pages:__mock_deleted__");
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/refInListFromRequest.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/refInListFromRequest.test.ts
@@ -1,0 +1,28 @@
+// tests/services/analyticsService/mocks/refInListFromRequest.test.ts
+import { describe, expect, it } from "vitest";
+import { refInListFromRequest } from "../../../../src/services/analyticsService/mocks/refInListFromRequest";
+
+const DIM = "customEvent:fr_page_ref";
+
+describe("refInListFromRequest", () => {
+  it("reads a standalone inList filter", () => {
+    const req = { dimensionFilter: { filter: { fieldName: DIM, inListFilter: { values: ["pages:1", "__home"] } } } };
+    expect(refInListFromRequest(req, DIM)).toEqual(["pages:1", "__home"]);
+  });
+
+  it("reads an inList nested in an andGroup", () => {
+    const req = {
+      dimensionFilter: {
+        andGroup: {
+          expressions: [{ filter: { fieldName: "eventName", stringFilter: { value: "lead_action" } } }, { filter: { fieldName: DIM, inListFilter: { values: ["pages:2"] } } }],
+        },
+      },
+    };
+    expect(refInListFromRequest(req, DIM)).toEqual(["pages:2"]);
+  });
+
+  it("returns null when no fr_page_ref inList is present", () => {
+    expect(refInListFromRequest({ dimensionFilter: { filter: { fieldName: "eventName", stringFilter: { value: "x" } } } }, DIM)).toBeNull();
+    expect(refInListFromRequest({}, DIM)).toBeNull();
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/sessions.mock.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/sessions.mock.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { sessionsMock } from "../../../../src/services/analyticsService/mocks/sessions";
+import { setActiveExistingRefs, __clearActiveExistingRefs } from "../../../../src/services/pageFilter/activeRefsHolder";
+import { MOCK_MISSING_REF } from "../../../../src/services/analyticsService/mocks/mockRefs";
+
+type BatchRes = { reports: Array<{ rows: Array<{ dimensionValues: Array<{ value: string }> }> }> };
+
+describe("sessionsMock (ref-tagged session rows)", () => {
+  beforeEach(() => {
+    __clearActiveExistingRefs();
+    setActiveExistingRefs(["pages:1"]);
+  });
+
+  it("report[0] rows carry fr_page_ref at index 6 incl. a missing-ref session", () => {
+    const res = sessionsMock([{}, {}] as never) as BatchRes;
+    const refsAtIdx6 = res.reports[0].rows.map((r) => r.dimensionValues[6]?.value);
+    expect(refsAtIdx6).toContain(MOCK_MISSING_REF);
+    expect(refsAtIdx6).toContain("pages:1");
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/topDimensional.mock.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/topDimensional.mock.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { topSourcesMock } from "../../../../src/services/analyticsService/mocks/topSources";
+import { topDevicesMock } from "../../../../src/services/analyticsService/mocks/topDevices";
+import { topCountriesMock } from "../../../../src/services/analyticsService/mocks/topCountries";
+import { topEventsMock } from "../../../../src/services/analyticsService/mocks/topEvents";
+import { setActiveExistingRefs, __clearActiveExistingRefs } from "../../../../src/services/pageFilter/activeRefsHolder";
+
+const DIM = "customEvent:fr_page_ref";
+const filtered = { dimensionFilter: { filter: { fieldName: DIM, inListFilter: { values: ["pages:1"] } } } };
+
+type Res = { rows: Array<{ metricValues: Array<{ value: string }> }> };
+
+describe("3A dimensional mocks honor the ref filter", () => {
+  beforeEach(() => {
+    __clearActiveExistingRefs();
+    setActiveExistingRefs(["pages:1"]);
+  });
+
+  it("filtered top-sources totals are strictly less than unfiltered (missing page's traffic removed)", () => {
+    const sum = (r: Res) => r.rows.reduce((a, x) => a + Number(x.metricValues[0].value), 0);
+    const unfiltered = sum(topSourcesMock({} as never) as Res);
+    const withFilter = sum(topSourcesMock(filtered as never) as Res);
+    expect(withFilter).toBeLessThan(unfiltered);
+    expect(withFilter).toBeGreaterThan(0);
+  });
+
+  it("devices/countries/events all drop the missing page's contribution under filter", () => {
+    const sum = (r: Res) => r.rows.reduce((a, x) => a + Number(x.metricValues[0].value), 0);
+    for (const mock of [topDevicesMock, topCountriesMock, topEventsMock]) {
+      expect(sum(mock(filtered as never) as Res)).toBeLessThan(sum(mock({} as never) as Res));
+    }
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/topPages.mock.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/analyticsService/mocks/topPages.mock.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { topPagesMock } from "../../../../src/services/analyticsService/mocks/topPages";
+import { setActiveExistingRefs, __clearActiveExistingRefs } from "../../../../src/services/pageFilter/activeRefsHolder";
+import { MOCK_MISSING_REF } from "../../../../src/services/analyticsService/mocks/mockRefs";
+
+const DIM = "customEvent:fr_page_ref";
+
+describe("topPagesMock (filter-aware, ref-grouped)", () => {
+  beforeEach(() => {
+    __clearActiveExistingRefs();
+    setActiveExistingRefs(["pages:1"]);
+  });
+
+  it("excludes the missing page ref when the request filters by existing refs", () => {
+    const req = { dimensionFilter: { filter: { fieldName: DIM, inListFilter: { values: ["pages:1"] } } } };
+    const res = topPagesMock(req as never) as { rows: Array<{ dimensionValues: Array<{ value: string }> }> };
+    const refs = res.rows.map((r) => r.dimensionValues[0].value);
+    expect(refs).not.toContain(MOCK_MISSING_REF);
+    expect(refs.length).toBeGreaterThan(0);
+  });
+
+  it("the generator DID emit the missing page ref (so the filter, not omission, hides it)", () => {
+    // No filter on the request → missing ref present, proving it exists in mock data.
+    const res = topPagesMock({} as never) as { rows: Array<{ dimensionValues: Array<{ value: string }> }> };
+    const refs = res.rows.map((r) => r.dimensionValues[0].value);
+    expect(refs).toContain(MOCK_MISSING_REF);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/pageFilter/activeRefsHolder.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/pageFilter/activeRefsHolder.test.ts
@@ -1,0 +1,18 @@
+// tests/services/pageFilter/activeRefsHolder.test.ts
+import { describe, expect, it, beforeEach } from "vitest";
+import { setActiveExistingRefs, getActiveExistingRefs, __clearActiveExistingRefs } from "../../../src/services/pageFilter/activeRefsHolder";
+
+describe("activeRefsHolder", () => {
+  beforeEach(() => __clearActiveExistingRefs());
+
+  it("returns an empty array before any set", () => {
+    expect(getActiveExistingRefs()).toEqual([]);
+  });
+
+  it("stores and returns the most recent refs", () => {
+    setActiveExistingRefs(["pages:1", "__home"]);
+    expect(getActiveExistingRefs()).toEqual(["pages:1", "__home"]);
+    setActiveExistingRefs(["pages:2"]);
+    expect(getActiveExistingRefs()).toEqual(["pages:2"]);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/pageFilter/buildPageFilterContext.labels.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/pageFilter/buildPageFilterContext.labels.test.ts
@@ -1,0 +1,31 @@
+// tests/services/pageFilter/buildPageFilterContext.labels.test.ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { buildPageFilterContext } from "../../../src/services/pageFilter/buildPageFilterContext";
+import { __clearExistingRefsCache } from "../../../src/services/pageFilter/existingRefsCache";
+import { __clearPageLabelsCache } from "../../../src/services/pageFilter/pageLabelsCache";
+import type { ResolvedPagesConfig } from "../../../src/config/resolvePagesConfig";
+
+const cfg: ResolvedPagesConfig = {
+  collections: [{ slug: "pages", publishedOnly: true, titleField: "title" }],
+  syntheticRefs: ["__home"],
+  dimensions: { pageRef: "customEvent:fr_page_ref", contentLocale: "customEvent:fr_content_locale" },
+  resolvePagePath: (ref) => (ref === "__home" ? "/" : `/p/${ref.split(":")[1]}`),
+};
+
+describe("buildPageFilterContext.resolveLabels", () => {
+  beforeEach(() => {
+    __clearExistingRefsCache();
+    __clearPageLabelsCache();
+  });
+
+  it("exposes resolveLabels that maps refs to {path,title}", async () => {
+    const payload = {
+      config: { localization: { defaultLocale: "en" } },
+      find: vi.fn(async ({ collection }: { collection: string }) => (collection === "pages" ? { docs: [{ id: 5, title: "Five" }] } : { docs: [] })),
+    };
+    const ctx = await buildPageFilterContext({ payload } as never, cfg);
+    const labels = await ctx!.resolveLabels(["pages:5", "__home"]);
+    expect(labels.get("pages:5")).toEqual({ path: "/p/5", title: "Five" });
+    expect(labels.get("__home")).toEqual({ path: "/", title: "/" });
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/pageFilter/buildPageFilterContext.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/pageFilter/buildPageFilterContext.test.ts
@@ -5,7 +5,7 @@ import { __clearExistingRefsCache } from "../../../src/services/pageFilter/exist
 import type { ResolvedPagesConfig } from "../../../src/config/resolvePagesConfig";
 
 const cfg: ResolvedPagesConfig = {
-  collections: [{ slug: "page", publishedOnly: true }],
+  collections: [{ slug: "page", publishedOnly: true, titleField: "title" }],
   syntheticRefs: ["__home"],
   dimensions: { pageRef: "customEvent:fr_page_ref", contentLocale: "customEvent:fr_content_locale" },
 };
@@ -15,16 +15,24 @@ describe("buildPageFilterContext", () => {
 
   it("returns null when pages config is null (feature off)", async () => {
     const payload = { find: vi.fn() };
-    const ctx = await buildPageFilterContext(payload as never, null);
+    const ctx = await buildPageFilterContext({ payload } as never, null);
     expect(ctx).toBeNull();
     expect(payload.find).not.toHaveBeenCalled();
   });
 
   it("returns refs + dim names when configured", async () => {
     const payload = { find: vi.fn().mockResolvedValue({ docs: [{ id: 1 }] }) };
-    const ctx = await buildPageFilterContext(payload as never, cfg);
+    const ctx = await buildPageFilterContext({ payload } as never, cfg);
     expect(ctx?.refs.sort()).toEqual(["__home", "page:1"].sort());
     expect(ctx?.pageRefDim).toBe("customEvent:fr_page_ref");
     expect(ctx?.contentLocaleDim).toBe("customEvent:fr_content_locale");
+  });
+
+  it("publishes the resolved refs to the active holder", async () => {
+    const { getActiveExistingRefs, __clearActiveExistingRefs } = await import("../../../src/services/pageFilter/activeRefsHolder");
+    __clearActiveExistingRefs();
+    const payload = { find: vi.fn().mockResolvedValue({ docs: [{ id: 1 }] }) };
+    await buildPageFilterContext({ payload } as never, cfg);
+    expect(getActiveExistingRefs().sort()).toEqual(["__home", "page:1"].sort());
   });
 });

--- a/packages/payload-plugin-analytics/tests/services/pageFilter/buildPageFilterContext.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/pageFilter/buildPageFilterContext.test.ts
@@ -1,0 +1,30 @@
+// tests/services/pageFilter/buildPageFilterContext.test.ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { buildPageFilterContext } from "../../../src/services/pageFilter/buildPageFilterContext";
+import { __clearExistingRefsCache } from "../../../src/services/pageFilter/existingRefsCache";
+import type { ResolvedPagesConfig } from "../../../src/config/resolvePagesConfig";
+
+const cfg: ResolvedPagesConfig = {
+  collections: [{ slug: "page", publishedOnly: true }],
+  syntheticRefs: ["__home"],
+  dimensions: { pageRef: "customEvent:fr_page_ref", contentLocale: "customEvent:fr_content_locale" },
+};
+
+describe("buildPageFilterContext", () => {
+  beforeEach(() => __clearExistingRefsCache());
+
+  it("returns null when pages config is null (feature off)", async () => {
+    const payload = { find: vi.fn() };
+    const ctx = await buildPageFilterContext(payload as never, null);
+    expect(ctx).toBeNull();
+    expect(payload.find).not.toHaveBeenCalled();
+  });
+
+  it("returns refs + dim names when configured", async () => {
+    const payload = { find: vi.fn().mockResolvedValue({ docs: [{ id: 1 }] }) };
+    const ctx = await buildPageFilterContext(payload as never, cfg);
+    expect(ctx?.refs.sort()).toEqual(["__home", "page:1"].sort());
+    expect(ctx?.pageRefDim).toBe("customEvent:fr_page_ref");
+    expect(ctx?.contentLocaleDim).toBe("customEvent:fr_content_locale");
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/pageFilter/excludeDeletedSessions.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/pageFilter/excludeDeletedSessions.test.ts
@@ -1,0 +1,31 @@
+// tests/services/pageFilter/excludeDeletedSessions.test.ts
+import { describe, expect, it } from "vitest";
+import { excludeDeletedSessions } from "../../../src/services/pageFilter/excludeDeletedSessions";
+
+describe("excludeDeletedSessions", () => {
+  const existing = new Set(["page:1", "page:2", "__home"]);
+
+  it("keeps sessions whose every ref is in the existing set", () => {
+    const sessionRefs = new Map([
+      ["s1", new Set(["page:1", "__home"])],
+      ["s2", new Set(["page:2"])],
+    ]);
+    expect([...excludeDeletedSessions(sessionRefs, existing)].sort()).toEqual(["s1", "s2"]);
+  });
+
+  it("drops a session that touched any non-existing ref (deleted page)", () => {
+    const sessionRefs = new Map([
+      ["s1", new Set(["page:1", "page:999"])], // 999 deleted
+      ["s2", new Set(["page:2"])],
+    ]);
+    expect([...excludeDeletedSessions(sessionRefs, existing)]).toEqual(["s2"]);
+  });
+
+  it("drops a session that has an empty/absent ref (untracked hit)", () => {
+    const sessionRefs = new Map([
+      ["s1", new Set([""])],
+      ["s2", new Set(["page:1"])],
+    ]);
+    expect([...excludeDeletedSessions(sessionRefs, existing)]).toEqual(["s2"]);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/pageFilter/existingRefsCache.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/pageFilter/existingRefsCache.test.ts
@@ -1,0 +1,40 @@
+// tests/services/pageFilter/existingRefsCache.test.ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { getCachedExistingRefs, __clearExistingRefsCache, __setNowForTests } from "../../../src/services/pageFilter/existingRefsCache";
+
+describe("existingRefsCache", () => {
+  beforeEach(() => {
+    __clearExistingRefsCache();
+    __setNowForTests(1_000_000);
+  });
+
+  it("calls the loader on first access and caches within TTL", async () => {
+    const loader = vi.fn().mockResolvedValue(new Set(["page:1"]));
+    const a = await getCachedExistingRefs("key", loader);
+    __setNowForTests(1_000_000 + 30_000); // +30s, within 60s TTL
+    const b = await getCachedExistingRefs("key", loader);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  it("reloads after the TTL expires", async () => {
+    const loader = vi
+      .fn()
+      .mockResolvedValueOnce(new Set(["page:1"]))
+      .mockResolvedValueOnce(new Set(["page:2"]));
+    await getCachedExistingRefs("key", loader);
+    __setNowForTests(1_000_000 + 61_000); // past 60s TTL
+    const b = await getCachedExistingRefs("key", loader);
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect([...b]).toEqual(["page:2"]);
+  });
+
+  it("isolates entries by cache key", async () => {
+    const l1 = vi.fn().mockResolvedValue(new Set(["page:1"]));
+    const l2 = vi.fn().mockResolvedValue(new Set(["posts:9"]));
+    await getCachedExistingRefs("k1", l1);
+    await getCachedExistingRefs("k2", l2);
+    expect(l1).toHaveBeenCalledTimes(1);
+    expect(l2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/pageFilter/getExistingPageRefs.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/pageFilter/getExistingPageRefs.test.ts
@@ -1,0 +1,66 @@
+// tests/services/pageFilter/getExistingPageRefs.test.ts
+import { describe, expect, it, vi } from "vitest";
+import { getExistingPageRefs } from "../../../src/services/pageFilter/getExistingPageRefs";
+import type { ResolvedPagesConfig } from "../../../src/config/resolvePagesConfig";
+
+const cfg: ResolvedPagesConfig = {
+  collections: [
+    { slug: "page", publishedOnly: true },
+    { slug: "posts", publishedOnly: true },
+  ],
+  syntheticRefs: ["__home"],
+  dimensions: { pageRef: "customEvent:fr_page_ref", contentLocale: "customEvent:fr_content_locale" },
+};
+
+function fakePayload(byCollection: Record<string, { id: string | number }[]>) {
+  return {
+    find: vi.fn(async ({ collection }: { collection: string }) => ({ docs: byCollection[collection] ?? [] })),
+  };
+}
+
+describe("getExistingPageRefs", () => {
+  it("builds collection:id refs across collections + appends synthetic refs", async () => {
+    const payload = fakePayload({ page: [{ id: 42 }, { id: 7 }], posts: [{ id: 7 }] });
+    const refs = await getExistingPageRefs(payload as never, cfg);
+    expect([...refs].sort()).toEqual(["__home", "page:42", "page:7", "posts:7"].sort());
+  });
+
+  it("queries published-only with _status filter and select id", async () => {
+    const payload = fakePayload({ page: [{ id: 1 }], posts: [] });
+    await getExistingPageRefs(payload as never, cfg);
+    const firstCall = payload.find.mock.calls[0][0];
+    expect(firstCall.collection).toBe("page");
+    expect(firstCall.where).toEqual({ _status: { equals: "published" } });
+    expect(firstCall.select).toEqual({ id: true });
+    expect(firstCall.pagination).toBe(false);
+    expect(firstCall.depth).toBe(0);
+  });
+
+  it("retries without _status when the collection has no drafts", async () => {
+    const payload = {
+      find: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("The field '_status' is not valid."))
+        .mockResolvedValueOnce({ docs: [{ id: 9 }] }),
+    };
+    const single: ResolvedPagesConfig = { ...cfg, collections: [{ slug: "events", publishedOnly: true }], syntheticRefs: [] };
+    const refs = await getExistingPageRefs(payload as never, single);
+    expect([...refs]).toEqual(["events:9"]);
+    expect(payload.find).toHaveBeenCalledTimes(2);
+    expect(payload.find.mock.calls[1][0].where).toBeUndefined();
+  });
+
+  it("re-throws non-_status errors instead of swallowing them", async () => {
+    const payload = { find: vi.fn().mockRejectedValueOnce(new Error("Connection refused")) };
+    const single: ResolvedPagesConfig = { ...cfg, collections: [{ slug: "events", publishedOnly: true }], syntheticRefs: [] };
+    await expect(getExistingPageRefs(payload as never, single)).rejects.toThrow("Connection refused");
+    expect(payload.find).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not filter by _status when publishedOnly is false", async () => {
+    const payload = fakePayload({ events: [{ id: 3 }] });
+    const single: ResolvedPagesConfig = { ...cfg, collections: [{ slug: "events", publishedOnly: false }], syntheticRefs: [] };
+    await getExistingPageRefs(payload as never, single);
+    expect(payload.find.mock.calls[0][0].where).toBeUndefined();
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/pageFilter/pageLabelsCache.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/pageFilter/pageLabelsCache.test.ts
@@ -1,0 +1,31 @@
+// tests/services/pageFilter/pageLabelsCache.test.ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { getCachedPageLabels, __clearPageLabelsCache, __setNowForTests } from "../../../src/services/pageFilter/pageLabelsCache";
+
+describe("pageLabelsCache", () => {
+  beforeEach(() => {
+    __clearPageLabelsCache();
+    __setNowForTests(1_000_000);
+  });
+
+  it("loads once and caches within TTL", async () => {
+    const loader = vi.fn().mockResolvedValue(new Map([["pages:1", { path: "/a", title: "A" }]]));
+    const a = await getCachedPageLabels("k", loader);
+    __setNowForTests(1_030_000);
+    const b = await getCachedPageLabels("k", loader);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  it("reloads after TTL", async () => {
+    const loader = vi
+      .fn()
+      .mockResolvedValueOnce(new Map())
+      .mockResolvedValueOnce(new Map([["pages:2", { path: "/b", title: "B" }]]));
+    await getCachedPageLabels("k", loader);
+    __setNowForTests(1_061_000);
+    const b = await getCachedPageLabels("k", loader);
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(b.get("pages:2")).toEqual({ path: "/b", title: "B" });
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/pageFilter/resolvePageLabels.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/pageFilter/resolvePageLabels.test.ts
@@ -1,0 +1,74 @@
+// tests/services/pageFilter/resolvePageLabels.test.ts
+import { describe, expect, it, vi } from "vitest";
+import { resolvePageLabels } from "../../../src/services/pageFilter/resolvePageLabels";
+import type { ResolvedPagesConfig } from "../../../src/config/resolvePagesConfig";
+
+function cfg(over: Partial<ResolvedPagesConfig> = {}): ResolvedPagesConfig {
+  return {
+    collections: [{ slug: "pages", publishedOnly: true, titleField: "title" }],
+    syntheticRefs: ["__home"],
+    dimensions: { pageRef: "customEvent:fr_page_ref", contentLocale: "customEvent:fr_content_locale" },
+    resolvePagePath: (ref) => (ref === "__home" ? "/" : `/p/${ref.split(":")[1]}`),
+    ...over,
+  };
+}
+
+function fakeReq(byCollection: Record<string, Array<{ id: number; title?: string }>>) {
+  return {
+    payload: { config: { localization: { defaultLocale: "en" } }, find: vi.fn(async ({ collection }: { collection: string }) => ({ docs: byCollection[collection] ?? [] })) },
+  };
+}
+
+describe("resolvePageLabels", () => {
+  it("resolves title from the CMS doc (default locale) and path from the callback", async () => {
+    const req = fakeReq({ pages: [{ id: 42, title: "Why Pick Us" }] });
+    const map = await resolvePageLabels(req as never, cfg(), ["pages:42"]);
+    expect(map.get("pages:42")).toEqual({ path: "/p/42", title: "Why Pick Us" });
+  });
+
+  it("queries the title field at the default locale, selecting only that field", async () => {
+    const req = fakeReq({ pages: [{ id: 1, title: "A" }] });
+    await resolvePageLabels(req as never, cfg(), ["pages:1"]);
+    const call = req.payload.find.mock.calls[0][0];
+    expect(call.collection).toBe("pages");
+    expect(call.locale).toBe("en");
+    expect(call.where).toEqual({ id: { in: [1] } });
+    expect(call.select).toEqual({ title: true });
+  });
+
+  it("resolves synthetic refs via the callback; title falls back to the path", async () => {
+    const req = fakeReq({});
+    const map = await resolvePageLabels(req as never, cfg(), ["__home"]);
+    expect(map.get("__home")).toEqual({ path: "/", title: "/" });
+  });
+
+  it("falls back to the raw ref for title and path when nothing resolves", async () => {
+    const req = fakeReq({ pages: [] }); // doc missing
+    const map = await resolvePageLabels(req as never, cfg({ resolvePagePath: undefined }), ["pages:99"]);
+    expect(map.get("pages:99")).toEqual({ path: "pages:99", title: "pages:99" });
+  });
+
+  it("honors a custom titleField", async () => {
+    const req = fakeReq({ posts: [{ id: 7, title: undefined }] });
+    (req.payload.find as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ docs: [{ id: 7, name: "Headless CMS" }] });
+    const map = await resolvePageLabels(req as never, cfg({ collections: [{ slug: "posts", publishedOnly: true, titleField: "name" }] }), ["posts:7"]);
+    expect(map.get("posts:7")?.title).toBe("Headless CMS");
+  });
+
+  it("degrades gracefully when one collection's find throws, without poisoning others", async () => {
+    const req = fakeReq({ pages: [{ id: 5, title: "Healthy Page" }] });
+    // First find() call rejects (the throwing collection), second resolves (healthy).
+    (req.payload.find as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("DB down")).mockResolvedValueOnce({ docs: [{ id: 5, title: "Healthy Page" }] });
+    const config = cfg({
+      collections: [
+        { slug: "broken", publishedOnly: true, titleField: "title" },
+        { slug: "pages", publishedOnly: true, titleField: "title" },
+      ],
+    });
+    const map = await resolvePageLabels(req as never, config, ["broken:1", "pages:5"]);
+    // Throwing collection's ref falls through to path/ref fallback (path from callback).
+    expect(map.get("broken:1")).toEqual({ path: "/p/1", title: "/p/1" });
+    // Healthy collection still gets its real CMS title.
+    expect(map.get("pages:5")).toEqual({ path: "/p/5", title: "Healthy Page" });
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/queries/getJourneys.identity.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getJourneys.identity.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getJourneys } from "../../../src/services/queries/getJourneys";
+import { __setGa4ClientForTests } from "../../../src/services/ga4DataClient";
+import type { PageFilterContext } from "../../../src/services/pageFilter/types";
+
+afterEach(() => vi.restoreAllMocks());
+
+const pageFilter: PageFilterContext = {
+  refs: ["pages:1", "__home"],
+  pageRefDim: "customEvent:fr_page_ref",
+  contentLocaleDim: "customEvent:fr_content_locale",
+  resolveLabels: async () =>
+    new Map([
+      ["__home", { path: "/", title: "Home" }],
+      ["pages:1", { path: "/why-pick-us", title: "Why Pick Us" }],
+    ]),
+};
+
+// Two converting sessions hit the SAME ref (pages:1) under DIFFERENT historical pagePaths
+// (/old-pricing vs /pricing). Identity grouping must collapse them to one journey labeled
+// by the resolved path (/why-pick-us).
+const FIXTURE = {
+  dimensionHeaders: [],
+  metricHeaders: [{ name: "eventCount", type: "TYPE_INTEGER" }],
+  rows: [
+    { dimensionValues: [{ value: "S1" }, { value: "page_view" }, { value: "/" }, { value: "202605101430" }, { value: "1" }, { value: "" }, { value: "__home" }], metricValues: [{ value: "1" }] },
+    {
+      dimensionValues: [{ value: "S1" }, { value: "page_view" }, { value: "/old-pricing" }, { value: "202605101431" }, { value: "2" }, { value: "" }, { value: "pages:1" }],
+      metricValues: [{ value: "1" }],
+    },
+    {
+      dimensionValues: [{ value: "S1" }, { value: "lead_action" }, { value: "/old-pricing" }, { value: "202605101431" }, { value: "3" }, { value: "phone_click" }, { value: "pages:1" }],
+      metricValues: [{ value: "1" }],
+    },
+    { dimensionValues: [{ value: "S2" }, { value: "page_view" }, { value: "/" }, { value: "202605101500" }, { value: "1" }, { value: "" }, { value: "__home" }], metricValues: [{ value: "1" }] },
+    {
+      dimensionValues: [{ value: "S2" }, { value: "page_view" }, { value: "/pricing" }, { value: "202605101501" }, { value: "2" }, { value: "" }, { value: "pages:1" }],
+      metricValues: [{ value: "1" }],
+    },
+    {
+      dimensionValues: [{ value: "S2" }, { value: "lead_action" }, { value: "/pricing" }, { value: "202605101501" }, { value: "3" }, { value: "phone_click" }, { value: "pages:1" }],
+      metricValues: [{ value: "1" }],
+    },
+  ],
+  rowCount: 6,
+};
+
+describe("getJourneys identity labels", () => {
+  it("labels page steps by resolved path and consolidates differing historical pagePaths", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([FIXTURE]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+
+    const res = await getJourneys("12345", { dateRange: { preset: "last-7d" }, limit: 20, sampleLimit: 50_000 }, pageFilter);
+
+    expect(res.sessionsConsidered).toBe(2);
+    expect(res.rows).toHaveLength(1);
+    expect(res.rows[0].count).toBe(2);
+    expect(res.rows[0].path).toEqual([
+      { kind: "page", value: "/" },
+      { kind: "page", value: "/why-pick-us" },
+      { kind: "leadAction", value: "phone_click" },
+    ]);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/queries/getJourneys.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getJourneys.test.ts
@@ -104,6 +104,7 @@ describe("getJourneys", () => {
     refs: ["page:1", "__home"],
     pageRefDim: "customEvent:fr_page_ref",
     contentLocaleDim: "customEvent:fr_content_locale",
+    resolveLabels: async () => new Map(),
   };
 
   // Two converting sessions: S1 touches only existing refs (kept), S2 touches a deleted ref (dropped).

--- a/packages/payload-plugin-analytics/tests/services/queries/getJourneys.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getJourneys.test.ts
@@ -99,4 +99,85 @@ describe("getJourneys", () => {
     __setGa4ClientForTests(fake as never);
     await expect(getJourneys("12345", { dateRange: { preset: "last-7d" }, limit: 20, maxSteps: 8, sampleLimit: 50_000 })).rejects.toBe(err);
   });
+
+  const PAGE_FILTER = {
+    refs: ["page:1", "__home"],
+    pageRefDim: "customEvent:fr_page_ref",
+    contentLocaleDim: "customEvent:fr_content_locale",
+  };
+
+  // Two converting sessions: S1 touches only existing refs (kept), S2 touches a deleted ref (dropped).
+  const PAGE_FILTER_FIXTURE = {
+    dimensionHeaders: [],
+    metricHeaders: [{ name: "eventCount", type: "TYPE_INTEGER" }],
+    rows: [
+      {
+        dimensionValues: [{ value: "S1" }, { value: "page_view" }, { value: "/" }, { value: "202605101430" }, { value: "1" }, { value: "" }, { value: "__home" }],
+        metricValues: [{ value: "1" }],
+      },
+      {
+        dimensionValues: [{ value: "S1" }, { value: "lead_action" }, { value: "/" }, { value: "202605101430" }, { value: "2" }, { value: "phone_click" }, { value: "__home" }],
+        metricValues: [{ value: "1" }],
+      },
+      {
+        dimensionValues: [{ value: "S2" }, { value: "page_view" }, { value: "/gone" }, { value: "202605101500" }, { value: "1" }, { value: "" }, { value: "page:999" }],
+        metricValues: [{ value: "1" }],
+      },
+      {
+        dimensionValues: [{ value: "S2" }, { value: "lead_action" }, { value: "/gone" }, { value: "202605101500" }, { value: "2" }, { value: "email_click" }, { value: "page:999" }],
+        metricValues: [{ value: "1" }],
+      },
+    ],
+    rowCount: 4,
+  };
+
+  it("appends the page-ref dim and excludes a session that touched a deleted ref when pageFilter is set", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([PAGE_FILTER_FIXTURE]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    const res = await getJourneys("12345", { dateRange: { preset: "last-7d" }, limit: 20, sampleLimit: 50_000 }, PAGE_FILTER);
+
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensions).toEqual([
+      { name: "customEvent:fr_session_id" },
+      { name: "eventName" },
+      { name: "pagePath" },
+      { name: "dateHourMinute" },
+      { name: "customEvent:fr_event_seq" },
+      { name: "customEvent:fr_lead_type" },
+      { name: "customEvent:fr_page_ref" },
+    ]);
+
+    // Only S1 survives; S2 (deleted ref) is not counted nor present.
+    expect(res.sessionsConsidered).toBe(1);
+    expect(res.rows).toHaveLength(1);
+    expect(res.rows[0].path).toEqual([
+      { kind: "page", value: "/" },
+      { kind: "leadAction", value: "phone_click" },
+    ]);
+  });
+
+  it("does NOT append the page-ref dim and counts all sessions when pageFilter is null", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([basic]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    const res = await getJourneys("12345", { dateRange: { preset: "last-7d" }, limit: 20, maxSteps: 8, sampleLimit: 50_000 }, null);
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensions).toEqual([
+      { name: "customEvent:fr_session_id" },
+      { name: "eventName" },
+      { name: "pagePath" },
+      { name: "dateHourMinute" },
+      { name: "customEvent:fr_event_seq" },
+      { name: "customEvent:fr_lead_type" },
+    ]);
+    expect(res.sessionsConsidered).toBe(2);
+  });
+
+  it("adds fr_page_ref to the catch missing-key candidates", async () => {
+    const err = new Error("3 INVALID_ARGUMENT: Field customEvent:fr_page_ref is unrecognized.");
+    const fake = { runReport: vi.fn().mockRejectedValue(err), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    const res = await getJourneys("12345", { dateRange: { preset: "last-7d" }, limit: 20, sampleLimit: 50_000 }, PAGE_FILTER);
+    expect(res.setupRequired).toBe(true);
+    expect(res.missing).toEqual(["fr_page_ref"]);
+  });
 });

--- a/packages/payload-plugin-analytics/tests/services/queries/getKpis.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getKpis.test.ts
@@ -79,4 +79,97 @@ describe("getKpis", () => {
     const res = await getKpis("12345", { dateRange: { from: "2026-05-04", to: "2026-05-06" } });
     expect(res.comparisonSeries).toBeUndefined();
   });
+
+  it("keeps the native-metric path when pageFilter is null (no refs)", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([kpisCurrent]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    await getKpis("12345", { dateRange: { from: "2026-05-04", to: "2026-05-06" } }, null);
+    expect(fake.runReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metrics: expect.arrayContaining([{ name: "sessions" }, { name: "totalUsers" }, { name: "screenPageViews" }, { name: "bounceRate" }, { name: "averageSessionDuration" }]),
+        dimensions: [{ name: "date" }],
+      })
+    );
+  });
+
+  const PAGE_FILTER = {
+    refs: ["page:1", "__home"],
+    pageRefDim: "customEvent:fr_page_ref",
+    contentLocaleDim: "customEvent:fr_content_locale",
+  };
+
+  function sessionLevelReport(rows: unknown[]) {
+    return {
+      dimensionHeaders: [],
+      metricHeaders: [{ name: "eventCount", type: "TYPE_INTEGER" }],
+      rows,
+      rowCount: rows.length,
+    };
+  }
+
+  it("issues a session-level report (fr_session_id + date + pageRefDim + eventName + dateHourMinute) when pageFilter has refs", async () => {
+    const fake = {
+      runReport: vi.fn().mockResolvedValue([sessionLevelReport([])]),
+      batchRunReports: vi.fn(),
+    };
+    __setGa4ClientForTests(fake as never);
+    await getKpis("12345", { dateRange: { from: "2026-05-04", to: "2026-05-06" } }, PAGE_FILTER);
+    const arg = fake.runReport.mock.calls[0][0];
+    const dimNames = arg.dimensions.map((d: { name: string }) => d.name);
+    expect(dimNames).toContain("customEvent:fr_session_id");
+    expect(dimNames).toContain("date");
+    expect(dimNames).toContain("customEvent:fr_page_ref");
+    expect(dimNames).toContain("eventName");
+    expect(dimNames).toContain("dateHourMinute");
+    // fr_elapsed_ms is a custom METRIC, not a dimension — must not be requested as a dim.
+    expect(dimNames).not.toContain("customEvent:fr_elapsed_ms");
+    expect(arg.metrics).toEqual([{ name: "eventCount" }]);
+  });
+
+  it("excludes a deleted-ref session from current totals under pageFilter", async () => {
+    const r = (sessionId: string, pageRef: string, eventName: string, elapsedMs: string) => ({
+      dimensionValues: [{ value: sessionId }, { value: "20260504" }, { value: pageRef }, { value: eventName }, { value: elapsedMs }],
+      metricValues: [{ value: "1" }],
+    });
+    const report = sessionLevelReport([
+      r("s1", "page:1", "page_view", "1000"),
+      r("s1", "__home", "page_view", "3000"),
+      // s2 touched a deleted ref → excluded
+      r("s2", "page:999", "page_view", "9000"),
+    ]);
+    const fake = { runReport: vi.fn().mockResolvedValue([report]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    const res = await getKpis("12345", { dateRange: { from: "2026-05-04", to: "2026-05-06" } }, PAGE_FILTER);
+    expect(res.current.sessions).toBe(1);
+    expect(res.current.pageViews).toBe(2);
+    expect(res.current.users).toBe(1);
+  });
+
+  it("populates comparison + comparisonSeries from the previous range under pageFilter", async () => {
+    const r = (sessionId: string, date: string, pageRef: string) => ({
+      dimensionValues: [{ value: sessionId }, { value: date }, { value: pageRef }, { value: "page_view" }, { value: "1000" }],
+      metricValues: [{ value: "1" }],
+    });
+    // With two date ranges GA4 appends a trailing `dateRange` dim whose value is
+    // the range NAME we assigned ("current" / "previous"); the service splits on it.
+    const withRange = (base: ReturnType<typeof r>, range: string) => ({
+      ...base,
+      dimensionValues: [...base.dimensionValues, { value: range }],
+    });
+    const report = sessionLevelReport([withRange(r("c1", "20260504", "page:1"), "current"), withRange(r("p1", "20260427", "page:1"), "previous")]);
+    const fake = { runReport: vi.fn().mockResolvedValue([report]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    const res = await getKpis("12345", { dateRange: { from: "2026-05-04", to: "2026-05-06" }, comparison: { kind: "previous-period" } }, PAGE_FILTER);
+    expect(res.current.sessions).toBe(1);
+    expect(res.comparison?.sessions).toBe(1);
+    expect(res.series).toHaveLength(1);
+    expect(res.comparisonSeries).toHaveLength(1);
+  });
+
+  it("surfaces a setup gate (mapped error) including fr_page_ref under pageFilter", async () => {
+    const err = new Error("3 INVALID_ARGUMENT: Field customEvent:fr_page_ref is unrecognized.");
+    const fake = { runReport: vi.fn().mockRejectedValue(err), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    await expect(getKpis("12345", { dateRange: { from: "2026-05-04", to: "2026-05-06" } }, PAGE_FILTER)).rejects.toBe(err);
+  });
 });

--- a/packages/payload-plugin-analytics/tests/services/queries/getKpis.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getKpis.test.ts
@@ -96,6 +96,7 @@ describe("getKpis", () => {
     refs: ["page:1", "__home"],
     pageRefDim: "customEvent:fr_page_ref",
     contentLocaleDim: "customEvent:fr_content_locale",
+    resolveLabels: async () => new Map(),
   };
 
   function sessionLevelReport(rows: unknown[]) {

--- a/packages/payload-plugin-analytics/tests/services/queries/getLeadActions.identity.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getLeadActions.identity.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getLeadActions } from "../../../src/services/queries/getLeadActions";
+import { __setGa4ClientForTests } from "../../../src/services/ga4DataClient";
+import { setPluginConfig } from "../../../src/config";
+import type { PageFilterContext } from "../../../src/services/pageFilter/types";
+
+const pageFilter: PageFilterContext = {
+  refs: ["pages:1"],
+  pageRefDim: "customEvent:fr_page_ref",
+  contentLocaleDim: "customEvent:fr_content_locale",
+  resolveLabels: async () => new Map([["pages:1", { path: "/why-pick-us", title: "Why Pick Us" }]]),
+};
+
+beforeEach(() => {
+  setPluginConfig({ ga4: { propertyId: "1", measurementId: "G-X", serviceAccount: { clientEmail: "", privateKey: "" } }, leadActions: { types: ["phone_click"] } });
+});
+
+describe("getLeadActions perPage identity", () => {
+  it("requests fr_page_ref as the second events dim and keys perPage by resolved label path", async () => {
+    const events = { rows: [{ dimensionValues: [{ value: "phone_click" }, { value: "pages:1" }], metricValues: [{ value: "7" }, { value: "1200" }] }] };
+    const sessions = { rows: [{ metricValues: [{ value: "100" }] }] };
+    const fake = { runReport: vi.fn(), batchRunReports: vi.fn().mockResolvedValue([{ reports: [events, sessions] }]) };
+    __setGa4ClientForTests(fake as never);
+
+    const res = await getLeadActions("1", { dateRange: { preset: "last-7d" } }, pageFilter);
+    const eventsReqDims = fake.batchRunReports.mock.calls[0][0].requests[0].dimensions;
+    expect(eventsReqDims).toEqual([{ name: "customEvent:fr_lead_type" }, { name: "customEvent:fr_page_ref" }]);
+    expect(res.current.perPage).toEqual([{ pagePath: "/why-pick-us", counts: { phone_click: 7 } }]);
+  });
+
+  it("consolidates two historical pagePaths for the same ref into one perPage row", async () => {
+    const events = {
+      rows: [
+        { dimensionValues: [{ value: "phone_click" }, { value: "pages:1" }], metricValues: [{ value: "4" }, { value: "1000" }] },
+        { dimensionValues: [{ value: "phone_click" }, { value: "pages:1" }], metricValues: [{ value: "3" }, { value: "2000" }] },
+      ],
+    };
+    const sessions = { rows: [{ metricValues: [{ value: "50" }] }] };
+    const fake = { runReport: vi.fn(), batchRunReports: vi.fn().mockResolvedValue([{ reports: [events, sessions] }]) };
+    __setGa4ClientForTests(fake as never);
+
+    const res = await getLeadActions("1", { dateRange: { preset: "last-7d" } }, pageFilter);
+    expect(res.current.perPage).toEqual([{ pagePath: "/why-pick-us", counts: { phone_click: 7 } }]);
+    expect(res.current.totals.phone_click).toBe(7);
+  });
+
+  it("falls back to the ref string when a label is missing", async () => {
+    const events = { rows: [{ dimensionValues: [{ value: "phone_click" }, { value: "pages:2" }], metricValues: [{ value: "5" }, { value: "900" }] }] };
+    const sessions = { rows: [{ metricValues: [{ value: "100" }] }] };
+    const fake = { runReport: vi.fn(), batchRunReports: vi.fn().mockResolvedValue([{ reports: [events, sessions] }]) };
+    __setGa4ClientForTests(fake as never);
+
+    const res = await getLeadActions("1", { dateRange: { preset: "last-7d" } }, pageFilter);
+    expect(res.current.perPage).toEqual([{ pagePath: "pages:2", counts: { phone_click: 5 } }]);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/queries/getLeadActions.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getLeadActions.test.ts
@@ -120,7 +120,7 @@ describe("getLeadActions", () => {
       batchRunReports: vi.fn().mockResolvedValue([withMetric]),
     };
     __setGa4ClientForTests(fake as never);
-    const pageFilter = { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" };
+    const pageFilter = { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale", resolveLabels: async () => new Map() };
     await getLeadActions("12345", { dateRange: { preset: "last-7d" } }, pageFilter);
     const requests = fake.batchRunReports.mock.calls[0][0].requests;
     const pageRefInList = { filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } };
@@ -139,7 +139,7 @@ describe("getLeadActions", () => {
       batchRunReports: vi.fn().mockRejectedValueOnce(err).mockResolvedValueOnce([withoutMetric]),
     };
     __setGa4ClientForTests(fake as never);
-    const pageFilter = { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" };
+    const pageFilter = { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale", resolveLabels: async () => new Map() };
     await getLeadActions("12345", { dateRange: { preset: "last-7d" } }, pageFilter);
     const retryRequests = fake.batchRunReports.mock.calls[1][0].requests;
     const pageRefInList = { filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } };

--- a/packages/payload-plugin-analytics/tests/services/queries/getLeadActions.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getLeadActions.test.ts
@@ -114,6 +114,53 @@ describe("getLeadActions", () => {
     expect(res.current.avgTimeToAction).toBe(0);
   });
 
+  it("ANDs fr_page_ref inList into the events filter and filters the sessions request when pageFilter has refs", async () => {
+    const fake = {
+      runReport: vi.fn(),
+      batchRunReports: vi.fn().mockResolvedValue([withMetric]),
+    };
+    __setGa4ClientForTests(fake as never);
+    const pageFilter = { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" };
+    await getLeadActions("12345", { dateRange: { preset: "last-7d" } }, pageFilter);
+    const requests = fake.batchRunReports.mock.calls[0][0].requests;
+    const pageRefInList = { filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } };
+
+    // events request: existing leadActionFilter ANDed with the page-ref inList
+    expect(requests[0].dimensionFilter.andGroup.expressions[requests[0].dimensionFilter.andGroup.expressions.length - 1]).toEqual(pageRefInList);
+
+    // sessions request (denominator): standalone page-ref inList
+    expect(requests[1].dimensionFilter).toEqual(pageRefInList);
+  });
+
+  it("filters the fallback events request and sessions request when pageFilter set and fr_elapsed_ms missing", async () => {
+    const err = new Error("3 INVALID_ARGUMENT: Field averageCustomEvent:fr_elapsed_ms is unrecognized.");
+    const fake = {
+      runReport: vi.fn(),
+      batchRunReports: vi.fn().mockRejectedValueOnce(err).mockResolvedValueOnce([withoutMetric]),
+    };
+    __setGa4ClientForTests(fake as never);
+    const pageFilter = { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" };
+    await getLeadActions("12345", { dateRange: { preset: "last-7d" } }, pageFilter);
+    const retryRequests = fake.batchRunReports.mock.calls[1][0].requests;
+    const pageRefInList = { filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } };
+    expect(retryRequests[0].metrics).toEqual([{ name: "eventCount" }]);
+    expect(retryRequests[0].dimensionFilter.andGroup.expressions[retryRequests[0].dimensionFilter.andGroup.expressions.length - 1]).toEqual(pageRefInList);
+    expect(retryRequests[1].dimensionFilter).toEqual(pageRefInList);
+  });
+
+  it("leaves events filter as leadActionFilter only and sessions unfiltered when pageFilter is null", async () => {
+    const fake = {
+      runReport: vi.fn(),
+      batchRunReports: vi.fn().mockResolvedValue([withMetric]),
+    };
+    __setGa4ClientForTests(fake as never);
+    await getLeadActions("12345", { dateRange: { preset: "last-7d" } }, null);
+    const requests = fake.batchRunReports.mock.calls[0][0].requests;
+    // events request still carries the lead-action filter, but no page-ref inList anywhere in it
+    expect(JSON.stringify(requests[0].dimensionFilter)).not.toContain("fr_page_ref");
+    expect(requests[1].dimensionFilter).toBeUndefined();
+  });
+
   it("does NOT retry on unrelated INVALID_ARGUMENT", async () => {
     const err = new Error("3 INVALID_ARGUMENT: bad date format");
     const fake = {

--- a/packages/payload-plugin-analytics/tests/services/queries/getSessionDetail.identity.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getSessionDetail.identity.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getSessionDetail } from "../../../src/services/queries/getSessionDetail";
+import { __setGa4ClientForTests } from "../../../src/services/ga4DataClient";
+import type { PageFilterContext } from "../../../src/services/pageFilter/types";
+
+afterEach(() => vi.restoreAllMocks());
+
+const SESSION_ID = "11111111-2222-4333-8444-555555555555";
+
+const pageFilter: PageFilterContext = {
+  refs: ["pages:1", "__home"],
+  pageRefDim: "customEvent:fr_page_ref",
+  contentLocaleDim: "customEvent:fr_content_locale",
+  resolveLabels: async () =>
+    new Map([
+      ["__home", { path: "/", title: "Home" }],
+      ["pages:1", { path: "/why-pick-us", title: "Why Pick Us" }],
+    ]),
+};
+
+// Session whose refs all exist; the raw GA4 pagePath (/old-pricing) is historical and must be
+// replaced by the resolved label path keyed on the event row's ref.
+function fixture() {
+  return {
+    dimensionHeaders: [],
+    metricHeaders: [{ name: "eventCount", type: "TYPE_INTEGER" }],
+    rows: [
+      { dimensionValues: [{ value: "page_view" }, { value: "/" }, { value: "202605101430" }, { value: "1" }, { value: "" }, { value: "__home" }], metricValues: [{ value: "1" }] },
+      { dimensionValues: [{ value: "page_view" }, { value: "/old-pricing" }, { value: "202605101431" }, { value: "2" }, { value: "" }, { value: "pages:1" }], metricValues: [{ value: "1" }] },
+      {
+        dimensionValues: [{ value: "lead_action" }, { value: "/old-pricing" }, { value: "202605101431" }, { value: "3" }, { value: "phone_click" }, { value: "pages:1" }],
+        metricValues: [{ value: "1" }],
+      },
+    ],
+    rowCount: 3,
+  };
+}
+
+describe("getSessionDetail identity labels", () => {
+  it("labels each event pagePath via resolveLabels by the row's ref", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([fixture()]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+
+    const res = await getSessionDetail("12345", SESSION_ID, { dateRange: { preset: "last-7d" } }, pageFilter);
+
+    expect(res.events).toHaveLength(3);
+    expect(res.events.map((e) => e.pagePath)).toEqual(["/", "/why-pick-us", "/why-pick-us"]);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/queries/getSessionDetail.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getSessionDetail.test.ts
@@ -103,4 +103,93 @@ describe("getSessionDetail", () => {
     __setGa4ClientForTests(fake as never);
     await expect(getSessionDetail("12345", SESSION_ID, { dateRange: { preset: "last-7d" } })).rejects.toBe(err);
   });
+
+  const PAGE_FILTER = {
+    refs: ["page:1", "__home"],
+    pageRefDim: "customEvent:fr_page_ref",
+    contentLocaleDim: "customEvent:fr_content_locale",
+  };
+
+  function detailFixture(ref: string) {
+    return {
+      dimensionHeaders: [],
+      metricHeaders: [{ name: "eventCount", type: "TYPE_INTEGER" }],
+      rows: [
+        { dimensionValues: [{ value: "page_view" }, { value: "/" }, { value: "202605101430" }, { value: "1" }, { value: "" }, { value: ref }], metricValues: [{ value: "1" }] },
+        { dimensionValues: [{ value: "scroll" }, { value: "/" }, { value: "202605101430" }, { value: "2" }, { value: "" }, { value: ref }], metricValues: [{ value: "1" }] },
+        { dimensionValues: [{ value: "lead_action" }, { value: "/" }, { value: "202605101430" }, { value: "3" }, { value: "phone_click" }, { value: ref }], metricValues: [{ value: "1" }] },
+      ],
+      rowCount: 3,
+    };
+  }
+
+  it("appends the page-ref dim and returns events for a clean session when pageFilter is set", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([detailFixture("__home")]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    const res = await getSessionDetail("12345", SESSION_ID, { dateRange: { preset: "last-7d" } }, PAGE_FILTER);
+
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensions).toEqual([
+      { name: "eventName" },
+      { name: "pagePath" },
+      { name: "dateHourMinute" },
+      { name: "customEvent:fr_event_seq" },
+      { name: "customEvent:fr_lead_type" },
+      { name: "customEvent:fr_page_ref" },
+    ]);
+    expect(res.sessionId).toBe(SESSION_ID);
+    expect(res.events).toHaveLength(3);
+  });
+
+  it("returns empty events when the session touched a deleted ref", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([detailFixture("page:999")]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    const res = await getSessionDetail("12345", SESSION_ID, { dateRange: { preset: "last-7d" } }, PAGE_FILTER);
+    expect(res.sessionId).toBe(SESSION_ID);
+    expect(res.events).toEqual([]);
+  });
+
+  function detailFixtureNoLeadType(ref: string) {
+    return {
+      dimensionHeaders: [],
+      metricHeaders: [{ name: "eventCount", type: "TYPE_INTEGER" }],
+      rows: [
+        { dimensionValues: [{ value: "page_view" }, { value: "/" }, { value: "202605101430" }, { value: "1" }, { value: ref }], metricValues: [{ value: "1" }] },
+        { dimensionValues: [{ value: "scroll" }, { value: "/" }, { value: "202605101430" }, { value: "2" }, { value: ref }], metricValues: [{ value: "1" }] },
+        { dimensionValues: [{ value: "lead_action" }, { value: "/" }, { value: "202605101430" }, { value: "3" }, { value: ref }], metricValues: [{ value: "1" }] },
+      ],
+      rowCount: 3,
+    };
+  }
+
+  it("excludes a deleted-ref session on the fr_lead_type-less fallback path (ref at index 4)", async () => {
+    // why: first call rejects with the fr_lead_type-only error → deriveMissing yields
+    // ["fr_lead_type"] → retry without lead-type. The retry returns rows whose ref
+    // column is now at index 4 and points at a DELETED ref → events must be excluded.
+    const err = new Error("3 INVALID_ARGUMENT: Field customEvent:fr_lead_type is unrecognized.");
+    const runReport = vi
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce([detailFixtureNoLeadType("page:999")]);
+    const fake = { runReport, batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+
+    const res = await getSessionDetail("12345", SESSION_ID, { dateRange: { preset: "last-7d" } }, PAGE_FILTER);
+
+    expect(runReport).toHaveBeenCalledTimes(2);
+    const retryDims = runReport.mock.calls[1][0].dimensions;
+    expect(retryDims).toEqual([{ name: "eventName" }, { name: "pagePath" }, { name: "dateHourMinute" }, { name: "customEvent:fr_event_seq" }, { name: "customEvent:fr_page_ref" }]);
+    expect(res.setupRequired).toBeUndefined();
+    expect(res.missing).toEqual(["fr_lead_type"]);
+    expect(res.events).toEqual([]);
+  });
+
+  it("does NOT append the page-ref dim and returns full events when pageFilter is null", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([sessionDetail]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    const res = await getSessionDetail("12345", SESSION_ID, { dateRange: { preset: "last-7d" } }, null);
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensions).toEqual([{ name: "eventName" }, { name: "pagePath" }, { name: "dateHourMinute" }, { name: "customEvent:fr_event_seq" }, { name: "customEvent:fr_lead_type" }]);
+    expect(res.events).toHaveLength(3);
+  });
 });

--- a/packages/payload-plugin-analytics/tests/services/queries/getSessionDetail.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getSessionDetail.test.ts
@@ -108,6 +108,7 @@ describe("getSessionDetail", () => {
     refs: ["page:1", "__home"],
     pageRefDim: "customEvent:fr_page_ref",
     contentLocaleDim: "customEvent:fr_content_locale",
+    resolveLabels: async () => new Map(),
   };
 
   function detailFixture(ref: string) {

--- a/packages/payload-plugin-analytics/tests/services/queries/getTopCountries.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getTopCountries.test.ts
@@ -128,3 +128,20 @@ describe("getTopCountries — comparison join key", () => {
     expect(res.comparison?.rows[0]).toMatchObject({ city: "New York", country: "United States", sessions: 60 });
   });
 });
+
+describe("getTopCountries — page filter", () => {
+  it("applies fr_page_ref inList filter when pageFilter has refs", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([topCountries]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    await getTopCountries("12345", { dateRange: { preset: "last-7d" } }, { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" });
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensionFilter).toEqual({ filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } });
+  });
+  it("adds no fr_page_ref filter when pageFilter is null", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([topCountries]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    await getTopCountries("12345", { dateRange: { preset: "last-7d" } }, null);
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensionFilter).toBeUndefined();
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/queries/getTopCountries.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getTopCountries.test.ts
@@ -133,7 +133,11 @@ describe("getTopCountries — page filter", () => {
   it("applies fr_page_ref inList filter when pageFilter has refs", async () => {
     const fake = { runReport: vi.fn().mockResolvedValue([topCountries]), batchRunReports: vi.fn() };
     __setGa4ClientForTests(fake as never);
-    await getTopCountries("12345", { dateRange: { preset: "last-7d" } }, { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" });
+    await getTopCountries(
+      "12345",
+      { dateRange: { preset: "last-7d" } },
+      { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale", resolveLabels: async () => new Map() }
+    );
     const arg = fake.runReport.mock.calls[0][0];
     expect(arg.dimensionFilter).toEqual({ filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } });
   });

--- a/packages/payload-plugin-analytics/tests/services/queries/getTopDevices.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getTopDevices.test.ts
@@ -34,4 +34,18 @@ describe("getTopDevices", () => {
     const res = await getTopDevices("12345", { dateRange: { preset: "last-7d" } });
     expect(res.rows.map((r) => r.deviceCategory)).toEqual(["desktop", "mobile", "tablet"]);
   });
+  it("applies fr_page_ref inList filter when pageFilter has refs", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([topDevices]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    await getTopDevices("12345", { dateRange: { preset: "last-7d" } }, { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" });
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensionFilter).toEqual({ filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } });
+  });
+  it("adds no fr_page_ref filter when pageFilter is null", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([topDevices]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    await getTopDevices("12345", { dateRange: { preset: "last-7d" } }, null);
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensionFilter).toBeUndefined();
+  });
 });

--- a/packages/payload-plugin-analytics/tests/services/queries/getTopDevices.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getTopDevices.test.ts
@@ -37,7 +37,11 @@ describe("getTopDevices", () => {
   it("applies fr_page_ref inList filter when pageFilter has refs", async () => {
     const fake = { runReport: vi.fn().mockResolvedValue([topDevices]), batchRunReports: vi.fn() };
     __setGa4ClientForTests(fake as never);
-    await getTopDevices("12345", { dateRange: { preset: "last-7d" } }, { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" });
+    await getTopDevices(
+      "12345",
+      { dateRange: { preset: "last-7d" } },
+      { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale", resolveLabels: async () => new Map() }
+    );
     const arg = fake.runReport.mock.calls[0][0];
     expect(arg.dimensionFilter).toEqual({ filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } });
   });

--- a/packages/payload-plugin-analytics/tests/services/queries/getTopEvents.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getTopEvents.test.ts
@@ -19,4 +19,18 @@ describe("getTopEvents", () => {
     expect(res.rows.length).toBeGreaterThan(0);
     expect(typeof res.rows[0].eventCount).toBe("number");
   });
+  it("applies fr_page_ref inList filter when pageFilter has refs", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([topEvents]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    await getTopEvents("12345", { dateRange: { preset: "last-7d" } }, { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" });
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensionFilter).toEqual({ filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } });
+  });
+  it("adds no fr_page_ref filter when pageFilter is null", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([topEvents]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    await getTopEvents("12345", { dateRange: { preset: "last-7d" } }, null);
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensionFilter).toBeUndefined();
+  });
 });

--- a/packages/payload-plugin-analytics/tests/services/queries/getTopEvents.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getTopEvents.test.ts
@@ -22,7 +22,11 @@ describe("getTopEvents", () => {
   it("applies fr_page_ref inList filter when pageFilter has refs", async () => {
     const fake = { runReport: vi.fn().mockResolvedValue([topEvents]), batchRunReports: vi.fn() };
     __setGa4ClientForTests(fake as never);
-    await getTopEvents("12345", { dateRange: { preset: "last-7d" } }, { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" });
+    await getTopEvents(
+      "12345",
+      { dateRange: { preset: "last-7d" } },
+      { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale", resolveLabels: async () => new Map() }
+    );
     const arg = fake.runReport.mock.calls[0][0];
     expect(arg.dimensionFilter).toEqual({ filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } });
   });

--- a/packages/payload-plugin-analytics/tests/services/queries/getTopPages.identity.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getTopPages.identity.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { getTopPages } from "../../../src/services/queries/getTopPages";
+import { __setGa4ClientForTests } from "../../../src/services/ga4DataClient";
+import type { PageFilterContext } from "../../../src/services/pageFilter/types";
+
+const pageFilter: PageFilterContext = {
+  refs: ["pages:1", "pages:2"],
+  pageRefDim: "customEvent:fr_page_ref",
+  contentLocaleDim: "customEvent:fr_content_locale",
+  resolveLabels: async () => new Map([["pages:1", { path: "/why-pick-us", title: "Why Pick Us" }]]),
+};
+
+describe("getTopPages identity grouping", () => {
+  it("groups by fr_page_ref and labels rows with resolved path/title", async () => {
+    // Two GA4 rows for the SAME ref under different historical paths → must consolidate.
+    const fixture = {
+      rows: [
+        { dimensionValues: [{ value: "pages:1" }], metricValues: [{ value: "100" }, { value: "60" }, { value: "30" }] },
+        { dimensionValues: [{ value: "pages:1" }], metricValues: [{ value: "40" }, { value: "20" }, { value: "31" }] },
+      ],
+    };
+    const fake = { runReport: vi.fn().mockResolvedValue([fixture]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+
+    const res = await getTopPages("123", { dateRange: { preset: "last-7d" } }, pageFilter);
+    // request grouped by the ref dim
+    expect(fake.runReport.mock.calls[0][0].dimensions).toEqual([{ name: "customEvent:fr_page_ref" }]);
+    // existence inList filter on the ref dim
+    expect(fake.runReport.mock.calls[0][0].dimensionFilter).toEqual({ filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["pages:1", "pages:2"] } } });
+    // one consolidated row, labeled from CMS
+    expect(res.rows).toEqual([{ pagePath: "/why-pick-us", pageTitle: "Why Pick Us", pageViews: 140, sessions: 80, avgTime: expect.any(Number) }]);
+  });
+
+  it("falls back to the ref string when a label is missing", async () => {
+    const fixture = {
+      rows: [{ dimensionValues: [{ value: "pages:2" }], metricValues: [{ value: "10" }, { value: "5" }, { value: "12" }] }],
+    };
+    const fake = { runReport: vi.fn().mockResolvedValue([fixture]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+
+    const res = await getTopPages("123", { dateRange: { preset: "last-7d" } }, pageFilter);
+    expect(res.rows).toEqual([{ pagePath: "pages:2", pageTitle: "pages:2", pageViews: 10, sessions: 5, avgTime: 12 }]);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/queries/getTopPages.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getTopPages.test.ts
@@ -23,11 +23,18 @@ describe("getTopPages", () => {
     expect(res.total).toBe(res.rows.reduce((a, r) => a + r.pageViews, 0));
   });
 
-  it("applies fr_page_ref inList filter when pageFilter has refs", async () => {
+  it("groups by fr_page_ref and applies its inList filter when pageFilter has refs", async () => {
+    // Identity behavior: when pageFilter is set, the request groups by the ref dim ONLY
+    // (no pagePath/pageTitle) and existence is enforced by the ref inList filter.
     const fake = { runReport: vi.fn().mockResolvedValue([topPages]), batchRunReports: vi.fn() };
     __setGa4ClientForTests(fake as never);
-    await getTopPages("12345", { dateRange: { preset: "last-7d" } }, { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" });
+    await getTopPages(
+      "12345",
+      { dateRange: { preset: "last-7d" } },
+      { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale", resolveLabels: async () => new Map() }
+    );
     const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensions).toEqual([{ name: "customEvent:fr_page_ref" }]);
     expect(arg.dimensionFilter).toEqual({ filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } });
   });
 

--- a/packages/payload-plugin-analytics/tests/services/queries/getTopPages.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getTopPages.test.ts
@@ -23,6 +23,22 @@ describe("getTopPages", () => {
     expect(res.total).toBe(res.rows.reduce((a, r) => a + r.pageViews, 0));
   });
 
+  it("applies fr_page_ref inList filter when pageFilter has refs", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([topPages]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    await getTopPages("12345", { dateRange: { preset: "last-7d" } }, { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" });
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensionFilter).toEqual({ filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } });
+  });
+
+  it("adds no fr_page_ref filter when pageFilter is null", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([topPages]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    await getTopPages("12345", { dateRange: { preset: "last-7d" } }, null);
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensionFilter).toBeUndefined();
+  });
+
   it("comparison.rows is keyed on current rows; previous-only rows are dropped", async () => {
     const fixture = {
       rows: [

--- a/packages/payload-plugin-analytics/tests/services/queries/getTopSources.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getTopSources.test.ts
@@ -23,7 +23,11 @@ describe("getTopSources", () => {
   it("applies fr_page_ref inList filter when pageFilter has refs", async () => {
     const fake = { runReport: vi.fn().mockResolvedValue([topSources]), batchRunReports: vi.fn() };
     __setGa4ClientForTests(fake as never);
-    await getTopSources("12345", { dateRange: { preset: "last-7d" } }, { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" });
+    await getTopSources(
+      "12345",
+      { dateRange: { preset: "last-7d" } },
+      { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale", resolveLabels: async () => new Map() }
+    );
     const arg = fake.runReport.mock.calls[0][0];
     expect(arg.dimensionFilter).toEqual({ filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } });
   });

--- a/packages/payload-plugin-analytics/tests/services/queries/getTopSources.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/getTopSources.test.ts
@@ -20,4 +20,18 @@ describe("getTopSources", () => {
     expect(typeof res.rows[0].sessions).toBe("number");
     expect(typeof res.rows[0].users).toBe("number");
   });
+  it("applies fr_page_ref inList filter when pageFilter has refs", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([topSources]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    await getTopSources("12345", { dateRange: { preset: "last-7d" } }, { refs: ["page:1", "__home"], pageRefDim: "customEvent:fr_page_ref", contentLocaleDim: "customEvent:fr_content_locale" });
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensionFilter).toEqual({ filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: ["page:1", "__home"] } } });
+  });
+  it("adds no fr_page_ref filter when pageFilter is null", async () => {
+    const fake = { runReport: vi.fn().mockResolvedValue([topSources]), batchRunReports: vi.fn() };
+    __setGa4ClientForTests(fake as never);
+    await getTopSources("12345", { dateRange: { preset: "last-7d" } }, null);
+    const arg = fake.runReport.mock.calls[0][0];
+    expect(arg.dimensionFilter).toBeUndefined();
+  });
 });

--- a/packages/payload-plugin-analytics/tests/services/queries/kpiRecompute/aggregateSessions.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/kpiRecompute/aggregateSessions.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { aggregateSessions } from '../../../../src/services/queries/kpiRecompute/aggregateSessions';
+import type { KpiSessionEventRow } from '../../../../src/services/queries/kpiRecompute/aggregateSessions';
+
+const EXISTING = new Set(["page:1", "page:2", "__home"]);
+
+function row(partial: Partial<KpiSessionEventRow> & { sessionId: string }): KpiSessionEventRow {
+  return {
+    date: "20260504",
+    pageRef: "page:1",
+    eventName: "page_view",
+    dhm: "",
+    ...partial,
+  };
+}
+
+describe("aggregateSessions", () => {
+  it("returns all-zero current + empty series for empty input", () => {
+    const { current, series } = aggregateSessions([], EXISTING);
+    expect(current).toEqual({ sessions: 0, users: 0, pageViews: 0, bounceRate: 0, avgSessionDuration: 0 });
+    expect(series).toEqual([]);
+  });
+
+  it("excludes a session that touched a deleted ref from every metric + series", () => {
+    const rows: KpiSessionEventRow[] = [
+      // s1 — clean session (page:1 + __home), spans 14:30 → 14:32 = 120s
+      row({ sessionId: "s1", pageRef: "page:1", eventName: "page_view", dhm: "202605041430" }),
+      row({ sessionId: "s1", pageRef: "__home", eventName: "page_view", dhm: "202605041432" }),
+      // s2 — touched a deleted ref → dropped whole
+      row({ sessionId: "s2", pageRef: "page:999", eventName: "page_view", dhm: "202605041440" }),
+    ];
+    const { current, series } = aggregateSessions(rows, EXISTING);
+    expect(current.sessions).toBe(1);
+    // s2's duration + its pageview must not leak.
+    expect(current.pageViews).toBe(2);
+    expect(current.avgSessionDuration).toBe(120); // dhm span 14:30→14:32 over s1 only
+    expect(series).toHaveLength(1);
+    expect(series[0].sessions).toBe(1);
+    expect(series[0].pageViews).toBe(2);
+  });
+
+  it("derives session duration as the dateHourMinute span (max−min minute) in seconds", () => {
+    const rows: KpiSessionEventRow[] = [
+      // s1 spans two minutes: 14:30 → 14:32 = 120s
+      row({ sessionId: "s1", pageRef: "page:1", dhm: "202606171430" }),
+      row({ sessionId: "s1", pageRef: "page:1", dhm: "202606171432" }),
+    ];
+    const { current } = aggregateSessions(rows, EXISTING);
+    expect(current.avgSessionDuration).toBe(120);
+  });
+
+  it("treats a single-event (single-minute) session as zero duration", () => {
+    const rows: KpiSessionEventRow[] = [row({ sessionId: "s1", pageRef: "page:1", dhm: "202606171430" })];
+    const { current } = aggregateSessions(rows, EXISTING);
+    expect(current.avgSessionDuration).toBe(0);
+  });
+
+  it("treats a session with missing/invalid dhm as zero duration", () => {
+    const rows: KpiSessionEventRow[] = [row({ sessionId: "s1", pageRef: "page:1", dhm: "" }), row({ sessionId: "s1", pageRef: "page:1", dhm: "bad" })];
+    const { current } = aggregateSessions(rows, EXISTING);
+    expect(current.avgSessionDuration).toBe(0);
+  });
+
+  it("treats a single-pageview session as a bounce and a multi-pageview session as not a bounce", () => {
+    const rows: KpiSessionEventRow[] = [
+      // bounce: exactly one page_view
+      row({ sessionId: "b", pageRef: "page:1", eventName: "page_view" }),
+      // non-bounce: two page_views
+      row({ sessionId: "nb", pageRef: "page:1", eventName: "page_view" }),
+      row({ sessionId: "nb", pageRef: "page:2", eventName: "page_view" }),
+    ];
+    const { current } = aggregateSessions(rows, EXISTING);
+    expect(current.sessions).toBe(2);
+    expect(current.bounceRate).toBe(0.5);
+  });
+
+  it("counts only page_view events for pageViews (non-pageview events ignored)", () => {
+    const rows: KpiSessionEventRow[] = [
+      row({ sessionId: "s", pageRef: "page:1", eventName: "page_view" }),
+      row({ sessionId: "s", pageRef: "page:1", eventName: "lead_action" }),
+      row({ sessionId: "s", pageRef: "page:1", eventName: "scroll" }),
+    ];
+    const { current } = aggregateSessions(rows, EXISTING);
+    expect(current.pageViews).toBe(1);
+    // single pageview → bounce
+    expect(current.bounceRate).toBe(1);
+  });
+
+  it("computes avgSessionDuration as the mean of per-session dhm spans (seconds)", () => {
+    const rows: KpiSessionEventRow[] = [
+      row({ sessionId: "s1", pageRef: "page:1", dhm: "202605041430" }),
+      row({ sessionId: "s1", pageRef: "page:1", dhm: "202605041438" }), // s1 span = 8min = 480s
+      row({ sessionId: "s2", pageRef: "page:2", dhm: "202605041400" }),
+      row({ sessionId: "s2", pageRef: "page:2", dhm: "202605041404" }), // s2 span = 4min = 240s
+    ];
+    const { current } = aggregateSessions(rows, EXISTING);
+    // mean(480, 240) = 360
+    expect(current.avgSessionDuration).toBe(360);
+  });
+
+  it("reports users equal to sessions (documented approximation)", () => {
+    const rows: KpiSessionEventRow[] = [row({ sessionId: "s1", pageRef: "page:1" }), row({ sessionId: "s2", pageRef: "page:2" })];
+    const { current } = aggregateSessions(rows, EXISTING);
+    expect(current.users).toBe(current.sessions);
+    expect(current.users).toBe(2);
+  });
+
+  it("buckets allowed sessions per first-seen (min) date, sorted ascending", () => {
+    const rows: KpiSessionEventRow[] = [
+      // s1 first seen 0504, also has a later 0506 engagement row → assigned to 0504.
+      // Single page_view → bounce. dhm span 14:30 → 14:32 (across days) = larger; assert below.
+      row({ sessionId: "s1", date: "20260504", pageRef: "page:1", eventName: "page_view", dhm: "202605041430" }),
+      row({ sessionId: "s1", date: "20260506", pageRef: "page:1", eventName: "scroll", dhm: "202605041432" }),
+      // s2 on 0505 — two page_views → not a bounce.
+      row({ sessionId: "s2", date: "20260505", pageRef: "page:2", eventName: "page_view" }),
+      row({ sessionId: "s2", date: "20260505", pageRef: "page:2", eventName: "page_view" }),
+    ];
+    const { series } = aggregateSessions(rows, EXISTING);
+    expect(series.map((p) => p.date)).toEqual(["2026-05-04", "2026-05-05"]);
+    const day1 = series[0];
+    expect(day1.sessions).toBe(1);
+    expect(day1.pageViews).toBe(1);
+    expect(day1.bounceRate).toBe(1); // single pageview → bounce
+    expect(day1.avgSessionDuration).toBe(120); // dhm span 14:30 → 14:32 = 120s
+    const day2 = series[1];
+    expect(day2.sessions).toBe(1);
+    expect(day2.pageViews).toBe(2);
+    expect(day2.bounceRate).toBe(0); // 2 pageviews → not a bounce
+    expect(day2.users).toBe(1);
+  });
+
+  it("drops a session whose only ref is empty (untracked hit)", () => {
+    const rows: KpiSessionEventRow[] = [row({ sessionId: "s1", pageRef: "" }), row({ sessionId: "s2", pageRef: "page:1" })];
+    const { current } = aggregateSessions(rows, EXISTING);
+    expect(current.sessions).toBe(1);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/queries/listSessions.identity.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/listSessions.identity.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listSessions } from "../../../src/services/queries/listSessions";
+import { __setGa4ClientForTests } from "../../../src/services/ga4DataClient";
+import type { PageFilterContext } from "../../../src/services/pageFilter/types";
+
+afterEach(() => vi.restoreAllMocks());
+
+const EMPTY_LEAD_REPORT = {
+  dimensionHeaders: [{ name: "customEvent:fr_session_id" }],
+  metricHeaders: [{ name: "eventCount", type: "TYPE_INTEGER" }],
+  rows: [],
+  rowCount: 0,
+};
+
+function batchWith(sessionsReport: unknown, leadReport: unknown = EMPTY_LEAD_REPORT) {
+  return [{ reports: [sessionsReport, leadReport] }];
+}
+
+const pageFilter: PageFilterContext = {
+  refs: ["pages:1", "pages:2"],
+  pageRefDim: "customEvent:fr_page_ref",
+  contentLocaleDim: "customEvent:fr_content_locale",
+  // Landing ref (pages:1) resolves; the later ref (pages:2) intentionally does not.
+  resolveLabels: async () => new Map([["pages:1", { path: "/why-pick-us", title: "Why Pick Us" }]]),
+};
+
+// Session A spans two existing refs; both are kept by excludeDeletedSessions.
+const SESSIONS_FIXTURE = {
+  dimensionHeaders: [],
+  metricHeaders: [{ name: "eventCount", type: "TYPE_INTEGER" }],
+  rows: [
+    {
+      dimensionValues: [{ value: "A" }, { value: "/raw-landing?x=1" }, { value: "google" }, { value: "desktop" }, { value: "US" }, { value: "2026-05-10T16:00:00.000Z" }, { value: "pages:1" }],
+      metricValues: [{ value: "1" }],
+    },
+    {
+      dimensionValues: [{ value: "A" }, { value: "/raw-landing?x=1" }, { value: "google" }, { value: "desktop" }, { value: "US" }, { value: "2026-05-10T16:00:00.000Z" }, { value: "pages:2" }],
+      metricValues: [{ value: "1" }],
+    },
+  ],
+  rowCount: 2,
+};
+
+describe("listSessions landing-page identity resolution", () => {
+  it("resolves landingPage from the FIRST/earliest page_view ref, not a later ref in the session", async () => {
+    // Ordered event-level rows: pages:1 is the landing (first) event; pages:2 is later.
+    const landingReport = {
+      rows: [
+        { dimensionValues: [{ value: "A" }, { value: "pages:1" }, { value: "202605101600" }, { value: "1" }], metricValues: [{ value: "1" }] },
+        { dimensionValues: [{ value: "A" }, { value: "pages:2" }, { value: "202605101605" }, { value: "2" }], metricValues: [{ value: "1" }] },
+      ],
+    };
+    const fake = {
+      batchRunReports: vi.fn().mockResolvedValue(batchWith(SESSIONS_FIXTURE)),
+      runReport: vi.fn().mockResolvedValue([landingReport]),
+    };
+    __setGa4ClientForTests(fake as never);
+
+    const res = await listSessions("12345", { dateRange: { preset: "last-7d" } }, pageFilter);
+
+    const rowA = res.rows.find((r) => r.sessionId === "A");
+    expect(rowA?.landingPage).toBe("/why-pick-us");
+
+    // Supplementary landing-refs query was issued with the right shape.
+    // runQuery.runReport forwards { ...request, property } as one arg to the client.
+    expect(fake.runReport).toHaveBeenCalledTimes(1);
+    const request = fake.runReport.mock.calls[0][0];
+    expect(request.property).toBe("properties/12345");
+    expect(request.dimensions).toEqual([{ name: "customEvent:fr_session_id" }, { name: "customEvent:fr_page_ref" }, { name: "dateHourMinute" }, { name: "customEvent:fr_event_seq" }]);
+    const json = JSON.stringify(request.dimensionFilter);
+    expect(json).toContain("page_view");
+    expect(json).toContain('"A"');
+  });
+
+  it("falls back to the raw GA4 landingPagePlusQueryString when the landing-refs query rejects", async () => {
+    const fake = {
+      batchRunReports: vi.fn().mockResolvedValue(batchWith(SESSIONS_FIXTURE)),
+      runReport: vi.fn().mockRejectedValue(new Error("boom")),
+    };
+    __setGa4ClientForTests(fake as never);
+
+    const res = await listSessions("12345", { dateRange: { preset: "last-7d" } }, pageFilter);
+
+    const rowA = res.rows.find((r) => r.sessionId === "A");
+    expect(rowA?.landingPage).toBe("/raw-landing?x=1");
+  });
+
+  it("does NOT issue a sessionLandingRefs query and keeps the raw GA4 landingPage when pageFilter is null", async () => {
+    const fixture = {
+      dimensionHeaders: [],
+      metricHeaders: [{ name: "eventCount", type: "TYPE_INTEGER" }],
+      rows: [
+        {
+          dimensionValues: [{ value: "A" }, { value: "/raw-landing?x=1" }, { value: "google" }, { value: "desktop" }, { value: "US" }, { value: "2026-05-10T16:00:00.000Z" }],
+          metricValues: [{ value: "1" }],
+        },
+      ],
+      rowCount: 1,
+    };
+    const fake = {
+      batchRunReports: vi.fn().mockResolvedValue(batchWith(fixture)),
+      runReport: vi.fn(),
+    };
+    __setGa4ClientForTests(fake as never);
+
+    const res = await listSessions("12345", { dateRange: { preset: "last-7d" } }, null);
+
+    expect(fake.runReport).not.toHaveBeenCalled();
+    expect(res.rows[0].landingPage).toBe("/raw-landing?x=1");
+  });
+});

--- a/packages/payload-plugin-analytics/tests/services/queries/listSessions.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/listSessions.test.ts
@@ -234,6 +234,7 @@ describe("listSessions", () => {
     refs: ["page:1", "__home"],
     pageRefDim: "customEvent:fr_page_ref",
     contentLocaleDim: "customEvent:fr_content_locale",
+    resolveLabels: async () => new Map(),
   };
 
   it("appends the page-ref dimension and drops sessions touching a deleted ref when pageFilter is set", async () => {

--- a/packages/payload-plugin-analytics/tests/services/queries/listSessions.test.ts
+++ b/packages/payload-plugin-analytics/tests/services/queries/listSessions.test.ts
@@ -230,6 +230,112 @@ describe("listSessions", () => {
     expect(row.startedAt).toBe("2026-05-10T16:00:00.000Z");
   });
 
+  const PAGE_FILTER = {
+    refs: ["page:1", "__home"],
+    pageRefDim: "customEvent:fr_page_ref",
+    contentLocaleDim: "customEvent:fr_content_locale",
+  };
+
+  it("appends the page-ref dimension and drops sessions touching a deleted ref when pageFilter is set", async () => {
+    const fixture = {
+      dimensionHeaders: [],
+      metricHeaders: [{ name: "eventCount", type: "TYPE_INTEGER" }],
+      rows: [
+        // Session A — touches only existing refs (kept).
+        {
+          dimensionValues: [{ value: "A" }, { value: "/" }, { value: "google" }, { value: "desktop" }, { value: "US" }, { value: "2026-05-10T16:00:00.000Z" }, { value: "page:1" }],
+          metricValues: [{ value: "1" }],
+        },
+        {
+          dimensionValues: [{ value: "A" }, { value: "/" }, { value: "google" }, { value: "desktop" }, { value: "US" }, { value: "2026-05-10T16:00:00.000Z" }, { value: "__home" }],
+          metricValues: [{ value: "1" }],
+        },
+        // Session B — touches a deleted ref (dropped).
+        {
+          dimensionValues: [{ value: "B" }, { value: "/gone" }, { value: "google" }, { value: "mobile" }, { value: "UK" }, { value: "2026-05-10T17:00:00.000Z" }, { value: "page:999" }],
+          metricValues: [{ value: "1" }],
+        },
+      ],
+      rowCount: 3,
+    };
+    const fake = { runReport: vi.fn(), batchRunReports: vi.fn().mockResolvedValue(batchWith(fixture)) };
+    __setGa4ClientForTests(fake as never);
+    const res = await listSessions("12345", { dateRange: { preset: "last-7d" } }, PAGE_FILTER);
+
+    const { requests } = fake.batchRunReports.mock.calls[0][0];
+    expect(requests[0].dimensions).toEqual([
+      { name: "customEvent:fr_session_id" },
+      { name: "landingPagePlusQueryString" },
+      { name: "sessionSource" },
+      { name: "deviceCategory" },
+      { name: "country" },
+      { name: "customEvent:fr_session_start" },
+      { name: "customEvent:fr_page_ref" },
+    ]);
+    // Lead-sessions request is NOT given the page-ref dim.
+    expect(requests[1].dimensions).toEqual([{ name: "customEvent:fr_session_id" }]);
+
+    const ids = res.rows.map((r) => r.sessionId);
+    expect(ids).toContain("A");
+    expect(ids).not.toContain("B");
+  });
+
+  it("filtered path advances the cursor by RAW GA4 rows, not the displayed session count", async () => {
+    // One kept session (A) spans 2 ref-rows, so session-count (1) != row-count (2).
+    // limit=2 means GA4 returned a full page of 2 ROWS, and rowCount=4 signals more
+    // rows exist — the cursor must encode the GA4 ROW offset (2), not 1 (sessions).
+    const fixture = {
+      dimensionHeaders: [],
+      metricHeaders: [{ name: "eventCount", type: "TYPE_INTEGER" }],
+      rows: [
+        {
+          dimensionValues: [{ value: "A" }, { value: "/" }, { value: "google" }, { value: "desktop" }, { value: "US" }, { value: "2026-05-10T16:00:00.000Z" }, { value: "page:1" }],
+          metricValues: [{ value: "1" }],
+        },
+        {
+          dimensionValues: [{ value: "A" }, { value: "/" }, { value: "google" }, { value: "desktop" }, { value: "US" }, { value: "2026-05-10T16:00:00.000Z" }, { value: "__home" }],
+          metricValues: [{ value: "1" }],
+        },
+      ],
+      rowCount: 4,
+    };
+    const fake = { runReport: vi.fn(), batchRunReports: vi.fn().mockResolvedValue(batchWith(fixture)) };
+    __setGa4ClientForTests(fake as never);
+    const res = await listSessions("12345", { dateRange: { preset: "last-7d" }, limit: 2 }, PAGE_FILTER);
+
+    // One merged session displayed, but the cursor advanced by 2 GA4 rows.
+    expect(res.rows.length).toBe(1);
+    expect(res.pagination.hasMore).toBe(true);
+    expect(res.pagination.cursor).not.toBeNull();
+    const decoded = JSON.parse(Buffer.from(res.pagination.cursor as string, "base64").toString("utf-8"));
+    expect(decoded.offset).toBe(2);
+  });
+
+  it("does NOT append the page-ref dimension and keeps all sessions when pageFilter is null", async () => {
+    const fake = { runReport: vi.fn(), batchRunReports: vi.fn().mockResolvedValue(batchWith(sessions)) };
+    __setGa4ClientForTests(fake as never);
+    const res = await listSessions("12345", { dateRange: { preset: "last-7d" } }, null);
+    const { requests } = fake.batchRunReports.mock.calls[0][0];
+    expect(requests[0].dimensions).toEqual([
+      { name: "customEvent:fr_session_id" },
+      { name: "landingPagePlusQueryString" },
+      { name: "sessionSource" },
+      { name: "deviceCategory" },
+      { name: "country" },
+      { name: "customEvent:fr_session_start" },
+    ]);
+    expect(res.rows.length).toBe(2);
+  });
+
+  it("adds fr_page_ref to the catch missing-key candidates", async () => {
+    const err = new Error("3 INVALID_ARGUMENT: Field customEvent:fr_page_ref is unrecognized.");
+    const fake = { runReport: vi.fn(), batchRunReports: vi.fn().mockRejectedValue(err) };
+    __setGa4ClientForTests(fake as never);
+    const res = await listSessions("12345", { dateRange: { preset: "last-7d" } }, PAGE_FILTER);
+    expect(res.setupRequired).toBe(true);
+    expect(res.missing).toEqual(["fr_page_ref"]);
+  });
+
   it("skips GA4 rows with empty fr_session_id (defensive guard)", async () => {
     const malformed = {
       dimensionHeaders: [],

--- a/packages/payload-plugin-analytics/tests/utils/ga4/aggregateByRef.test.ts
+++ b/packages/payload-plugin-analytics/tests/utils/ga4/aggregateByRef.test.ts
@@ -1,0 +1,25 @@
+// tests/utils/ga4/aggregateByRef.test.ts
+import { describe, expect, it } from "vitest";
+import { aggregateByRef } from "../../../src/utils/ga4/aggregateByRef";
+import type { Row } from "../../../src/types/query";
+
+const rows: Row[] = [
+  { dimensionValues: [{ value: "pages:1" }], metricValues: [{ value: "100" }, { value: "10" }] },
+  { dimensionValues: [{ value: "pages:1" }], metricValues: [{ value: "50" }, { value: "5" }] },
+  { dimensionValues: [{ value: "pages:2" }], metricValues: [{ value: "20" }, { value: "2" }] },
+];
+
+describe("aggregateByRef", () => {
+  it("sums each metric per ref at the given dim index", () => {
+    expect(aggregateByRef(rows, 0, 2)).toEqual(
+      new Map([
+        ["pages:1", [150, 15]],
+        ["pages:2", [20, 2]],
+      ])
+    );
+  });
+
+  it("ignores rows with an empty ref", () => {
+    expect(aggregateByRef([{ dimensionValues: [{ value: "" }], metricValues: [{ value: "9" }] }], 0, 1)).toEqual(new Map());
+  });
+});

--- a/packages/payload-plugin-analytics/tests/utils/ga4/withPageRefFilter.test.ts
+++ b/packages/payload-plugin-analytics/tests/utils/ga4/withPageRefFilter.test.ts
@@ -1,0 +1,29 @@
+// tests/utils/ga4/withPageRefFilter.test.ts
+import { describe, expect, it } from "vitest";
+import { withPageRefFilter } from "../../../src/utils/ga4/withPageRefFilter";
+
+const REFS = ["page:1", "__home"];
+
+describe("withPageRefFilter", () => {
+  it("adds a standalone inList filter when the request has none", () => {
+    const req = { metrics: [{ name: "sessions" }], dimensions: [{ name: "sessionSource" }] };
+    const out = withPageRefFilter(req, "customEvent:fr_page_ref", REFS);
+    expect(out.dimensionFilter).toEqual({ filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: REFS } } });
+  });
+
+  it("ANDs the inList with an existing dimensionFilter", () => {
+    const existing = { filter: { fieldName: "eventName", stringFilter: { value: "lead_action" } } };
+    const req = { metrics: [{ name: "eventCount" }], dimensionFilter: existing };
+    const out = withPageRefFilter(req, "customEvent:fr_page_ref", REFS);
+    expect(out.dimensionFilter).toEqual({
+      andGroup: {
+        expressions: [existing, { filter: { fieldName: "customEvent:fr_page_ref", inListFilter: { values: REFS } } }],
+      },
+    });
+  });
+
+  it("returns the request unchanged when refs is empty", () => {
+    const req = { metrics: [{ name: "sessions" }] };
+    expect(withPageRefFilter(req, "customEvent:fr_page_ref", [])).toBe(req);
+  });
+});

--- a/packages/payload-plugin-analytics/tests/utils/page/formatPageRef.test.ts
+++ b/packages/payload-plugin-analytics/tests/utils/page/formatPageRef.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { formatPageRef } from "../../../src/utils/page/formatPageRef";
+
+describe("formatPageRef", () => {
+  it("joins collection + numeric id", () => {
+    expect(formatPageRef("page", 42)).toBe("page:42");
+  });
+
+  it("joins collection + string id (uuid future-proof)", () => {
+    expect(formatPageRef("posts", "abc-1")).toBe("posts:abc-1");
+  });
+});


### PR DESCRIPTION
- **feat(analytics): scope all views to existing pages via page_ref identity**
- **feat(analytics): resolve page titles and paths for page_ref labels**
- **feat(analytics): resolve landing paths and scope mocks to page_ref**
- **feat(dev): set up resolvePagePath in analytics plugin**
- **feat(cms): set up resolvePagePath in analytics plugin**
- **fix(analytics): resolve sessions landing page to current CMS path**
