### PR TITLE
feat(translator): translation provenance & lifecycle events (#47)

### DIFF
--- a/packages/payload-plugin-translator/README.md
+++ b/packages/payload-plugin-translator/README.md
@@ -167,6 +167,10 @@ Enabling it adds a plugin-managed, hidden sidecar collection to your config. **O
 (Postgres/SQLite) this requires a migration** — run `payload migrate:create` then `payload migrate`
 (or let dev push apply it in development). MongoDB infers the collection with no migration step.
 
+When a translated document is deleted, its provenance rows are cleaned up automatically (across all
+locales). The cleanup is best-effort — a failure is logged and never blocks the delete. The exported
+`TranslationProvenanceRecord` type describes a stored row if you query the sidecar collection directly.
+
 ```typescript
 translatorPlugin({
   collections: [Posts, Pages],

--- a/packages/payload-plugin-translator/README.md
+++ b/packages/payload-plugin-translator/README.md
@@ -142,6 +142,7 @@ Allowed on **`text`, `textarea`, and `richText`** fields (a compile error on oth
 | `basePath`            | `string`              | No       | `'/translate'`                         | Base path for the plugin's API endpoints.                                                                      |
 | `levels`              | `TranslationLevel[]`  | No       | `[documentLevel(), collectionLevel()]` | Which surfaces to enable — see [Translation surfaces](#translation-surfaces-levels).                           |
 | `provenance`          | `boolean \| { slug?: string }` | No | `false` (disabled) | Opt in to recording a provenance record per translation. _Since v0.7.0._ See [Provenance](#provenance-opt-in) below. |
+| `lifecycle`           | `{ onQueued?, onCompleted?, onFailed? }` | No | `undefined` | Server-side callbacks fired around each task. _Since v0.7.0._ See [Lifecycle callbacks](#lifecycle-callbacks). |
 
 ```typescript
 translatorPlugin({
@@ -172,6 +173,32 @@ translatorPlugin({
   translationProvider: createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY }),
   runner: createPayloadJobsRunner(),
   provenance: true, // or { slug: "my-provenance" }
+});
+```
+
+### Lifecycle callbacks
+
+_Since v0.7.0._
+
+Optional server-side hooks fired around each translation task — for logging, notifications, cache
+invalidation, or feeding a dashboard. They need no schema or migration and are independent of the
+`provenance` opt-in. Each receives a `TranslationTask` descriptor
+(`{ collection, id, sourceLng, targetLng, strategy }`); `onFailed` also receives the error.
+
+A callback that throws is caught and logged — it never fails the translation. `onCompleted` /
+`onFailed` fire per execution attempt (the Payload Jobs runner may retry a failed task); `onQueued`
+fires once at enqueue.
+
+```typescript
+translatorPlugin({
+  collections: [Posts, Pages],
+  translationProvider: createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY }),
+  runner: createPayloadJobsRunner(),
+  lifecycle: {
+    onQueued: (task) => console.log("queued", task),
+    onCompleted: (task) => console.log("done", task),
+    onFailed: (task, error) => console.error("failed", task, error),
+  },
 });
 ```
 

--- a/packages/payload-plugin-translator/README.md
+++ b/packages/payload-plugin-translator/README.md
@@ -141,6 +141,7 @@ Allowed on **`text`, `textarea`, and `richText`** fields (a compile error on oth
 | `access`              | `AccessGuard`         | No       | `undefined`                            | Access guard (`{ check }`) for the translation endpoints; omit to leave them open.                             |
 | `basePath`            | `string`              | No       | `'/translate'`                         | Base path for the plugin's API endpoints.                                                                      |
 | `levels`              | `TranslationLevel[]`  | No       | `[documentLevel(), collectionLevel()]` | Which surfaces to enable — see [Translation surfaces](#translation-surfaces-levels).                           |
+| `provenance`          | `boolean \| { slug?: string }` | No | `false` (disabled) | Opt in to recording a provenance record per translation. _Since v0.7.0._ See [Provenance](#provenance-opt-in) below. |
 
 ```typescript
 translatorPlugin({
@@ -148,6 +149,29 @@ translatorPlugin({
   translationProvider: createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY }),
   runner: createPayloadJobsRunner(),
   access: { check: ({ req }) => req.user?.role === "admin" },
+});
+```
+
+### Provenance (opt-in)
+
+_Since v0.7.0._
+
+Set `provenance: true` (or `{}`) to record, after each successful translation, a durable per-locale
+provenance entry — what source state a translation was derived from. Use `{ slug }` to customise the
+sidecar collection's slug (default `'translator-provenance'`), e.g. to resolve a name collision with
+one of your own collections. Omit (or set `false`) to leave everything as-is: no collection, no
+migration, no behavior change.
+
+Enabling it adds a plugin-managed, hidden sidecar collection to your config. **On a SQL database
+(Postgres/SQLite) this requires a migration** — run `payload migrate:create` then `payload migrate`
+(or let dev push apply it in development). MongoDB infers the collection with no migration step.
+
+```typescript
+translatorPlugin({
+  collections: [Posts, Pages],
+  translationProvider: createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY }),
+  runner: createPayloadJobsRunner(),
+  provenance: true, // or { slug: "my-provenance" }
 });
 ```
 

--- a/packages/payload-plugin-translator/docs/plans/2026-06-26-translation-provenance-and-lifecycle-design.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-26-translation-provenance-and-lifecycle-design.md
@@ -319,10 +319,11 @@ payload-free → they live in `@core`; only the Payload-backed store impl and ho
   the handler's catch (fire, then rethrow so the runner still marks the job failed). Callback errors
   swallowed-and-logged. Independent of the `provenance` flag. Tests: each fires with the right
   descriptor; a throwing callback does not break the translation.
-- **Slice D — delete cleanup + docs.** When `provenance` is enabled, inject an `afterDelete` hook on
-  configured collections → `store.deleteByDocument` (not injected when opted out). README: the opt-in
-  `provenance` config, the required SQL migration step, the callbacks API, `@since 0.7.0`. Tests:
-  deleting a document removes its provenance rows.
+- **Slice D — delete cleanup + docs.** When `provenance` is enabled, inject an `afterDelete` hook
+  (separate transaction + swallow-and-log — see D.1 detail) on configured collections →
+  `store.deleteByDocument` (not injected when opted out). README: the opt-in `provenance` config, the
+  required SQL migration step, the callbacks API, `@since 0.7.0`. Tests: deleting a document removes
+  its provenance rows.
 
 ### Sidecar collection shape (slice A)
 
@@ -338,6 +339,105 @@ Minimal, DB-portable. All `text`/`date`; composite uniqueness on
 | `sourceFingerprint` | text | `fingerprint(projectTranslatableContent(sourceDoc, schema))` |
 | `translatedAt` | date | last successful translation time |
 | `dismissedFingerprint` | text (nullable) | added now, unused until #50 |
+
+### Slice D — delete cleanup, public surface & docs (detailed)
+
+The closing slice of #47. Three parts + a real-DB verification pass. No new algorithm — it wires the
+`deleteByDocument` primitive built in slice A, closes the public surface, and documents the opt-in.
+
+#### D.1 — delete cleanup (via `afterDelete` + separate transaction + swallow)
+
+**Why.** A provenance row is keyed `(collectionSlug, documentId, targetLocale)`. When the consumer
+deletes the source document, its rows are orphaned — never updated again, misreported by the #49/#50
+dashboard, and (under id reuse on Mongo/uuid) potentially re-attached to an unrelated document. So we
+cascade-clean on delete.
+
+**Hook choice — `afterDelete` (chosen 2026-07-06, Option B).** Source review of Payload 3.84.1
+(`deleteByID.js`, `delete.js`) found that **BOTH `afterDelete` (loop @192-202) AND `afterOperation`
+(@206 / @259) run inside the delete transaction, *before* `commitTransaction` (@216 / @266)** — neither
+is post-commit, and an unhandled throw in either propagates to the `catch` that calls `killTransaction`
+(rollback). So the "never fail the delete" guarantee does **not** come from picking a post-commit hook
+(there isn't one); it comes from two things together:
+1. **Swallow** the cleanup error in our hook (try/catch) → we never throw → no `killTransaction` → the
+   primary delete proceeds to commit.
+2. Run the cleanup in a **separate transaction** — `deleteByDocument` calls `payload.delete` **without**
+   threading `req`, so it opens its own transaction on its own connection. A failure there cannot poison
+   the primary delete's Postgres transaction. (Threading `req` would join the primary tx, where a failed
+   statement poisons it → the primary commit fails even if we swallow. So we deliberately do NOT pass
+   `req`.)
+
+Given both hold, `afterDelete` vs `afterOperation` is purely ergonomic, and `afterDelete` wins: it hands
+us `id` directly, fires **once per deleted document** (so bulk delete is handled automatically), and
+needs no result-shape branching. (See `2026-07-06-slice-d-research.md` for the full evidence + A/B/C.)
+Residual risk: a tiny orphan-on-rollback window if `commitTransaction` itself fails *after* our separate
+cleanup already committed — negligible and self-healing (the next translation re-upserts provenance).
+
+**How.** The primitive already exists: `PayloadProvenanceStore.deleteByDocument(collectionSlug,
+documentId)` (its `where` deliberately omits `targetLocale`, so one call removes the document's rows
+across *all* target locales). Slice D only wires the hook:
+
+- In `plugin.ts` `init()`, **gated on `provenanceSlug` being set** (opted out → no collection exists,
+  so no hook — attaching one would query a missing table). Added through the config-modifier path,
+  mutating the sanitized `config.collections` objects (not the throwaway `pluginConfig.collections`).
+- Attach the `afterDelete` hook only to the **translatable collections** (`collectionSlugs` — the ones
+  in the plugin's `collections` config), since provenance rows exist only for those. The sidecar is not
+  in that set, so it is never hooked (no recursion).
+- Hook body: `deleteByDocument(collection.slug, String(id))` — `collection.slug` comes from the hook arg
+  and `id` is `number | string`, so always stringify. The store's delete runs in its own transaction
+  (no `req` threaded), keeping cleanup isolated from the primary delete.
+- **Best-effort, swallow-and-log** via `req.payload.logger`: wrap the body in try/catch so a cleanup
+  failure only logs and never fails the user's delete.
+- **Append, don't replace** any consumer-supplied `afterDelete` array, and make injection
+  **idempotent**: mark the injected hook (a flag on the hook fn) so repeated `init()` runs don't stack
+  duplicates — analogous to `isProvenanceCollection`.
+
+**Resolved — versions / drafts / locales.** Payload's `afterDelete` fires on **document** deletion,
+not on version/draft pruning; locales in Payload are field-level, not separate documents. So one
+delete = remove that `documentId`'s provenance across every locale, which `deleteByDocument` already
+does. **No** version/draft-specific handling is added in v1. If a consumer enables trash/soft-delete,
+`afterDelete` fires only on the real (permanent) delete — acceptable: a trashed-then-restored document
+keeps its provenance, which is the correct behavior.
+
+#### D.2 — Public surface (0.7.0)
+
+- **Export `TranslationProvenanceRecord`** from `src/index.ts` with `@since 0.7.0` — a consumer that
+  queries the sidecar collection (and #50's dashboard) wants the typed record shape.
+- Keep `ProvenanceStore`, `ProvenanceKey`, and `PayloadProvenanceStore` **internal** — the consumer
+  opts in via config and never constructs a store; exposing them now would freeze a wider surface than
+  #47 needs.
+- Verify `TranslatorPluginConfig.provenance` carries `@since 0.7.0` (inline in `plugin.ts`), and that
+  the slice-C lifecycle exports are wired (already done).
+
+#### D.3 — README: enabling provenance (migration)
+
+The sidecar is a new collection → a new SQL **table**. The plugin ships only the `CollectionConfig`;
+it cannot create the table in the consumer's database (no access to their migration dir/creds). This
+is the whole reason provenance is opt-in, default-OFF, and it must be documented as a conscious step:
+
+- `provenance: true` (or `{ slug }`);
+- **SQL (Postgres):** `payload migrate:create` then `payload migrate` (precedent: the AB plugin's
+  `apps/dev/src/migrations/…create_ab_experiments.ts`);
+- **Mongo:** nothing — the collection is inferred;
+- caveat: future schema changes stay **additive & nullable only** (renames = data loss).
+
+Also document the lifecycle callbacks API (`lifecycle: { onQueued, onCompleted, onFailed }`) with
+`Since v0.7.0` notes.
+
+#### D.4 — Deferred real-DB verification (carried from A/B)
+
+Run once on a real instance (`apps/dev` or `apps/cms`, Postgres) as part of slice D:
+
+- `dismissedFingerprint: null` round-trips on both SQL and Mongo.
+- Real table-name collision (snake_case / `dbName`) behaves acceptably — the startup guard
+  deliberately checks only exact-slug collision, not the derived SQL table name.
+
+#### Tests
+
+- Deleting a document with provenance enabled removes all its rows (across locales); other documents'
+  rows are untouched.
+- `afterDelete` is a no-op / not attached when provenance is opted out.
+- A `deleteByDocument` failure is swallowed and logged, and does not fail the delete.
+- Idempotency: two plugin runs don't stack duplicate `afterDelete` hooks.
 
 ## Out of scope
 

--- a/packages/payload-plugin-translator/docs/plans/2026-06-26-translation-provenance-and-lifecycle-design.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-26-translation-provenance-and-lifecycle-design.md
@@ -256,7 +256,7 @@ Each numbered item is the former open question, now answered.
 2. **Version-based fingerprint — DEFERRED.** v1 uses the content hash only. An opt-in
    `updatedAt`/version fingerprint (for consumers with versions enabled) can be added later,
    additively, without breaking the record shape. Not built now.
-3. **Provenance collection is opt-in; slug guarded. [pending confirm]** The provenance *collection*
+3. **Provenance collection is opt-in; slug guarded. [confirmed 2026-07-03]** The provenance *collection*
    is default-OFF, enabled by presence of a `provenance` config key (`provenance?: { slug?: string }`
    on `TranslatorPluginConfig`) — because it needs a consumer migration on SQL and must not be forced
    silently (see "Opt-in, because it needs a consumer migration"). Default slug `translator-provenance`,
@@ -274,7 +274,7 @@ Each numbered item is the former open question, now answered.
 6. **Callback errors — swallow-and-log. [pending confirm]** Every lifecycle callback is wrapped in
    try/catch; a throw is logged via the Payload logger and never propagates. A failing host callback
    is never a reason to fail the translation (especially `onTranslationFailed`).
-7. **Status endpoint merge — OUT OF SCOPE for #47, deferred to #50. [pending confirm]** #47 only
+7. **Status endpoint merge — OUT OF SCOPE for #47, deferred to #50. [confirmed 2026-07-03]** #47 only
    *writes* provenance and exposes the sidecar collection as queryable. Merging the durable
    provenance layer into `get-document-status` / `get-collection-status` (the "runner-independent
    status" idea) is #50's job. To avoid a later migration, the `dismissedFingerprint` column is added

--- a/packages/payload-plugin-translator/docs/plans/2026-06-26-translation-provenance-and-lifecycle-design.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-26-translation-provenance-and-lifecycle-design.md
@@ -1,7 +1,9 @@
 # Translation provenance & lifecycle events — design
 
 **Date:** 2026-06-26
-**Status:** Draft (first pass — to be refined before implementation)
+**Status:** Ready for implementation — all open questions resolved 2026-07-02. Four decisions
+(scope, sidecar slug, callback-error semantics, delete cleanup) are marked **[pending confirm]**
+below: they use the recommended default and can be overridden before the relevant slice is coded.
 **Tracks:** [#47](https://github.com/focusreactive/payload-plugins/issues/47) — foundation for
 [#50](https://github.com/focusreactive/payload-plugins/issues/50) (stale detection),
 [#51](https://github.com/focusreactive/payload-plugins/issues/51) (auto-translate on source change),
@@ -104,13 +106,46 @@ collect exactly this set in the pipeline — `FieldChunkCollector`). Version id 
 an opt-in cheaper fingerprint *for consumers who have versions enabled*, but it cannot be the default
 because versions are opt-in and coarser. (Open question below.)
 
-### Storage: plugin-managed sidecar collection
+### Storage: plugin-managed sidecar collection (opt-in)
 
 Store provenance in a **separate plugin-owned collection**, keyed by
 `(collectionSlug, documentId, locale)` — **not** as hidden fields on consumer collections. Hidden
 fields would force schema/migration changes onto every consumer collection; a sidecar keeps the
 blast radius inside the plugin. The collection is injected the same way the plugin already injects
 config, via a config modifier through `PluginConfigBuilder` (see `src/plugin.ts`).
+
+#### Opt-in, because it needs a consumer migration (drives the version bump)
+
+The sidecar is a **new collection**, and on SQL consumers (Postgres/SQLite) a new collection means a
+new table → a **migration the consumer must run**. We cannot run it for them (we don't own their
+migration directory, DB creds, or migration ordering; Payload creates SQL tables only via
+migrations). Silently forcing that on every consumer during an upgrade would be operationally
+breaking — unacceptable in a patch/minor.
+
+**Therefore the provenance collection is opt-in and default-OFF**, enabled by presence of a
+`provenance` config key:
+
+```ts
+translatorPlugin({
+  // ...
+  provenance: { /* slug?: string */ },   // present = enabled; omit = disabled (default)
+})
+```
+
+Consequences:
+
+- A consumer who does **not** set `provenance` sees **zero change** on upgrade — no new collection,
+  no migration, no behaviour change. So adding this feature is a backward-compatible **`feat` →
+  minor** (`0.6.x → 0.7.0`), **not** breaking and not a patch.
+- Enabling it is the programmer's **conscious act**. That is exactly where we tell them (JSDoc on the
+  field + README) to generate/run the migration on SQL (`payload migrate:create` + `payload migrate`;
+  dev push in development; MongoDB infers the collection with no migration).
+- If they enable it but forget to migrate on SQL, Payload itself errors on the first provenance query
+  with a clear "relation does not exist" — an acceptable, self-explaining failure. We do not attempt
+  runtime table creation.
+
+**Note the split:** only the *collection* is gated. The **lifecycle callbacks (Primitive 2) carry no
+schema and no migration**, so they are always available regardless of the `provenance` flag.
 
 #### Cross-database concern (raised in review — must be designed for)
 
@@ -131,15 +166,12 @@ Mongo. Migration generation/ordering on SQL is the main open risk — to be deta
 
 #### Name-collision concern (raised in review)
 
-The sidecar slug must not clash with a consumer collection or with another plugin's table. Options
-to decide on:
+The sidecar slug must not clash with a consumer collection or with another plugin's table. Resolved:
 
-- a distinctive default slug (e.g. `translator-provenance` / `_translator_translations`), **plus**
-- a config override (`provenance: { slug?: string }` or similar) so a consumer can rename on a clash,
-- and a startup guard: if the chosen slug already exists in `config.collections`, fail fast with a
-  clear error rather than silently colliding.
-
-(Exact slug + override shape: open question.)
+- default slug **`translator-provenance`**, `admin: { hidden: true }`;
+- override via **`provenance.slug`** so a consumer can rename on a clash;
+- a **startup guard**: if the chosen slug already exists in `config.collections`, throw a clear error
+  at init (fail fast, never silently share a table).
 
 ### Where it gets written
 
@@ -186,8 +218,11 @@ Firing points:
 
 Constraints:
 
+- **Always available, no migration.** Callbacks are just optional config functions — they carry no
+  schema and no collection, so they are active regardless of the `provenance` opt-in flag and never
+  require a consumer migration.
 - Callbacks must not break the translation if they throw — wrap and log; a failing callback is the
-  host's problem, not a reason to fail the run. (Confirm desired semantics.)
+  host's problem, not a reason to fail the run.
 - They run server-side only.
 
 This gives the host a push-based extension point (logging, notifications, cache invalidation, feeding
@@ -207,20 +242,94 @@ This gives the host a push-based extension point (logging, notifications, cache 
 
 ---
 
-## Open questions (to resolve in the next pass)
+## Decisions (resolved 2026-07-02)
 
-1. **Fingerprint algorithm** — exact hash input (normalized JSON of the translated source leaf set?),
-   hash function, and how rich text (Lexical) is normalized before hashing.
-2. **Version-based fingerprint** — offer it as an opt-in when consumer has versions enabled? Or defer
-   entirely?
-3. **Sidecar slug** — default name + override config shape + collision guard behaviour.
-4. **SQL migration story** — how the table is created across consumers we don't own the migrations
-   for; documented manual step vs. anything we can automate.
-5. **Provenance lifecycle** — what happens on document delete (cascade-clean the records?), and on a
-   collection being removed from the plugin config.
-6. **Callback error semantics** — swallow-and-log vs. surfacing.
-7. **Status endpoint merge shape** — how the durable + live layers combine in the response model
-   without breaking existing consumers of `get-document-status` / `get-collection-status`.
+Each numbered item is the former open question, now answered.
+
+1. **Fingerprint algorithm — RESOLVED by slice 6.** No new algorithm. The source fingerprint is
+   `sourceFingerprint = fingerprint(projectTranslatableContent(sourceDoc, schema))`, both from
+   `@core` (`src/core/content-projection/`). `fingerprint` sha256-hashes the `{ idPath, text }`
+   entries sorted by `idPath`, each length-prefixed. Rich text is normalized by the projector
+   (text-nodes-only) — the **same** extraction sent to the provider, so drift can only be a real
+   content change. Inherits the known "text-nodes-only" blind spot (formatting-only edits do not mark
+   stale) — accepted, documented.
+2. **Version-based fingerprint — DEFERRED.** v1 uses the content hash only. An opt-in
+   `updatedAt`/version fingerprint (for consumers with versions enabled) can be added later,
+   additively, without breaking the record shape. Not built now.
+3. **Provenance collection is opt-in; slug guarded. [pending confirm]** The provenance *collection*
+   is default-OFF, enabled by presence of a `provenance` config key (`provenance?: { slug?: string }`
+   on `TranslatorPluginConfig`) — because it needs a consumer migration on SQL and must not be forced
+   silently (see "Opt-in, because it needs a consumer migration"). Default slug `translator-provenance`,
+   `admin: { hidden: true }`; override via `provenance.slug`; **startup guard**: if the chosen slug
+   already exists in `config.collections`, throw a clear error at init (fail fast, never silently
+   share a table). The **lifecycle callbacks are NOT gated** by this flag — they carry no schema.
+4. **SQL migration — consumer-generated, documented.** The plugin ships only the collection *config*;
+   the consumer's Payload creates the table (SQL prod: `payload migrate`; SQL dev: push; Mongo:
+   inferred, no migration). The collection is deliberately minimal (all `text`/`date`, one composite
+   index) so the generated migration is trivial. README gets a required post-install step.
+5. **Delete cleanup — cascade-clean. [pending confirm]** An `afterDelete` hook injected on each
+   configured collection deletes provenance rows for `(collectionSlug, documentId)`. A collection
+   later removed from the plugin config leaves its rows orphaned (records simply stop updating) —
+   tolerated and documented; no cross-run reconciliation in v1.
+6. **Callback errors — swallow-and-log. [pending confirm]** Every lifecycle callback is wrapped in
+   try/catch; a throw is logged via the Payload logger and never propagates. A failing host callback
+   is never a reason to fail the translation (especially `onTranslationFailed`).
+7. **Status endpoint merge — OUT OF SCOPE for #47, deferred to #50. [pending confirm]** #47 only
+   *writes* provenance and exposes the sidecar collection as queryable. Merging the durable
+   provenance layer into `get-document-status` / `get-collection-status` (the "runner-independent
+   status" idea) is #50's job. To avoid a later migration, the `dismissedFingerprint` column is added
+   to the schema **now** but left unused until #50.
+8. **Version bump — minor `0.7.0`.** Because provenance is opt-in default-off and the callbacks are
+   backward-compatible additions, adding this feature changes nothing for a consumer who does not
+   opt in → it is a `feat` (minor), not breaking and not a patch. The public-API additions
+   (`provenance` config, the three callbacks, `TranslationTask`) get `@since 0.7.0`. At 0.x a caret
+   range (`^0.6.x`) will not auto-upgrade to `0.7.0`, so even opted-in SQL consumers pull it
+   deliberately.
+
+## Implementation slices
+
+TDD (red tests first), each slice run through `/sp-finalize` (simplify + iterative-review + gate)
+before its commit; tests are type-checked (tsconfig.check.json) and lint is run. New branch
+`feat/translator-provenance` off updated `main`. The `ProvenanceStore` **port** + record type are
+payload-free → they live in `@core`; only the Payload-backed store impl and hooks are adapter code.
+
+- **Slice A — provenance store + sidecar collection (no wiring).**
+  `TranslationProvenanceRecord` type + `ProvenanceStore` port in `src/core/provenance/`; the sidecar
+  `CollectionConfig` factory (fields below, composite index, `admin.hidden`, slug override); a
+  Payload-backed `ProvenanceStore` impl (upsert by composite key, find, `deleteByDocument`); the
+  startup collision guard. Tests: collection shape + store CRUD against a fake payload.
+- **Slice B — write provenance on successful translation (behind the opt-in flag).** Add the
+  `provenance?: { slug?: string }` config; **only when present**, inject the sidecar collection +
+  store into `plugin.ts` (config modifier), run the collision guard, and — in the document
+  translation path — compute `sourceFingerprint` via the core projector+fingerprint and `store.upsert`
+  after the target locale is written. When `provenance` is absent, nothing is injected and no write
+  happens. Tests: opted-in → a record appears with the right fingerprint/locales/timestamp and
+  re-translate updates the same row (upsert, not duplicate); opted-out → no collection, no write.
+- **Slice C — lifecycle callbacks (always available, not gated).** Extend `TranslatorPluginConfig`
+  with `onTranslationQueued` / `onTranslationCompleted` / `onTranslationFailed` + the `TranslationTask`
+  type (with `@since 0.7.0`); fire queued at enqueue, completed after a successful handle, failed in
+  the handler's catch (fire, then rethrow so the runner still marks the job failed). Callback errors
+  swallowed-and-logged. Independent of the `provenance` flag. Tests: each fires with the right
+  descriptor; a throwing callback does not break the translation.
+- **Slice D — delete cleanup + docs.** When `provenance` is enabled, inject an `afterDelete` hook on
+  configured collections → `store.deleteByDocument` (not injected when opted out). README: the opt-in
+  `provenance` config, the required SQL migration step, the callbacks API, `@since 0.7.0`. Tests:
+  deleting a document removes its provenance rows.
+
+### Sidecar collection shape (slice A)
+
+Minimal, DB-portable. All `text`/`date`; composite uniqueness on
+`(collectionSlug, documentId, targetLocale)` is the upsert key.
+
+| field | type | notes |
+| --- | --- | --- |
+| `collectionSlug` | text | indexed; part of upsert key |
+| `documentId` | text | stringified even when numeric; part of upsert key |
+| `targetLocale` | text | part of upsert key |
+| `sourceLocale` | text | which locale was translated from |
+| `sourceFingerprint` | text | `fingerprint(projectTranslatableContent(sourceDoc, schema))` |
+| `translatedAt` | date | last successful translation time |
+| `dismissedFingerprint` | text (nullable) | added now, unused until #50 |
 
 ## Out of scope
 

--- a/packages/payload-plugin-translator/docs/plans/2026-06-26-translation-provenance-and-lifecycle-design.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-26-translation-provenance-and-lifecycle-design.md
@@ -184,25 +184,33 @@ fingerprint is already available at that point in the pipeline.
 
 ## Primitive 2 — Lifecycle callbacks
 
-Add optional callbacks to `TranslatorPluginConfig` (`src/plugin.ts`), invoked by the runner:
+Add an optional `lifecycle` object to `TranslatorPluginConfig` (`src/plugin.ts`), invoked by the runner:
 
 ```ts
 translatorPlugin({
   // ...existing config...
-  onTranslationQueued?:    (task: TranslationTask) => void | Promise<void>,
-  onTranslationCompleted?: (task: TranslationTask) => void | Promise<void>,
-  onTranslationFailed?:    (task: TranslationTask, error: unknown) => void | Promise<void>,
+  lifecycle?: {
+    onQueued?:    (task: TranslationTask) => void | Promise<void>,
+    onCompleted?: (task: TranslationTask) => void | Promise<void>,
+    onFailed?:    (task: TranslationTask, error: unknown) => void | Promise<void>,
+  },
 })
 ```
 
+> **Implementation note (Slice C):** the callbacks were nested under a `lifecycle` config object
+> rather than left flat on the plugin config. Nesting makes the `onTranslation` prefix redundant, so
+> the shipped names are `onQueued` / `onCompleted` / `onFailed` (not the flat
+> `onTranslationQueued/…` sketched in the original draft above). This is the authoritative
+> `@since 0.7.0` public surface.
+
 `TranslationTask` mirrors the descriptor the runner already threads through
 (`{ collection, collectionId, sourceLng, targetLng, strategy }` — see `runnerContext.handler` in
-`src/plugin.ts`):
+`src/plugin.ts`). `id` is normalized to a `string` at ingress (the plugin is ID-agnostic):
 
 ```ts
 type TranslationTask = {
   collection: string;
-  id: string | number;
+  id: string;
   sourceLng: string;
   targetLng: string;
   strategy: string;
@@ -273,7 +281,7 @@ Each numbered item is the former open question, now answered.
    tolerated and documented; no cross-run reconciliation in v1.
 6. **Callback errors — swallow-and-log. [pending confirm]** Every lifecycle callback is wrapped in
    try/catch; a throw is logged via the Payload logger and never propagates. A failing host callback
-   is never a reason to fail the translation (especially `onTranslationFailed`).
+   is never a reason to fail the translation (especially `onFailed`).
 7. **Status endpoint merge — OUT OF SCOPE for #47, deferred to #50. [confirmed 2026-07-03]** #47 only
    *writes* provenance and exposes the sidecar collection as queryable. Merging the durable
    provenance layer into `get-document-status` / `get-collection-status` (the "runner-independent
@@ -306,7 +314,7 @@ payload-free → they live in `@core`; only the Payload-backed store impl and ho
   happens. Tests: opted-in → a record appears with the right fingerprint/locales/timestamp and
   re-translate updates the same row (upsert, not duplicate); opted-out → no collection, no write.
 - **Slice C — lifecycle callbacks (always available, not gated).** Extend `TranslatorPluginConfig`
-  with `onTranslationQueued` / `onTranslationCompleted` / `onTranslationFailed` + the `TranslationTask`
+  with a `lifecycle: { onQueued, onCompleted, onFailed }` object + the `TranslationTask`
   type (with `@since 0.7.0`); fire queued at enqueue, completed after a successful handle, failed in
   the handler's catch (fire, then rethrow so the runner still marks the job failed). Callback errors
   swallowed-and-logged. Independent of the `provenance` flag. Tests: each fires with the right

--- a/packages/payload-plugin-translator/docs/plans/2026-07-06-slice-d-research.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-07-06-slice-d-research.md
@@ -1,0 +1,108 @@
+# Slice D — pre-implementation research (#47)
+
+Research date: 2026-07-06. Payload **3.84.1**. Branch `feat/translator-provenance`, PR #61.
+Feeds `/sp-task` for Slice D. Companion to the design doc
+`2026-06-26-translation-provenance-and-lifecycle-design.md` (§ "Slice D … (detailed)").
+
+## Problem statement
+
+Provenance rows (sidecar collection, keyed `(collectionSlug, documentId, targetLocale)`) are orphaned
+when the source document is deleted — never updated again, misreported by the #49/#50 dashboard, and
+reusable-id-prone. Slice D cleans them up on delete, closes the public API surface for 0.7.0, and
+documents the opt-in. The cleanup primitive (`PayloadProvenanceStore.deleteByDocument`) already exists
+from Slice A.
+
+## Verified facts (from 3.84.1 dist source)
+
+1. **`afterDelete` hook args** — `{ collection, context, doc, id, req }` (`collections/config/types.d.ts:155-162`).
+   `id` is **`number | string`** — must be stringified. `doc` is the just-deleted document (post-afterRead).
+2. **`afterDelete` runs INSIDE the delete transaction, BEFORE commit** (`deleteByID.js`: init tx @22,
+   hook loop @192-202, commit @216-218, catch→`killTransaction`→rethrow @220-223). There is **no
+   built-in per-hook try/catch** in single delete → an unhandled throw **rolls back the delete**.
+   → **The design-doc premise "the document is already gone" at afterDelete time is FALSE.**
+3. **`afterOperation` ALSO runs before commit** (`deleteByID.js:206`, `delete.js:259`, both before the
+   `commitTransaction` call). So there is **no post-commit standard collection hook** for delete.
+4. **Bulk delete (`delete({where})`)** fires afterDelete **once per matched document**, each with its own
+   `id` (`delete.js:82` map, `:84` `{id}=doc`, hooks @201-211). Per-doc `try/catch` records failures in
+   `result.errors[]` and continues (`delete.js:219-229`) — so in bulk mode a throwing hook fails only that
+   doc, not the batch; in single mode it aborts the whole delete.
+5. **Nested `payload.delete` + `req`** — pass `req` → joins the same transaction (same connection, atomic,
+   no deadlock, serialized). Omit `req` → **new independent transaction on another connection** → orphan-on-
+   rollback risk + theoretical lock-wait/deadlock (mitigated here: sidecar has no FK to consumer tables).
+   (`@payloadcms/drizzle/utilities/getTransaction.js:10-17`, `initTransaction.js:11-24`.)
+6. **Current `deleteByDocument(collectionSlug, documentId)` does NOT pass `req`** — it runs the sidecar
+   delete in its own transaction (`PayloadProvenanceStore.ts:68-78`).
+7. **No collection hooks exist anywhere in the plugin** — greenfield. Precedent for chain-and-preserve:
+   `PayloadJobsRunnerProvider.ts:193-204` (wraps existing `onInit`, try/catch, never blocks startup).
+8. **Injection target** = the **sanitized `config.collections`** objects at init, filtered by the managed
+   slug set (`PluginConfigBuilder.attachCollectionComponents` pattern) — NOT `pluginConfig.collections`
+   (throwaway JSON clones). Mutate `collection.hooks.afterDelete` by **appending** (preserve consumer hooks).
+9. **Idempotency** — `init()` modifiers can run >1×; a naive `.push(hook)` stacks duplicates. Must guard
+   with a marker like `isProvenanceCollection` (`provenanceCollection.ts` marker).
+10. **Sidecar is not in the managed slug set** → filtering by managed slugs naturally excludes it; the
+    sidecar has no afterDelete hook → **no recursion risk**.
+11. **Public exports** — `src/index.ts` exports **no** provenance symbols today; core barrel exports the 3
+    types (`core/provenance/index.ts`). `TranslationProvenanceRecord` already carries `@since 0.7.0`.
+12. **Trash / versions** — trash = an `update` setting `deletedAt` (fires afterChange, not afterDelete);
+    version pruning bypasses collection hooks (DB-adapter level). Neither needs special handling.
+
+## The headline finding — best-effort vs atomicity conflict
+
+> **RESOLVED 2026-07-06 → Option B.** Follow-up source review found that `afterOperation` ALSO runs
+> before commit (`deleteByID.js:206` / `delete.js:259`, both before `commitTransaction`), so Option A's
+> "post-commit" premise was **wrong** — no standard collection hook is post-commit for delete. Best-effort
+> therefore comes from *swallow + separate transaction* (below), not from hook choice. `afterDelete` was
+> chosen (Option B): simplest, hands us `id` per document, handles bulk automatically.
+
+The design says cleanup is **best-effort, swallow-and-log, "never fails the delete."** But facts #2/#3
+show both delete hooks run *before* commit with no isolation. Best-effort is achieved by TWO things
+together:
+1. **Swallow** the cleanup error in our hook (try/catch) → we never throw → no `killTransaction` → the
+   primary delete proceeds to commit.
+2. Run cleanup in a **separate transaction** — `deleteByDocument` calls `payload.delete` **without** `req`,
+   so a failure there cannot poison the primary delete's Postgres transaction. (Threading `req` would join
+   the primary tx, where a failed statement poisons it → the primary commit fails even if we swallow.)
+
+Given both hold, `afterDelete` vs `afterOperation` is purely ergonomic; `afterDelete` wins (id in hand,
+per-document, no result-shape branching). Residual risk: a tiny orphan-on-rollback window if
+`commitTransaction` itself fails after our separate cleanup already committed — negligible, self-healing
+(next translation re-upserts provenance).
+
+## Proposed scope
+
+**IN:** D.1 delete-cleanup `afterDelete` hook (swallow + separate tx); D.2 export
+`TranslationProvenanceRecord` (`@since 0.7.0`), keep store/key/impl internal, verify `@since` on
+`provenance` config; D.3 README enable+migration section + lifecycle API docs; D.4 real-DB checks
+(`dismissedFingerprint: null` round-trip SQL+Mongo, real table-name collision).
+
+**OUT:** versions/drafts special handling; trash special handling; field-level provenance (#48/#51);
+dashboard/indicator merge (#49/#50).
+
+## Acceptance criteria
+
+1. With `provenance` enabled, deleting a document removes **all** its provenance rows (every target
+   locale); other documents' rows untouched.
+2. Cleanup hook is **not attached** when `provenance` is opted out.
+3. A failing sidecar cleanup **does not fail the user's document delete** (best-effort).
+4. Bulk delete (`delete({where})` matching N docs) cleans provenance for all N.
+5. Running plugin init twice does not stack duplicate hooks (idempotent injection).
+6. Consumer-supplied `afterDelete` hooks on the same collection still run (append, not replace).
+7. `TranslationProvenanceRecord` is importable from the package root; `ProvenanceStore`/`ProvenanceKey`/
+   `PayloadProvenanceStore` are not.
+8. `id` handled as `number | string` (stringified).
+
+## Risks & constraints
+
+- Must **append** to existing hook arrays and be idempotent — else clobber consumer hooks or stack dups.
+- Attach to sanitized `config.collections`, not the throwaway `pluginConfig.collections`.
+- Gate on `provenanceSlug` — no hook when opted out.
+- Do **not** thread `req` into `deleteByDocument` — separate tx is what makes cleanup best-effort.
+- D.4 needs a real Postgres instance (`apps/dev`/`apps/cms`); Mongo for the null round-trip.
+
+## Comprehension: 9/10
+
+Every implementation fact is source-verified. The transaction/hook strategy is resolved (Option B).
+
+## Suggested next step
+
+**Ready for `/sp-task`** (done — implemented via Option B).

--- a/packages/payload-plugin-translator/src/core/content-projection/computeSourceFingerprint.test.ts
+++ b/packages/payload-plugin-translator/src/core/content-projection/computeSourceFingerprint.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import type { FieldLike } from "../field-traversal";
+import { computeSourceFingerprint } from "./computeSourceFingerprint";
+import { projectTranslatableContent } from "./contentProjector";
+import { fingerprint } from "./fingerprinter";
+
+describe("computeSourceFingerprint", () => {
+  const schema: FieldLike[] = [{ name: "title", type: "text", localized: true }];
+
+  it("composes projectTranslatableContent + fingerprint", () => {
+    const doc = { title: "Hello" };
+    expect(computeSourceFingerprint(doc, schema)).toBe(
+      fingerprint(projectTranslatableContent(doc, schema))
+    );
+  });
+
+  it("changes when translatable content changes", () => {
+    expect(computeSourceFingerprint({ title: "Hello" }, schema)).not.toBe(
+      computeSourceFingerprint({ title: "Goodbye" }, schema)
+    );
+  });
+});

--- a/packages/payload-plugin-translator/src/core/content-projection/computeSourceFingerprint.ts
+++ b/packages/payload-plugin-translator/src/core/content-projection/computeSourceFingerprint.ts
@@ -1,0 +1,23 @@
+import type { FieldLike } from "../field-traversal";
+import { projectTranslatableContent } from "./contentProjector";
+import { fingerprint } from "./fingerprinter";
+
+/**
+ * The staleness baseline: a stable hash of a document's translatable content.
+ * `CURRENT = computeSourceFingerprint(sourceDoc, schema)` — the value provenance stores at translation
+ * time and #50 recomputes to detect source drift. A named composition of
+ * {@link projectTranslatableContent} + {@link fingerprint} so the "how to fingerprint source content"
+ * contract lives in one place (callers don't re-wire the two primitives). Reorder-invariant and
+ * text-nodes-only, inheriting those properties from its parts.
+ *
+ * @param doc - The source document to fingerprint (never mutated).
+ * @param schema - The ORIGINAL (un-sanitized) field schema.
+ * @returns A hex sha256 digest of the projected translatable content.
+ * @since 0.7.0
+ */
+export function computeSourceFingerprint(
+  doc: Record<string, unknown>,
+  schema: FieldLike[]
+): string {
+  return fingerprint(projectTranslatableContent(doc, schema));
+}

--- a/packages/payload-plugin-translator/src/core/index.ts
+++ b/packages/payload-plugin-translator/src/core/index.ts
@@ -21,6 +21,7 @@ export type { ProvenanceKey, ProvenanceStore, TranslationProvenanceRecord } from
 export { projectTranslatableContent } from "./content-projection/contentProjector";
 export type { ProjectionEntry } from "./content-projection/contentProjector";
 export { fingerprint } from "./content-projection/fingerprinter";
+export { computeSourceFingerprint } from "./content-projection/computeSourceFingerprint";
 export { makeIdPath } from "./content-projection/idPath";
 export type { IdPath, PathSegment } from "./content-projection/idPath";
 

--- a/packages/payload-plugin-translator/src/core/index.ts
+++ b/packages/payload-plugin-translator/src/core/index.ts
@@ -14,6 +14,9 @@ export type {
 export { TranslationPipeline, translateContent } from "./translation-pipeline";
 export type { TranslateContentArgs, TranslationStrategy } from "./translation-pipeline";
 
+// Provenance (contracts only — payload-free port + record types)
+export type { ProvenanceKey, ProvenanceStore, TranslationProvenanceRecord } from "./provenance";
+
 // Content projection
 export { projectTranslatableContent } from "./content-projection/contentProjector";
 export type { ProjectionEntry } from "./content-projection/contentProjector";

--- a/packages/payload-plugin-translator/src/core/provenance/ProvenanceStore.interface.ts
+++ b/packages/payload-plugin-translator/src/core/provenance/ProvenanceStore.interface.ts
@@ -1,0 +1,102 @@
+/**
+ * Translation provenance — the durable record of *what source state a target locale was translated
+ * from* (design: `docs/plans/2026-06-26-translation-provenance-and-lifecycle-design.md`).
+ *
+ * These are framework-agnostic contracts: plain data plus a storage port, with no Payload types, so
+ * they live in the core. Only the Payload-backed implementation of {@link ProvenanceStore} (in the
+ * plugin adapter) knows about Payload.
+ */
+
+/**
+ * One provenance receipt: a single `(collection, document, target locale)` translation.
+ *
+ * `documentId` is always a string (Payload ids may be string or number — callers stringify on the
+ * way in) and `translatedAt` is an ISO-8601 string, so the record shape is stable across databases.
+ *
+ * @since 0.7.0
+ */
+export interface TranslationProvenanceRecord {
+  /** Slug of the translated collection. */
+  collectionSlug: string;
+  /** Stringified id of the translated document. */
+  documentId: string;
+  /** Locale that was written (translated into). */
+  targetLocale: string;
+  /** Locale the translation was derived from. */
+  sourceLocale: string;
+  /**
+   * Fingerprint of the source content at translation time —
+   * `fingerprint(projectTranslatableContent(sourceDoc, schema))`. Staleness (later, in #50) is
+   * `currentSourceFingerprint !== sourceFingerprint`.
+   */
+  sourceFingerprint: string;
+  /** ISO-8601 timestamp of the last successful translation. */
+  translatedAt: string;
+  /**
+   * The source fingerprint an editor acknowledged as "stale but leave it" (#50's dismissable
+   * indicator). `null` until dismissed. Written by #50 — carried here now so no later migration is
+   * needed.
+   */
+  dismissedFingerprint: string | null;
+}
+
+/**
+ * The composite key that identifies exactly one provenance record. Also the {@link ProvenanceStore}
+ * `upsert`/`find` match key.
+ *
+ * @since 0.7.0
+ */
+export interface ProvenanceKey {
+  /** Slug of the translated collection. */
+  collectionSlug: string;
+  /** Stringified id of the translated document. */
+  documentId: string;
+  /** Locale that was written (translated into). */
+  targetLocale: string;
+}
+
+/**
+ * Storage port for translation provenance. The core depends only on this interface; the plugin
+ * supplies a Payload-backed implementation. Kept minimal so it maps cleanly onto any store.
+ *
+ * @since 0.7.0
+ *
+ * @example
+ * ```ts
+ * const store: ProvenanceStore = new PayloadProvenanceStore(payload, "translator-provenance");
+ * await store.upsert({
+ *   collectionSlug: "posts",
+ *   documentId: "42",
+ *   targetLocale: "de",
+ *   sourceLocale: "en",
+ *   sourceFingerprint: fp,
+ *   translatedAt: new Date().toISOString(),
+ *   dismissedFingerprint: null,
+ * });
+ * const record = await store.find({ collectionSlug: "posts", documentId: "42", targetLocale: "de" });
+ * ```
+ */
+export interface ProvenanceStore {
+  /**
+   * Create the record, or update it in place if one already exists for its
+   * `(collectionSlug, documentId, targetLocale)` key. Never produces a duplicate for the same key.
+   *
+   * @param record - The provenance receipt to persist.
+   */
+  upsert(record: TranslationProvenanceRecord): Promise<void>;
+  /**
+   * Look up the record for a key.
+   *
+   * @param key - The `(collectionSlug, documentId, targetLocale)` identity.
+   * @returns The stored record, or `null` if none exists.
+   */
+  find(key: ProvenanceKey): Promise<TranslationProvenanceRecord | null>;
+  /**
+   * Delete every record for a document (all target locales). Used to cascade-clean when the source
+   * document is deleted.
+   *
+   * @param collectionSlug - Slug of the deleted document's collection.
+   * @param documentId - Stringified id of the deleted document.
+   */
+  deleteByDocument(collectionSlug: string, documentId: string): Promise<void>;
+}

--- a/packages/payload-plugin-translator/src/core/provenance/index.ts
+++ b/packages/payload-plugin-translator/src/core/provenance/index.ts
@@ -1,0 +1,7 @@
+// Provenance contracts (port + record types) only — payload-free. The Payload-backed store lives
+// in the plugin (src/server/modules/provenance), outside the core.
+export type {
+  ProvenanceKey,
+  ProvenanceStore,
+  TranslationProvenanceRecord,
+} from "./ProvenanceStore.interface";

--- a/packages/payload-plugin-translator/src/index.ts
+++ b/packages/payload-plugin-translator/src/index.ts
@@ -2,6 +2,9 @@
 export { translatorPlugin } from "./plugin";
 export type { TranslatorPluginConfig } from "./plugin";
 
+// Lifecycle callbacks — the task descriptor passed to onQueued/onCompleted/onFailed
+export type { TranslationTask, TranslationLifecycleCallbacks } from "./server/modules/lifecycle";
+
 // Access control
 export type { AccessGuard, AccessGuardRequest } from "./types/AccessGuard";
 

--- a/packages/payload-plugin-translator/src/index.ts
+++ b/packages/payload-plugin-translator/src/index.ts
@@ -5,6 +5,10 @@ export type { TranslatorPluginConfig } from "./plugin";
 // Lifecycle callbacks — the task descriptor passed to onQueued/onCompleted/onFailed
 export type { TranslationTask, TranslationLifecycleCallbacks } from "./server/modules/lifecycle";
 
+// Provenance — the durable per-locale record shape (opt-in `provenance` sidecar). The store/key and
+// the Payload-backed impl stay internal; consumers only read the sidecar collection.
+export type { TranslationProvenanceRecord } from "./core";
+
 // Access control
 export type { AccessGuard, AccessGuardRequest } from "./types/AccessGuard";
 

--- a/packages/payload-plugin-translator/src/plugin.test.ts
+++ b/packages/payload-plugin-translator/src/plugin.test.ts
@@ -1,11 +1,30 @@
 import { describe, it, expect, vi } from "vitest";
-import type { Config } from "payload";
+import type { Config, Payload } from "payload";
 
 import { translatorPlugin } from "./plugin";
 import type { TranslatorPluginConfig } from "./plugin";
 import { documentLevel, fieldLevel } from "./composition/levels";
 import { TranslateDocumentExport } from "./client/widgets/translate-document";
 import { BulkDocumentTranslationDashboard } from "./client/widgets/bulk-translation-dashboard/ui/BulkTranslationDashboard.export";
+import { withQueuedNotification } from "./server/modules/lifecycle";
+
+// Isolate the lifecycle-wiring tests from the real pipeline: a mocked translateContent that returns
+// null makes the handler finish cleanly (nothing to translate) so we can assert `completed` fires
+// without standing up a provider. `vi.mock` is hoisted, so it applies regardless of position; kept
+// below the imports to satisfy the import/first lint rule. Other tests never execute the handler.
+vi.mock("./core/translation-pipeline", () => ({
+  translateContent: vi.fn().mockResolvedValue(null),
+}));
+
+// Spy on withQueuedNotification while keeping its real behaviour, so a test can assert the runner
+// was (or wasn't) wrapped for the `lifecycle.onQueued` absent/present branch in plugin.ts.
+vi.mock("./server/modules/lifecycle", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./server/modules/lifecycle")>();
+  return {
+    ...actual,
+    withQueuedNotification: vi.fn(actual.withQueuedNotification),
+  };
+});
 
 // End-to-end behaviour guard for the levels refactor: the default levels must
 // reproduce today's wiring (6-route bundle, cache provider, doc popup + bulk
@@ -194,5 +213,187 @@ describe("translatorPlugin — provenance (opt-in)", () => {
 
     expect(provenanceOf(twice, "provenance-a")).toBeDefined();
     expect(provenanceOf(twice, "provenance-b")).toBeDefined();
+  });
+});
+
+describe("translatorPlugin — lifecycle callbacks", () => {
+  // The runner's execution handler is what the plugin wraps for completed/failed. It is handed to
+  // `runner.configure(context)` at init, so we capture it from the configure mock and invoke it.
+  const capturedHandler = (runner: ReturnType<typeof makeRunner>) =>
+    runner.configure.mock.calls[0][0].handler as (
+      payload: Payload,
+      input: Record<string, unknown>
+    ) => Promise<void>;
+
+  const handlerInput = (overrides: Record<string, unknown> = {}) => ({
+    collection: "posts",
+    collectionId: "doc-1",
+    sourceLng: "en",
+    targetLng: "de",
+    strategy: "overwrite",
+    publishOnTranslation: false,
+    ...overrides,
+  });
+
+  const mockPayload = () =>
+    ({
+      findByID: vi.fn().mockResolvedValue({ id: "doc-1" }),
+      logger: { error: vi.fn() },
+    }) as unknown as Payload;
+
+  it("fires lifecycle.onCompleted after a successful task", async () => {
+    const onCompleted = vi.fn();
+    const { runner } = await build({
+      lifecycle: { onCompleted },
+    } as Partial<TranslatorPluginConfig>);
+
+    await capturedHandler(runner)(mockPayload(), handlerInput());
+
+    expect(onCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: "posts",
+        id: "doc-1",
+        sourceLng: "en",
+        targetLng: "de",
+      })
+    );
+  });
+
+  it("fires lifecycle.onFailed with the error and rethrows so the runner marks it failed", async () => {
+    const onFailed = vi.fn();
+    const { runner } = await build({ lifecycle: { onFailed } } as Partial<TranslatorPluginConfig>);
+
+    // an unknown collection makes the handler throw before translating
+    let rejectedError: unknown;
+    try {
+      await capturedHandler(runner)(mockPayload(), handlerInput({ collection: "unknown" }));
+    } catch (error) {
+      rejectedError = error;
+    }
+
+    expect(rejectedError).toBeInstanceOf(Error);
+    expect(onFailed).toHaveBeenCalledWith(
+      expect.objectContaining({ collection: "unknown" }),
+      rejectedError
+    );
+    // the rejected error and the error handed to onFailed must be the identical object
+    expect(onFailed.mock.calls[0][1]).toBe(rejectedError);
+  });
+
+  it("rethrows the original translation error even when onFailed itself throws", async () => {
+    const onFailed = vi.fn(() => {
+      throw new Error("callback boom");
+    });
+    const { runner } = await build({ lifecycle: { onFailed } } as Partial<TranslatorPluginConfig>);
+
+    await expect(
+      capturedHandler(runner)(mockPayload(), handlerInput({ collection: "unknown" }))
+    ).rejects.toThrow(/not found in schemaMap/u);
+  });
+
+  it("does not fail the task when a lifecycle callback throws (swallow + log)", async () => {
+    const onCompleted = vi.fn(() => {
+      throw new Error("callback boom");
+    });
+    const { runner } = await build({
+      lifecycle: { onCompleted },
+    } as Partial<TranslatorPluginConfig>);
+
+    await expect(capturedHandler(runner)(mockPayload(), handlerInput())).resolves.toBeUndefined();
+  });
+
+  it("fires lifecycle.onQueued for each task when enqueuing", async () => {
+    const onQueued = vi.fn();
+    const taskRunner = {
+      enqueue: vi.fn().mockResolvedValue(undefined),
+      cancel: vi.fn(),
+      run: vi.fn(),
+      findByCollection: vi.fn(),
+    };
+    const runner = {
+      create: vi.fn().mockReturnValue(taskRunner),
+      configure: vi.fn().mockReturnValue((c: Config) => c),
+    };
+    const { result } = await build({
+      runner,
+      lifecycle: { onQueued },
+    } as unknown as Partial<TranslatorPluginConfig>);
+
+    const enqueue = result.endpoints?.find((e) => e.path === "/translate/enqueue");
+    const req = {
+      json: async () => ({
+        source_lng: "en",
+        target_lng: "de",
+        collection_slug: "posts",
+        collection_id: ["1", "2"],
+      }),
+      payload: { logger: { error: vi.fn() } },
+    };
+    await enqueue?.handler?.(req as never);
+
+    expect(onQueued).toHaveBeenCalledTimes(2);
+    expect(onQueued).toHaveBeenCalledWith(expect.objectContaining({ id: "1" }));
+    expect(taskRunner.enqueue).toHaveBeenCalled();
+  });
+
+  it("does not wrap the runner in withQueuedNotification when lifecycle.onQueued is absent", async () => {
+    vi.mocked(withQueuedNotification).mockClear();
+    const taskRunner = {
+      enqueue: vi.fn().mockResolvedValue(undefined),
+      cancel: vi.fn(),
+      run: vi.fn(),
+      findByCollection: vi.fn(),
+    };
+    const runner = {
+      create: vi.fn().mockReturnValue(taskRunner),
+      configure: vi.fn().mockReturnValue((c: Config) => c),
+    };
+    const { result } = await build({
+      runner,
+      lifecycle: { onCompleted: vi.fn() },
+    } as unknown as Partial<TranslatorPluginConfig>);
+
+    const enqueue = result.endpoints?.find((e) => e.path === "/translate/enqueue");
+    const req = {
+      json: async () => ({
+        source_lng: "en",
+        target_lng: "de",
+        collection_slug: "posts",
+        collection_id: ["1", "2"],
+      }),
+      payload: { logger: { error: vi.fn() } },
+    };
+    await enqueue?.handler?.(req as never);
+
+    expect(withQueuedNotification).not.toHaveBeenCalled();
+    expect(taskRunner.enqueue).toHaveBeenCalled();
+  });
+
+  it("does not fire onFailed on the success path when both onCompleted and onFailed are registered", async () => {
+    const onCompleted = vi.fn();
+    const onFailed = vi.fn();
+    const { runner } = await build({
+      lifecycle: { onCompleted, onFailed },
+    } as Partial<TranslatorPluginConfig>);
+
+    await capturedHandler(runner)(mockPayload(), handlerInput());
+
+    expect(onCompleted).toHaveBeenCalledTimes(1);
+    expect(onFailed).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onCompleted on the failure path when both onCompleted and onFailed are registered", async () => {
+    const onCompleted = vi.fn();
+    const onFailed = vi.fn();
+    const { runner } = await build({
+      lifecycle: { onCompleted, onFailed },
+    } as Partial<TranslatorPluginConfig>);
+
+    await expect(
+      capturedHandler(runner)(mockPayload(), handlerInput({ collection: "unknown" }))
+    ).rejects.toThrow();
+
+    expect(onFailed).toHaveBeenCalledTimes(1);
+    expect(onCompleted).not.toHaveBeenCalled();
   });
 });

--- a/packages/payload-plugin-translator/src/plugin.test.ts
+++ b/packages/payload-plugin-translator/src/plugin.test.ts
@@ -113,3 +113,86 @@ describe("translatorPlugin — explicit levels", () => {
     expect(runner.configure).toHaveBeenCalledTimes(1);
   });
 });
+
+const provenanceOf = (result: Config, slug = "translator-provenance") =>
+  result.collections?.find((c) => c.slug === slug) as Record<string, any> | undefined;
+
+describe("translatorPlugin — provenance (opt-in)", () => {
+  it("does not add the provenance collection by default", async () => {
+    const { result } = await build();
+    expect(provenanceOf(result)).toBeUndefined();
+  });
+
+  it("adds the hidden provenance sidecar when provenance is enabled with {}", async () => {
+    const { result } = await build({ provenance: {} } as Partial<TranslatorPluginConfig>);
+    const provenance = provenanceOf(result);
+    expect(provenance).toBeDefined();
+    expect(provenance?.admin?.hidden).toBe(true);
+  });
+
+  it("enables provenance with the default slug when set to true", async () => {
+    const { result } = await build({ provenance: true } as Partial<TranslatorPluginConfig>);
+    expect(provenanceOf(result)).toBeDefined();
+  });
+
+  it("does not add the provenance collection when set to false", async () => {
+    const { result } = await build({ provenance: false } as Partial<TranslatorPluginConfig>);
+    expect(provenanceOf(result)).toBeUndefined();
+  });
+
+  it("honours a custom provenance slug", async () => {
+    const { result } = await build({
+      provenance: { slug: "my-provenance" },
+    } as Partial<TranslatorPluginConfig>);
+    expect(provenanceOf(result, "my-provenance")).toBeDefined();
+    expect(provenanceOf(result)).toBeUndefined();
+  });
+
+  it("throws when the provenance slug collides with an existing collection", async () => {
+    await expect(
+      build({ provenance: { slug: "posts" } } as Partial<TranslatorPluginConfig>)
+    ).rejects.toThrow(/posts/u);
+  });
+
+  it("does not duplicate the provenance collection when run twice", async () => {
+    const collection = {
+      slug: "posts",
+      fields: [{ name: "title", type: "text", localized: true }],
+    };
+    const pluginConfig = {
+      collections: [collection],
+      translationProvider: { translate: vi.fn() },
+      runner: { create: vi.fn(), configure: vi.fn().mockReturnValue((c: Config) => c) },
+      provenance: {},
+    } as unknown as TranslatorPluginConfig;
+
+    const once = await translatorPlugin(pluginConfig)({
+      collections: [collection],
+    } as unknown as Config);
+    const twice = await translatorPlugin(pluginConfig)(once);
+
+    expect(twice.collections?.filter((c) => c.slug === "translator-provenance")).toHaveLength(1);
+  });
+
+  it("adds both sidecars when run twice with two different provenance slugs", async () => {
+    const collection = {
+      slug: "posts",
+      fields: [{ name: "title", type: "text", localized: true }],
+    };
+    const makePluginConfig = (slug: string) =>
+      ({
+        collections: [collection],
+        translationProvider: { translate: vi.fn() },
+        runner: { create: vi.fn(), configure: vi.fn().mockReturnValue((c: Config) => c) },
+        provenance: { slug },
+      }) as unknown as TranslatorPluginConfig;
+
+    const once = await translatorPlugin(makePluginConfig("provenance-a"))({
+      collections: [collection],
+    } as unknown as Config);
+    const twice = await translatorPlugin(makePluginConfig("provenance-b"))(once);
+
+    expect(provenanceOf(twice, "provenance-a")).toBeDefined();
+    expect(provenanceOf(twice, "provenance-b")).toBeDefined();
+  });
+});

--- a/packages/payload-plugin-translator/src/plugin.test.ts
+++ b/packages/payload-plugin-translator/src/plugin.test.ts
@@ -214,6 +214,42 @@ describe("translatorPlugin — provenance (opt-in)", () => {
     expect(provenanceOf(twice, "provenance-a")).toBeDefined();
     expect(provenanceOf(twice, "provenance-b")).toBeDefined();
   });
+
+  it("attaches a delete-cleanup afterDelete hook to translatable collections when enabled", async () => {
+    const { posts } = await build({ provenance: {} } as Partial<TranslatorPluginConfig>);
+    expect(posts.hooks?.afterDelete).toHaveLength(1);
+  });
+
+  it("does not attach a cleanup hook when provenance is disabled", async () => {
+    const { posts } = await build();
+    expect(posts.hooks?.afterDelete ?? []).toHaveLength(0);
+  });
+
+  it("does not attach the cleanup hook to the sidecar collection itself", async () => {
+    const { result } = await build({ provenance: {} } as Partial<TranslatorPluginConfig>);
+    expect(provenanceOf(result)?.hooks?.afterDelete ?? []).toHaveLength(0);
+  });
+
+  it("does not stack duplicate cleanup hooks when run twice", async () => {
+    const collection = {
+      slug: "posts",
+      fields: [{ name: "title", type: "text", localized: true }],
+    };
+    const pluginConfig = {
+      collections: [collection],
+      translationProvider: { translate: vi.fn() },
+      runner: { create: vi.fn(), configure: vi.fn().mockReturnValue((c: Config) => c) },
+      provenance: {},
+    } as unknown as TranslatorPluginConfig;
+
+    const once = await translatorPlugin(pluginConfig)({
+      collections: [collection],
+    } as unknown as Config);
+    const twice = await translatorPlugin(pluginConfig)(once);
+
+    const posts = twice.collections?.find((c) => c.slug === "posts") as Record<string, any>;
+    expect(posts.hooks?.afterDelete).toHaveLength(1);
+  });
 });
 
 describe("translatorPlugin — lifecycle callbacks", () => {

--- a/packages/payload-plugin-translator/src/plugin.test.ts
+++ b/packages/payload-plugin-translator/src/plugin.test.ts
@@ -167,6 +167,14 @@ describe("translatorPlugin — provenance (opt-in)", () => {
     expect(provenanceOf(result)).toBeUndefined();
   });
 
+  it("falls back to the default slug when given a blank slug", async () => {
+    // `||` (not `??`) in resolveProvenanceSlug: a blank slug must enable with the default, not disable.
+    const { result } = await build({
+      provenance: { slug: "" },
+    } as Partial<TranslatorPluginConfig>);
+    expect(provenanceOf(result)).toBeDefined();
+  });
+
   it("throws when the provenance slug collides with an existing collection", async () => {
     await expect(
       build({ provenance: { slug: "posts" } } as Partial<TranslatorPluginConfig>)

--- a/packages/payload-plugin-translator/src/plugin.ts
+++ b/packages/payload-plugin-translator/src/plugin.ts
@@ -1,6 +1,13 @@
-import type { CollectionConfig, Config } from "payload";
+import type { CollectionConfig, Config, Payload } from "payload";
 
 import { CacheProviderExport } from "./client/app/cache/CacheProvider.export";
+import {
+  DEFAULT_PROVENANCE_SLUG,
+  PayloadProvenanceStore,
+  assertProvenanceSlugFree,
+  isProvenanceCollection,
+  makeProvenanceCollection,
+} from "./server/modules/provenance";
 import type { AccessGuard } from "./types/AccessGuard";
 import type { TranslationProvider } from "./core/translation-providers";
 import type {
@@ -13,6 +20,17 @@ import { documentLevel, collectionLevel } from "./composition/levels";
 import type { TranslationLevel } from "./server/modules/translation-levels";
 import { PluginConfigBuilder } from "./server/modules/translation-levels/PluginConfigBuilder";
 import { normalizePath } from "./server/shared";
+
+/**
+ * Resolve the opt-in `provenance` config to a sidecar slug, or `null` when disabled.
+ * `false`/omitted → off; `true` or `{}` → on with the default slug; `{ slug }` → on with that slug.
+ */
+function resolveProvenanceSlug(provenance: TranslatorPluginConfig["provenance"]): string | null {
+  if (!provenance) return null;
+  if (provenance === true) return DEFAULT_PROVENANCE_SLUG;
+  // `||` (not `??`) so an empty/blank slug falls back to the default instead of silently disabling.
+  return provenance.slug || DEFAULT_PROVENANCE_SLUG;
+}
 
 export type TranslatorPluginConfig = {
   /**
@@ -54,6 +72,26 @@ export type TranslatorPluginConfig = {
    * @since 0.5.0
    */
   levels?: TranslationLevel[];
+  /**
+   * Opt-in translation provenance — a durable, per-locale record of what source state each
+   * translation was derived from, stored in a plugin-managed sidecar collection. Set `true` (or `{}`)
+   * to enable with the default slug, or `{ slug }` to customise it. Omit (or `false`) to disable
+   * entirely — no collection, no migration, no behaviour change. **Enabling it on a SQL database adds
+   * a table**: generate and run a migration (`payload migrate:create` + `payload migrate`; dev push in
+   * development; MongoDB infers it with no migration). The lifecycle callbacks are unaffected by this
+   * flag.
+   * @since 0.7.0
+   */
+  provenance?:
+    | boolean
+    | {
+        /**
+         * Slug for the sidecar collection. Change it only to resolve a collision with an existing
+         * collection.
+         * @default 'translator-provenance'
+         */
+        slug?: string;
+      };
 };
 
 /** @deprecated Use `TranslatorPluginConfig` instead */
@@ -75,6 +113,7 @@ export class TranslateCollectionPlugin {
         runner,
         collections,
         levels,
+        provenance,
         basePath: rawBasePath = "/translate",
       } = this.pluginConfig;
 
@@ -91,7 +130,27 @@ export class TranslateCollectionPlugin {
       );
       const collectionSlugs = new Set(schemaMap.keys());
       const basePath = normalizePath(rawBasePath);
-      const translateHandler = new TranslateDocumentHandler(translationProvider, schemaMap);
+
+      // Provenance is opt-in: present `provenance` → resolve the slug, guard it against a collision
+      // with a collection the consumer already defines (ignoring an already-added sidecar so repeated
+      // plugin runs stay idempotent), and give the handler a factory that binds a store to the
+      // request's Payload instance. Absent → no factory, no collection, no behaviour change.
+      const provenanceSlug = resolveProvenanceSlug(provenance);
+      if (provenanceSlug) {
+        const existing = (config.collections ?? []).filter(
+          (collection) => !isProvenanceCollection(collection)
+        );
+        assertProvenanceSlugFree(provenanceSlug, existing);
+      }
+      const provenanceStoreFactory = provenanceSlug
+        ? (p: Payload) => new PayloadProvenanceStore(p, provenanceSlug)
+        : undefined;
+
+      const translateHandler = new TranslateDocumentHandler(
+        translationProvider,
+        schemaMap,
+        provenanceStoreFactory
+      );
 
       const runnerContext: TaskRunnerContext = {
         handler: async (payload, input) => {
@@ -131,6 +190,20 @@ export class TranslateCollectionPlugin {
       //    so a modifier returning a fresh config object doesn't drop later writes),
       //  - the always-on client cache provider.
       builder.addConfigModifier(runnerConfigModifier);
+      if (provenanceSlug) {
+        builder.addConfigModifier((cfg) => {
+          const alreadyAdded = cfg.collections?.some(
+            (collection) => collection.slug === provenanceSlug && isProvenanceCollection(collection)
+          );
+          if (!alreadyAdded) {
+            cfg.collections = [
+              ...(cfg.collections ?? []),
+              makeProvenanceCollection(provenanceSlug),
+            ];
+          }
+          return cfg;
+        });
+      }
       builder.addAdminProvider(new CacheProviderExport(basePath));
 
       // The single place the Payload config is mutated.

--- a/packages/payload-plugin-translator/src/plugin.ts
+++ b/packages/payload-plugin-translator/src/plugin.ts
@@ -16,6 +16,12 @@ import type {
   TaskRunnerFactory,
 } from "./server/modules/task-runner";
 import { TranslateDocumentHandler } from "./server/features/translate-document";
+import {
+  LifecycleNotifier,
+  taskFromHandlerInput,
+  withQueuedNotification,
+} from "./server/modules/lifecycle";
+import type { TranslationLifecycleCallbacks } from "./server/modules/lifecycle";
 import { documentLevel, collectionLevel } from "./composition/levels";
 import type { TranslationLevel } from "./server/modules/translation-levels";
 import { PluginConfigBuilder } from "./server/modules/translation-levels/PluginConfigBuilder";
@@ -92,6 +98,13 @@ export type TranslatorPluginConfig = {
          */
         slug?: string;
       };
+  /**
+   * Optional server-side lifecycle callbacks fired around each translation task
+   * (`onQueued` / `onCompleted` / `onFailed`). Always available — no schema, no migration, not gated
+   * by `provenance`. A throwing callback is caught and logged, never failing the translation.
+   * @since 0.7.0
+   */
+  lifecycle?: TranslationLifecycleCallbacks;
 };
 
 /** @deprecated Use `TranslatorPluginConfig` instead */
@@ -114,8 +127,11 @@ export class TranslateCollectionPlugin {
         collections,
         levels,
         provenance,
+        lifecycle,
         basePath: rawBasePath = "/translate",
       } = this.pluginConfig;
+
+      const lifecycleCallbacks: TranslationLifecycleCallbacks = lifecycle ?? {};
 
       // Build schema map from deep-cloned collections
       // Deep clone is required because Payload mutates the original collection objects,
@@ -154,14 +170,22 @@ export class TranslateCollectionPlugin {
 
       const runnerContext: TaskRunnerContext = {
         handler: async (payload, input) => {
-          await translateHandler.handle(payload, {
-            collection: input.collection,
-            collectionId: input.collectionId,
-            sourceLng: input.sourceLng,
-            targetLng: input.targetLng,
-            strategy: input.strategy,
-            publishOnTranslation: input.publishOnTranslation,
-          });
+          const notifier = new LifecycleNotifier(lifecycleCallbacks, payload.logger);
+          const task = taskFromHandlerInput(input);
+          try {
+            await translateHandler.handle(payload, {
+              collection: input.collection,
+              collectionId: input.collectionId,
+              sourceLng: input.sourceLng,
+              targetLng: input.targetLng,
+              strategy: input.strategy,
+              publishOnTranslation: input.publishOnTranslation,
+            });
+          } catch (error) {
+            await notifier.failed(task, error);
+            throw error; // rethrow so the runner marks the job failed
+          }
+          await notifier.completed(task);
         },
         collections: Array.from(collectionSlugs),
       };
@@ -170,8 +194,16 @@ export class TranslateCollectionPlugin {
       // Bind the context once so routes receive a self-sufficient factory: the
       // runner needs no mutable per-instance handler state and create() has no
       // "configure() must run first" ordering coupling (translator plan, 0c).
+      // When an `onQueued` callback is set, decorate the runner so `enqueue` fires it.
       const taskRunnerFactory: TaskRunnerFactory = {
-        create: (payload) => runner.create(payload, runnerContext.handler),
+        create: (payload) => {
+          const taskRunner = runner.create(payload, runnerContext.handler);
+          if (!lifecycleCallbacks.onQueued) return taskRunner;
+          return withQueuedNotification(
+            taskRunner,
+            new LifecycleNotifier(lifecycleCallbacks, payload.logger)
+          );
+        },
       };
 
       const activeLevels = levels ?? [documentLevel(), collectionLevel()];

--- a/packages/payload-plugin-translator/src/plugin.ts
+++ b/packages/payload-plugin-translator/src/plugin.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_PROVENANCE_SLUG,
   PayloadProvenanceStore,
   assertProvenanceSlugFree,
+  injectProvenanceCleanup,
   isProvenanceCollection,
   makeProvenanceCollection,
 } from "./server/modules/provenance";
@@ -146,11 +147,6 @@ export class TranslateCollectionPlugin {
       );
       const collectionSlugs = new Set(schemaMap.keys());
       const basePath = normalizePath(rawBasePath);
-
-      // Provenance is opt-in: present `provenance` → resolve the slug, guard it against a collision
-      // with a collection the consumer already defines (ignoring an already-added sidecar so repeated
-      // plugin runs stay idempotent), and give the handler a factory that binds a store to the
-      // request's Payload instance. Absent → no factory, no collection, no behaviour change.
       const provenanceSlug = resolveProvenanceSlug(provenance);
       if (provenanceSlug) {
         const existing = (config.collections ?? []).filter(
@@ -217,12 +213,8 @@ export class TranslateCollectionPlugin {
       });
       for (const level of activeLevels) level.extend(builder);
 
-      // Plugin-level contributions, routed through the same single config-writer:
-      //  - the runner's jobs/autorun/onInit modifier (the builder applies it first,
-      //    so a modifier returning a fresh config object doesn't drop later writes),
-      //  - the always-on client cache provider.
       builder.addConfigModifier(runnerConfigModifier);
-      if (provenanceSlug) {
+      if (provenanceSlug && provenanceStoreFactory) {
         builder.addConfigModifier((cfg) => {
           const alreadyAdded = cfg.collections?.some(
             (collection) => collection.slug === provenanceSlug && isProvenanceCollection(collection)
@@ -233,6 +225,7 @@ export class TranslateCollectionPlugin {
               makeProvenanceCollection(provenanceSlug),
             ];
           }
+          injectProvenanceCleanup(cfg, collectionSlugs, provenanceStoreFactory, provenanceSlug);
           return cfg;
         });
       }

--- a/packages/payload-plugin-translator/src/server/features/translate-document/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-document/handler.test.ts
@@ -14,6 +14,12 @@ vi.mock("../../../core/translation-pipeline", () => ({
   translateContent: vi.fn().mockResolvedValue(null),
 }));
 
+// Provenance fingerprinting is the core's job and tested there; here we pin a fixed hash so the
+// handler test asserts only the record the handler builds and hands to the store.
+vi.mock("../../../core/content-projection/computeSourceFingerprint", () => ({
+  computeSourceFingerprint: vi.fn(() => "fp-fixed"),
+}));
+
 describe("TranslateDocumentHandler", () => {
   let handler: TranslateDocumentHandler;
   let mockTranslationProvider: TranslationProvider;
@@ -47,6 +53,7 @@ describe("TranslateDocumentHandler", () => {
     mockPayload = {
       findByID: vi.fn().mockResolvedValue({ id: "doc-123", title: "Test" }),
       update: vi.fn().mockResolvedValue({}),
+      logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
       collections: {
         posts: {
           config: {
@@ -256,6 +263,103 @@ describe("TranslateDocumentHandler", () => {
           autosave: false,
         })
       );
+    });
+  });
+
+  describe("provenance recording", () => {
+    let store: {
+      upsert: ReturnType<typeof vi.fn>;
+      find: ReturnType<typeof vi.fn>;
+      deleteByDocument: ReturnType<typeof vi.fn>;
+    };
+    let storeFactory: ReturnType<typeof vi.fn>;
+
+    const makeHandlerWithProvenance = () =>
+      new TranslateDocumentHandler(
+        mockTranslationProvider,
+        mockSchemaMap,
+        storeFactory as unknown as (payload: typeof mockPayload) => typeof store
+      );
+
+    beforeEach(() => {
+      store = { upsert: vi.fn(), find: vi.fn(), deleteByDocument: vi.fn() };
+      storeFactory = vi.fn(() => store);
+    });
+
+    const withTranslatedData = async () => {
+      const { translateContent } = await import("../../../core/translation-pipeline");
+      (translateContent as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        title: "Hallo",
+      });
+    };
+
+    it("upserts a provenance record after a successful translation", async () => {
+      await withTranslatedData();
+      const { computeSourceFingerprint } =
+        await import("../../../core/content-projection/computeSourceFingerprint");
+      // Distinguish source vs. target findByID calls by locale so this assertion actually
+      // proves the handler fingerprints the source document, not the target one.
+      (mockPayload.findByID as ReturnType<typeof vi.fn>).mockImplementation(
+        ({ locale }: { locale: string }) =>
+          Promise.resolve(
+            locale === "en"
+              ? { id: "doc-123", title: "Source" }
+              : { id: "doc-123", title: "Target" }
+          )
+      );
+      const handlerWithProvenance = makeHandlerWithProvenance();
+
+      await handlerWithProvenance.handle(
+        mockPayload,
+        createInput({ collection: "posts" as CollectionSlug, sourceLng: "en", targetLng: "de" })
+      );
+
+      expect(computeSourceFingerprint).toHaveBeenCalledWith({ id: "doc-123", title: "Source" }, [
+        { name: "title", type: "text", localized: true },
+      ]);
+      expect(storeFactory).toHaveBeenCalledWith(mockPayload);
+      expect(store.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collectionSlug: "posts",
+          documentId: "doc-123",
+          targetLocale: "de",
+          sourceLocale: "en",
+          sourceFingerprint: "fp-fixed",
+          dismissedFingerprint: null,
+        })
+      );
+      const record = store.upsert.mock.calls[0][0] as { translatedAt: string };
+      expect(new Date(record.translatedAt).toISOString()).toBe(record.translatedAt);
+    });
+
+    it("does not record provenance when no store factory is supplied (disabled)", async () => {
+      await withTranslatedData();
+      // handler built without the factory (default in beforeEach) — provenance off.
+      await handler.handle(mockPayload, createInput());
+
+      expect(store.upsert).not.toHaveBeenCalled();
+    });
+
+    it("does not record provenance when nothing was translated (pipeline returns null)", async () => {
+      const { translateContent } = await import("../../../core/translation-pipeline");
+      (translateContent as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await makeHandlerWithProvenance().handle(mockPayload, createInput());
+
+      expect(storeFactory).not.toHaveBeenCalled();
+      expect(store.upsert).not.toHaveBeenCalled();
+    });
+
+    it("does not fail the translation when the provenance write throws (best-effort + logged)", async () => {
+      await withTranslatedData();
+      store.upsert.mockRejectedValue(new Error("provenance table down"));
+
+      const result = await makeHandlerWithProvenance().handle(mockPayload, createInput());
+
+      expect(result).toEqual({ success: true });
+      expect(
+        (mockPayload as unknown as { logger: { error: ReturnType<typeof vi.fn> } }).logger.error
+      ).toHaveBeenCalled();
     });
   });
 });

--- a/packages/payload-plugin-translator/src/server/features/translate-document/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-document/handler.ts
@@ -4,6 +4,8 @@ import { APIError } from "payload";
 import type { Handler } from "../../shared";
 import type { TranslationProvider } from "../../../core/translation-providers";
 import { translateContent } from "../../../core/translation-pipeline";
+import { computeSourceFingerprint } from "../../../core/content-projection/computeSourceFingerprint";
+import type { ProvenanceStore } from "../../../core/provenance";
 
 import type { CollectionSchemaMap } from "../../../types/CollectionSchemaMap";
 import type { TranslateDocumentInput, TranslateDocumentOutput } from "./model";
@@ -13,6 +15,9 @@ export type TranslateDocumentDependencies = {
   schemaMap: CollectionSchemaMap;
 };
 
+/** Builds a provenance store bound to a Payload instance; absent when provenance is disabled. */
+export type ProvenanceStoreFactory = (payload: Payload) => ProvenanceStore;
+
 /**
  * Translates a single document from source language to target language
  */
@@ -20,10 +25,19 @@ export class TranslateDocumentHandler implements Handler<
   TranslateDocumentInput,
   TranslateDocumentOutput
 > {
+  private readonly translationProvider: TranslationProvider;
+  private readonly schemaMap: CollectionSchemaMap;
+  private readonly provenanceStoreFactory?: ProvenanceStoreFactory;
+
   constructor(
-    private readonly translationProvider: TranslationProvider,
-    private readonly schemaMap: CollectionSchemaMap
-  ) {}
+    translationProvider: TranslationProvider,
+    schemaMap: CollectionSchemaMap,
+    provenanceStoreFactory?: ProvenanceStoreFactory
+  ) {
+    this.translationProvider = translationProvider;
+    this.schemaMap = schemaMap;
+    this.provenanceStoreFactory = provenanceStoreFactory;
+  }
 
   async handle(payload: Payload, input: TranslateDocumentInput): Promise<TranslateDocumentOutput> {
     const { collection, collectionId, sourceLng, targetLng, strategy, publishOnTranslation } =
@@ -69,6 +83,26 @@ export class TranslateDocumentHandler implements Handler<
       collectionConfig,
       publishOnTranslation
     );
+
+    if (this.provenanceStoreFactory) {
+      const store = this.provenanceStoreFactory(payload);
+      try {
+        await store.upsert({
+          collectionSlug: collection,
+          documentId: String(collectionId),
+          targetLocale: targetLng,
+          sourceLocale: sourceLng,
+          sourceFingerprint: computeSourceFingerprint(sourceData, schema),
+          translatedAt: new Date().toISOString(),
+          dismissedFingerprint: null,
+        });
+      } catch (error) {
+        payload.logger.error({
+          err: error,
+          msg: "translator: failed to record translation provenance",
+        });
+      }
+    }
 
     return { success: true };
   }

--- a/packages/payload-plugin-translator/src/server/features/translate-document/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-document/handler.ts
@@ -5,7 +5,7 @@ import type { Handler } from "../../shared";
 import type { TranslationProvider } from "../../../core/translation-providers";
 import { translateContent } from "../../../core/translation-pipeline";
 import { computeSourceFingerprint } from "../../../core/content-projection/computeSourceFingerprint";
-import type { ProvenanceStore } from "../../../core/provenance";
+import type { ProvenanceStoreFactory } from "../../modules/provenance";
 
 import type { CollectionSchemaMap } from "../../../types/CollectionSchemaMap";
 import type { TranslateDocumentInput, TranslateDocumentOutput } from "./model";
@@ -14,9 +14,6 @@ export type TranslateDocumentDependencies = {
   translationProvider: TranslationProvider;
   schemaMap: CollectionSchemaMap;
 };
-
-/** Builds a provenance store bound to a Payload instance; absent when provenance is disabled. */
-export type ProvenanceStoreFactory = (payload: Payload) => ProvenanceStore;
 
 /**
  * Translates a single document from source language to target language
@@ -99,6 +96,10 @@ export class TranslateDocumentHandler implements Handler<
       } catch (error) {
         payload.logger.error({
           err: error,
+          collection,
+          documentId: String(collectionId),
+          targetLocale: targetLng,
+          sourceLocale: sourceLng,
           msg: "translator: failed to record translation provenance",
         });
       }

--- a/packages/payload-plugin-translator/src/server/modules/lifecycle/LifecycleNotifier.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/lifecycle/LifecycleNotifier.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import { LifecycleNotifier } from "./LifecycleNotifier";
+import type { TranslationTask } from "./types";
+
+const task: TranslationTask = {
+  collection: "posts",
+  id: "doc-1",
+  sourceLng: "en",
+  targetLng: "de",
+  strategy: "overwrite",
+};
+
+const makeLogger = () => ({ error: vi.fn() });
+
+describe("LifecycleNotifier", () => {
+  it("invokes onQueued with the task", async () => {
+    const onQueued = vi.fn();
+    await new LifecycleNotifier({ onQueued }, makeLogger()).queued(task);
+    expect(onQueued).toHaveBeenCalledWith(task);
+  });
+
+  it("invokes onCompleted with the task", async () => {
+    const onCompleted = vi.fn();
+    await new LifecycleNotifier({ onCompleted }, makeLogger()).completed(task);
+    expect(onCompleted).toHaveBeenCalledWith(task);
+  });
+
+  it("invokes onFailed with the task and the error", async () => {
+    const onFailed = vi.fn();
+    const error = new Error("boom");
+    await new LifecycleNotifier({ onFailed }, makeLogger()).failed(task, error);
+    expect(onFailed).toHaveBeenCalledWith(task, error);
+  });
+
+  it("is a no-op (no throw, no log) when the callback is absent", async () => {
+    const logger = makeLogger();
+    await expect(new LifecycleNotifier({}, logger).queued(task)).resolves.toBeUndefined();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("swallows and logs a synchronous throw from a callback", async () => {
+    const logger = makeLogger();
+    const notifier = new LifecycleNotifier(
+      {
+        onQueued: () => {
+          throw new Error("sync boom");
+        },
+      },
+      logger
+    );
+    await expect(notifier.queued(task)).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows and logs an async rejection from a callback", async () => {
+    const logger = makeLogger();
+    const notifier = new LifecycleNotifier(
+      { onCompleted: () => Promise.reject(new Error("async boom")) },
+      logger
+    );
+    await expect(notifier.completed(task)).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows and logs a synchronous throw from an onFailed callback", async () => {
+    const logger = makeLogger();
+    const error = new Error("boom");
+    const notifier = new LifecycleNotifier(
+      {
+        onFailed: () => {
+          throw new Error("sync boom");
+        },
+      },
+      logger
+    );
+    await expect(notifier.failed(task, error)).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows and logs an async rejection from an onFailed callback", async () => {
+    const logger = makeLogger();
+    const error = new Error("boom");
+    const notifier = new LifecycleNotifier(
+      { onFailed: () => Promise.reject(new Error("async boom")) },
+      logger
+    );
+    await expect(notifier.failed(task, error)).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("awaits an async callback before resolving", async () => {
+    let done = false;
+    const notifier = new LifecycleNotifier(
+      {
+        onQueued: async () => {
+          await Promise.resolve();
+          done = true;
+        },
+      },
+      makeLogger()
+    );
+    await notifier.queued(task);
+    expect(done).toBe(true);
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/lifecycle/LifecycleNotifier.ts
+++ b/packages/payload-plugin-translator/src/server/modules/lifecycle/LifecycleNotifier.ts
@@ -1,0 +1,44 @@
+import type { TranslationLifecycleCallbacks, TranslationTask } from "./types";
+
+/** Minimal logger surface used for swallowed callback errors (Payload's `payload.logger` satisfies it). */
+type LifecycleLogger = { error: (obj: unknown) => void };
+
+/**
+ * Fires the host's translation lifecycle callbacks, best-effort. Each callback is invoked in a
+ * try/catch (covering both synchronous throws and rejected promises); a failure is logged and
+ * swallowed, never propagated — a broken host callback must not fail the translation. Absent
+ * callbacks are a no-op.
+ */
+export class LifecycleNotifier {
+  private readonly callbacks: TranslationLifecycleCallbacks;
+  private readonly logger: LifecycleLogger;
+
+  constructor(callbacks: TranslationLifecycleCallbacks, logger: LifecycleLogger) {
+    this.callbacks = callbacks;
+    this.logger = logger;
+  }
+
+  queued(task: TranslationTask): Promise<void> {
+    const callback = this.callbacks.onQueued;
+    return this.safe("lifecycle.onQueued", callback && (() => callback(task)));
+  }
+
+  completed(task: TranslationTask): Promise<void> {
+    const callback = this.callbacks.onCompleted;
+    return this.safe("lifecycle.onCompleted", callback && (() => callback(task)));
+  }
+
+  failed(task: TranslationTask, error: unknown): Promise<void> {
+    const callback = this.callbacks.onFailed;
+    return this.safe("lifecycle.onFailed", callback && (() => callback(task, error)));
+  }
+
+  private async safe(name: string, thunk?: () => void | Promise<void>): Promise<void> {
+    if (!thunk) return;
+    try {
+      await thunk();
+    } catch (error) {
+      this.logger.error({ err: error, msg: `translator: ${name} callback threw` });
+    }
+  }
+}

--- a/packages/payload-plugin-translator/src/server/modules/lifecycle/index.ts
+++ b/packages/payload-plugin-translator/src/server/modules/lifecycle/index.ts
@@ -1,0 +1,6 @@
+// Translation lifecycle callbacks — always-on host hooks fired around the runner (not gated by the
+// provenance opt-in, no schema/migration).
+export { LifecycleNotifier } from "./LifecycleNotifier";
+export { withQueuedNotification } from "./withQueuedNotification";
+export { taskFromHandlerInput, taskFromInput } from "./taskMapping";
+export type { TranslationLifecycleCallbacks, TranslationTask } from "./types";

--- a/packages/payload-plugin-translator/src/server/modules/lifecycle/taskMapping.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/lifecycle/taskMapping.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import type { TaskInput } from "../task-runner/types";
+import type { TaskHandlerInput } from "../task-runner/TaskRunnerProvider.interface";
+import { taskFromInput, taskFromHandlerInput } from "./taskMapping";
+
+// Both mappers project an internal task shape onto the public `TranslationTask`. The two fragile
+// properties are the full field set (incl. `strategy`) and the deliberate omission of
+// `publishOnTranslation` (an internal write concern). `toEqual` (exact match) locks both in — a
+// leaked field or a dropped `strategy` fails here rather than slipping through `objectContaining`.
+
+describe("taskFromInput", () => {
+  it("maps every public field and omits publishOnTranslation", () => {
+    const input: TaskInput = {
+      collectionSlug: "posts",
+      collectionId: "doc-1",
+      sourceLng: "en",
+      targetLng: "de",
+      strategy: "skip_existing",
+      publishOnTranslation: true,
+    };
+    expect(taskFromInput(input)).toEqual({
+      collection: "posts",
+      id: "doc-1",
+      sourceLng: "en",
+      targetLng: "de",
+      strategy: "skip_existing",
+    });
+  });
+});
+
+describe("taskFromHandlerInput", () => {
+  it("maps every public field and omits publishOnTranslation", () => {
+    const input: TaskHandlerInput = {
+      collection: "pages",
+      collectionId: "doc-2",
+      sourceLng: "en",
+      targetLng: "fr",
+      strategy: "overwrite",
+      publishOnTranslation: false,
+    };
+    expect(taskFromHandlerInput(input)).toEqual({
+      collection: "pages",
+      id: "doc-2",
+      sourceLng: "en",
+      targetLng: "fr",
+      strategy: "overwrite",
+    });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/lifecycle/taskMapping.ts
+++ b/packages/payload-plugin-translator/src/server/modules/lifecycle/taskMapping.ts
@@ -1,0 +1,21 @@
+import type { TaskInput } from "../task-runner/types";
+import type { TaskHandlerInput } from "../task-runner/TaskRunnerProvider.interface";
+import type { TranslationTask } from "./types";
+
+/** Map an enqueue-side {@link TaskInput} to the public {@link TranslationTask}. */
+export const taskFromInput = (task: TaskInput): TranslationTask => ({
+  collection: task.collectionSlug,
+  id: task.collectionId,
+  sourceLng: task.sourceLng,
+  targetLng: task.targetLng,
+  strategy: task.strategy,
+});
+
+/** Map an execution-side {@link TaskHandlerInput} to the public {@link TranslationTask}. */
+export const taskFromHandlerInput = (input: TaskHandlerInput): TranslationTask => ({
+  collection: input.collection,
+  id: input.collectionId,
+  sourceLng: input.sourceLng,
+  targetLng: input.targetLng,
+  strategy: input.strategy,
+});

--- a/packages/payload-plugin-translator/src/server/modules/lifecycle/types.ts
+++ b/packages/payload-plugin-translator/src/server/modules/lifecycle/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Descriptor passed to the lifecycle callbacks — a stable, framework-neutral view of one translation
+ * task. Mirrors the fields the runner already threads through; `publishOnTranslation` is intentionally
+ * omitted (an internal write concern, not lifecycle-relevant). `id` is a string: the plugin is
+ * ID-agnostic and normalizes every document id to a string at ingress.
+ *
+ * @since 0.7.0
+ */
+export type TranslationTask = {
+  collection: string;
+  id: string;
+  sourceLng: string;
+  targetLng: string;
+  /**
+   * The resolution strategy for the task. Deliberately widened to `string` (not the internal
+   * `"overwrite" | "skip_existing"` union) so adding a strategy is not a breaking change to this
+   * public type; host callbacks should treat unknown values gracefully.
+   */
+  strategy: string;
+};
+
+/**
+ * Optional server-side hooks the host can supply to react to translation lifecycle events, passed as
+ * the plugin's `lifecycle` config object. Always available (no schema, no migration) and independent
+ * of the `provenance` opt-in. A throwing callback never fails the translation — it is caught and
+ * logged (see {@link LifecycleNotifier}).
+ *
+ * `onCompleted` / `onFailed` fire per **execution attempt**: the Payload Jobs runner may retry a
+ * failed task, so a task that fails then succeeds fires `onFailed` on each failed attempt and
+ * `onCompleted` on the one that succeeds. `onQueued` fires once, when the task is enqueued.
+ *
+ * @since 0.7.0
+ */
+export type TranslationLifecycleCallbacks = {
+  /**
+   * Fired for each task as it is queued. Best-effort: emitted just before the task is handed to the
+   * runner, so if enqueueing then throws it may fire for a task that never actually queued.
+   *
+   * @since 0.7.0
+   */
+  onQueued?: (task: TranslationTask) => void | Promise<void>;
+  /** Fired after a task completes without error. @since 0.7.0 */
+  onCompleted?: (task: TranslationTask) => void | Promise<void>;
+  /** Fired when a task's translation throws, with the error. @since 0.7.0 */
+  onFailed?: (task: TranslationTask, error: unknown) => void | Promise<void>;
+};

--- a/packages/payload-plugin-translator/src/server/modules/lifecycle/withQueuedNotification.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/lifecycle/withQueuedNotification.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import type { CollectionSlug } from "payload";
+import { withQueuedNotification } from "./withQueuedNotification";
+import { LifecycleNotifier } from "./LifecycleNotifier";
+import type { TaskRunner } from "../task-runner/TaskRunner.interface";
+import type { TaskInput } from "../task-runner/types";
+
+const makeRunner = (): TaskRunner => ({
+  enqueue: vi.fn().mockResolvedValue(undefined),
+  cancel: vi.fn().mockResolvedValue(undefined),
+  run: vi.fn().mockResolvedValue({ success: true }),
+  findByCollection: vi.fn().mockResolvedValue([]),
+});
+
+const input = (id: string): TaskInput => ({
+  collectionSlug: "posts" as CollectionSlug,
+  collectionId: id,
+  sourceLng: "en",
+  targetLng: "de",
+  strategy: "overwrite",
+  publishOnTranslation: false,
+});
+
+describe("withQueuedNotification", () => {
+  it("fires queued for each task (mapped to TranslationTask) then delegates enqueue", async () => {
+    const runner = makeRunner();
+    const onQueued = vi.fn();
+    const notifier = new LifecycleNotifier({ onQueued }, { error: vi.fn() });
+
+    const wrapped = withQueuedNotification(runner, notifier);
+    await wrapped.enqueue([input("1"), input("2")]);
+
+    expect(onQueued).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ collection: "posts", id: "1", sourceLng: "en", targetLng: "de" })
+    );
+    expect(onQueued).toHaveBeenNthCalledWith(2, expect.objectContaining({ id: "2" }));
+    expect(runner.enqueue).toHaveBeenCalledWith([input("1"), input("2")]);
+  });
+
+  it("fires queued BEFORE delegating to the runner (ordering vs a synchronous runner)", async () => {
+    const calls: string[] = [];
+    const runner = makeRunner();
+    (runner.enqueue as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      calls.push("enqueue");
+    });
+    const notifier = new LifecycleNotifier(
+      {
+        onQueued: () => {
+          calls.push("queued");
+        },
+      },
+      { error: vi.fn() }
+    );
+
+    await withQueuedNotification(runner, notifier).enqueue([input("1")]);
+
+    expect(calls).toEqual(["queued", "enqueue"]);
+  });
+
+  it("delegates cancel / run / findByCollection unchanged", async () => {
+    const runner = makeRunner();
+    const wrapped = withQueuedNotification(runner, new LifecycleNotifier({}, { error: vi.fn() }));
+
+    await wrapped.cancel(["a"]);
+    await wrapped.run("b");
+    await wrapped.findByCollection("posts" as CollectionSlug, ["c"]);
+
+    expect(runner.cancel).toHaveBeenCalledWith(["a"]);
+    expect(runner.run).toHaveBeenCalledWith("b");
+    expect(runner.findByCollection).toHaveBeenCalledWith("posts", ["c"]);
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/lifecycle/withQueuedNotification.ts
+++ b/packages/payload-plugin-translator/src/server/modules/lifecycle/withQueuedNotification.ts
@@ -1,0 +1,27 @@
+import type { TaskRunner } from "../task-runner/TaskRunner.interface";
+import type { LifecycleNotifier } from "./LifecycleNotifier";
+import { taskFromInput } from "./taskMapping";
+
+/**
+ * Decorate a {@link TaskRunner} so `enqueue` fires the `queued` lifecycle callback for each task.
+ * Fired BEFORE delegating: a synchronous runner (the sync runner) may execute a task inline during
+ * `enqueue` and fire `completed`, so emitting `queued` first preserves the queued → completed order.
+ * All other methods delegate unchanged.
+ */
+export function withQueuedNotification(
+  runner: TaskRunner,
+  notifier: LifecycleNotifier
+): TaskRunner {
+  return {
+    async enqueue(tasks) {
+      for (const task of tasks) {
+        await notifier.queued(taskFromInput(task));
+      }
+      await runner.enqueue(tasks);
+    },
+    cancel: (taskIds) => runner.cancel(taskIds),
+    run: (taskId) => runner.run(taskId),
+    findByCollection: (collectionSlug, documentIds) =>
+      runner.findByCollection(collectionSlug, documentIds),
+  };
+}

--- a/packages/payload-plugin-translator/src/server/modules/lifecycle/withQueuedNotification.ts
+++ b/packages/payload-plugin-translator/src/server/modules/lifecycle/withQueuedNotification.ts
@@ -14,9 +14,7 @@ export function withQueuedNotification(
 ): TaskRunner {
   return {
     async enqueue(tasks) {
-      for (const task of tasks) {
-        await notifier.queued(taskFromInput(task));
-      }
+      await Promise.all(tasks.map((task) => notifier.queued(taskFromInput(task))));
       await runner.enqueue(tasks);
     },
     cancel: (taskIds) => runner.cancel(taskIds),

--- a/packages/payload-plugin-translator/src/server/modules/provenance/PayloadProvenanceStore.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/PayloadProvenanceStore.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Payload } from "payload";
+import type { TranslationProvenanceRecord } from "../../../core/provenance";
+import { PayloadProvenanceStore } from "./PayloadProvenanceStore";
+
+const SLUG = "translator-provenance";
+
+const record: TranslationProvenanceRecord = {
+  collectionSlug: "posts",
+  documentId: "doc-1",
+  targetLocale: "de",
+  sourceLocale: "en",
+  sourceFingerprint: "fp-abc",
+  translatedAt: "2026-07-02T00:00:00.000Z",
+  dismissedFingerprint: null,
+};
+
+describe("PayloadProvenanceStore", () => {
+  let payload: Payload;
+  let store: PayloadProvenanceStore;
+
+  const setFound = (docs: unknown[]) => {
+    (payload.find as ReturnType<typeof vi.fn>).mockResolvedValue({ docs });
+  };
+
+  beforeEach(() => {
+    payload = {
+      find: vi.fn().mockResolvedValue({ docs: [] }),
+      create: vi.fn().mockResolvedValue({}),
+      update: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    } as unknown as Payload;
+    store = new PayloadProvenanceStore(payload, SLUG);
+  });
+
+  describe("upsert", () => {
+    it("creates a new record when none exists for the key", async () => {
+      setFound([]);
+      await store.upsert(record);
+      expect(payload.create).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: SLUG, data: expect.objectContaining(record) })
+      );
+      expect(payload.update).not.toHaveBeenCalled();
+    });
+
+    it("updates the existing record in place, never duplicating", async () => {
+      setFound([{ id: 7, ...record }]);
+      await store.upsert({ ...record, sourceFingerprint: "fp-new" });
+      expect(payload.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collection: SLUG,
+          id: 7,
+          data: expect.objectContaining({ sourceFingerprint: "fp-new" }),
+        })
+      );
+      expect(payload.create).not.toHaveBeenCalled();
+    });
+
+    it("matches the existing record by the composite key", async () => {
+      setFound([]);
+      await store.upsert(record);
+      expect(payload.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collection: SLUG,
+          where: {
+            and: [
+              { collectionSlug: { equals: "posts" } },
+              { documentId: { equals: "doc-1" } },
+              { targetLocale: { equals: "de" } },
+            ],
+          },
+        })
+      );
+    });
+  });
+
+  describe("find", () => {
+    it("returns the record for the key", async () => {
+      setFound([{ id: 7, ...record }]);
+      const result = await store.find({
+        collectionSlug: "posts",
+        documentId: "doc-1",
+        targetLocale: "de",
+      });
+      expect(result).toEqual(record);
+    });
+
+    it("returns null when no record exists", async () => {
+      setFound([]);
+      const result = await store.find({
+        collectionSlug: "posts",
+        documentId: "missing",
+        targetLocale: "de",
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deleteByDocument", () => {
+    it("deletes every record for the document", async () => {
+      await store.deleteByDocument("posts", "doc-1");
+      expect(payload.delete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collection: SLUG,
+          where: {
+            and: [{ collectionSlug: { equals: "posts" } }, { documentId: { equals: "doc-1" } }],
+          },
+        })
+      );
+    });
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/provenance/PayloadProvenanceStore.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/PayloadProvenanceStore.test.ts
@@ -108,5 +108,14 @@ describe("PayloadProvenanceStore", () => {
         })
       );
     });
+
+    it("does not thread `req`, so cleanup runs in its own transaction (best-effort contract)", async () => {
+      // The delete-cleanup guarantee (never roll back the user's delete) relies on this: joining the
+      // primary delete's transaction would let a failed sidecar delete poison it. Lock it in.
+      await store.deleteByDocument("posts", "doc-1");
+      expect(payload.delete).not.toHaveBeenCalledWith(
+        expect.objectContaining({ req: expect.anything() })
+      );
+    });
   });
 });

--- a/packages/payload-plugin-translator/src/server/modules/provenance/PayloadProvenanceStore.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/PayloadProvenanceStore.test.ts
@@ -72,6 +72,32 @@ describe("PayloadProvenanceStore", () => {
         })
       );
     });
+
+    it("falls back to update when a concurrent writer wins the create race", async () => {
+      const findMock = payload.find as ReturnType<typeof vi.fn>;
+      findMock.mockResolvedValueOnce({ docs: [] }).mockResolvedValueOnce({
+        docs: [{ id: 9, ...record }],
+      });
+      (payload.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("unique constraint violation")
+      );
+
+      await expect(store.upsert(record)).resolves.toBeUndefined();
+
+      expect(payload.update).toHaveBeenCalledWith(
+        expect.objectContaining({ collection: SLUG, id: 9, data: expect.objectContaining(record) })
+      );
+    });
+
+    it("rethrows the original create error when the race-fallback re-find also finds nothing", async () => {
+      setFound([]);
+      const createError = new Error("unique constraint violation");
+      (payload.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(createError);
+
+      await expect(store.upsert(record)).rejects.toBe(createError);
+
+      expect(payload.update).not.toHaveBeenCalled();
+    });
   });
 
   describe("find", () => {
@@ -93,6 +119,28 @@ describe("PayloadProvenanceStore", () => {
         targetLocale: "de",
       });
       expect(result).toBeNull();
+    });
+
+    it("normalizes a Date translatedAt to an ISO-8601 string", async () => {
+      // Payload's `date` field may hand back a Date; #50's fingerprint comparison needs a stable ISO
+      // string, so toRecord must convert it.
+      setFound([{ id: 7, ...record, translatedAt: new Date("2026-07-02T00:00:00.000Z") }]);
+      const result = await store.find({
+        collectionSlug: "posts",
+        documentId: "doc-1",
+        targetLocale: "de",
+      });
+      expect(result?.translatedAt).toBe("2026-07-02T00:00:00.000Z");
+    });
+
+    it("preserves a non-null dismissedFingerprint as a string", async () => {
+      setFound([{ id: 7, ...record, dismissedFingerprint: "fp-dismissed" }]);
+      const result = await store.find({
+        collectionSlug: "posts",
+        documentId: "doc-1",
+        targetLocale: "de",
+      });
+      expect(result?.dismissedFingerprint).toBe("fp-dismissed");
     });
   });
 

--- a/packages/payload-plugin-translator/src/server/modules/provenance/PayloadProvenanceStore.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/PayloadProvenanceStore.ts
@@ -1,0 +1,90 @@
+import type { CollectionSlug, Payload, Where } from "payload";
+import type {
+  ProvenanceKey,
+  ProvenanceStore,
+  TranslationProvenanceRecord,
+} from "../../../core/provenance";
+
+interface ProvenanceDoc extends Record<string, unknown> {
+  id: string | number;
+}
+
+function keyWhere(key: ProvenanceKey): Where {
+  return {
+    and: [
+      { collectionSlug: { equals: key.collectionSlug } },
+      { documentId: { equals: key.documentId } },
+      { targetLocale: { equals: key.targetLocale } },
+    ],
+  };
+}
+
+function toRecord(doc: ProvenanceDoc): TranslationProvenanceRecord {
+  return {
+    collectionSlug: String(doc.collectionSlug),
+    documentId: String(doc.documentId),
+    targetLocale: String(doc.targetLocale),
+    sourceLocale: String(doc.sourceLocale),
+    sourceFingerprint: String(doc.sourceFingerprint),
+    // `translatedAt` is backed by a `date` field, which Payload may hand back as a Date; normalize to
+    // ISO-8601 so the stored contract holds and #50's fingerprint comparison stays format-stable.
+    translatedAt: new Date(doc.translatedAt as string | number | Date).toISOString(),
+    dismissedFingerprint:
+      doc.dismissedFingerprint == null ? null : String(doc.dismissedFingerprint),
+  };
+}
+
+/**
+ * Payload-backed {@link ProvenanceStore}. All Payload coupling for provenance lives here; the core
+ * knows only the port. Records are keyed by `(collectionSlug, documentId, targetLocale)`; `upsert`
+ * matches on that key so a re-translation updates the row in place instead of duplicating it.
+ *
+ * The sidecar holds custom fields that no generated collection type describes, so the slug is cast to
+ * `CollectionSlug` once; the record shape is guaranteed by {@link makeProvenanceCollection}.
+ */
+export class PayloadProvenanceStore implements ProvenanceStore {
+  private readonly payload: Payload;
+  private readonly collection: CollectionSlug;
+
+  constructor(payload: Payload, slug: string) {
+    this.payload = payload;
+    this.collection = slug as CollectionSlug;
+  }
+
+  async upsert(record: TranslationProvenanceRecord): Promise<void> {
+    const existing = await this.findDoc(record);
+    if (existing === null) {
+      await this.payload.create({ collection: this.collection, data: record });
+    } else {
+      await this.payload.update({ collection: this.collection, id: existing.id, data: record });
+    }
+  }
+
+  async find(key: ProvenanceKey): Promise<TranslationProvenanceRecord | null> {
+    const doc = await this.findDoc(key);
+    return doc === null ? null : toRecord(doc);
+  }
+
+  async deleteByDocument(collectionSlug: string, documentId: string): Promise<void> {
+    await this.payload.delete({
+      collection: this.collection,
+      where: {
+        and: [
+          { collectionSlug: { equals: collectionSlug } },
+          { documentId: { equals: documentId } },
+        ],
+      },
+    });
+  }
+
+  private async findDoc(key: ProvenanceKey): Promise<ProvenanceDoc | null> {
+    const result = await this.payload.find({
+      collection: this.collection,
+      where: keyWhere(key),
+      limit: 1,
+      depth: 0,
+      pagination: false,
+    });
+    return (result.docs[0] as ProvenanceDoc | undefined) ?? null;
+  }
+}

--- a/packages/payload-plugin-translator/src/server/modules/provenance/PayloadProvenanceStore.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/PayloadProvenanceStore.ts
@@ -5,6 +5,9 @@ import type {
   TranslationProvenanceRecord,
 } from "../../../core/provenance";
 
+/** Builds a provenance store bound to a Payload instance; absent when provenance is disabled. */
+export type ProvenanceStoreFactory = (payload: Payload) => ProvenanceStore;
+
 interface ProvenanceDoc extends Record<string, unknown> {
   id: string | number;
 }
@@ -54,7 +57,13 @@ export class PayloadProvenanceStore implements ProvenanceStore {
   async upsert(record: TranslationProvenanceRecord): Promise<void> {
     const existing = await this.findDoc(record);
     if (existing === null) {
-      await this.payload.create({ collection: this.collection, data: record });
+      try {
+        await this.payload.create({ collection: this.collection, data: record });
+      } catch (error) {
+        const raceWinner = await this.findDoc(record);
+        if (raceWinner === null) throw error;
+        await this.payload.update({ collection: this.collection, id: raceWinner.id, data: record });
+      }
     } else {
       await this.payload.update({ collection: this.collection, id: existing.id, data: record });
     }

--- a/packages/payload-plugin-translator/src/server/modules/provenance/index.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/index.ts
@@ -6,5 +6,6 @@ export {
   makeProvenanceCollection,
 } from "./provenanceCollection";
 export { PayloadProvenanceStore } from "./PayloadProvenanceStore";
+export type { ProvenanceStoreFactory } from "./PayloadProvenanceStore";
 export { injectProvenanceCleanup, makeProvenanceCleanupHook } from "./provenanceCleanupHook";
 export { assertProvenanceSlugFree } from "./slugGuard";

--- a/packages/payload-plugin-translator/src/server/modules/provenance/index.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/index.ts
@@ -1,5 +1,9 @@
 // Provenance adapter (Payload-backed). The framework-agnostic port + record types live in the core
 // (src/core/provenance); this module is the plugin-side implementation.
-export { DEFAULT_PROVENANCE_SLUG, makeProvenanceCollection } from "./provenanceCollection";
+export {
+  DEFAULT_PROVENANCE_SLUG,
+  isProvenanceCollection,
+  makeProvenanceCollection,
+} from "./provenanceCollection";
 export { PayloadProvenanceStore } from "./PayloadProvenanceStore";
 export { assertProvenanceSlugFree } from "./slugGuard";

--- a/packages/payload-plugin-translator/src/server/modules/provenance/index.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/index.ts
@@ -1,0 +1,5 @@
+// Provenance adapter (Payload-backed). The framework-agnostic port + record types live in the core
+// (src/core/provenance); this module is the plugin-side implementation.
+export { DEFAULT_PROVENANCE_SLUG, makeProvenanceCollection } from "./provenanceCollection";
+export { PayloadProvenanceStore } from "./PayloadProvenanceStore";
+export { assertProvenanceSlugFree } from "./slugGuard";

--- a/packages/payload-plugin-translator/src/server/modules/provenance/index.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/index.ts
@@ -6,4 +6,5 @@ export {
   makeProvenanceCollection,
 } from "./provenanceCollection";
 export { PayloadProvenanceStore } from "./PayloadProvenanceStore";
+export { injectProvenanceCleanup, makeProvenanceCleanupHook } from "./provenanceCleanupHook";
 export { assertProvenanceSlugFree } from "./slugGuard";

--- a/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCleanupHook.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCleanupHook.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Config, Payload } from "payload";
+
+import type { ProvenanceStore } from "../../../core/provenance";
+import { injectProvenanceCleanup, makeProvenanceCleanupHook } from "./provenanceCleanupHook";
+
+const makeStore = () =>
+  ({
+    upsert: vi.fn().mockResolvedValue(undefined),
+    find: vi.fn().mockResolvedValue(null),
+    deleteByDocument: vi.fn().mockResolvedValue(undefined),
+  }) satisfies ProvenanceStore;
+
+const makePayload = () => ({ logger: { error: vi.fn() } }) as unknown as Payload;
+
+// A minimal afterDelete hook arg — only the fields the cleanup hook reads.
+const hookArg = (id: string | number, slug = "posts", payload = makePayload()) =>
+  ({ id, collection: { slug }, req: { payload } }) as never;
+
+describe("makeProvenanceCleanupHook", () => {
+  it("deletes the document's provenance rows via the store", async () => {
+    const store = makeStore();
+    const hook = makeProvenanceCleanupHook(() => store, "translator-provenance");
+    await hook(hookArg("doc-1", "posts"));
+    expect(store.deleteByDocument).toHaveBeenCalledWith("posts", "doc-1");
+  });
+
+  it("stringifies a numeric id to match the stored documentId", async () => {
+    const store = makeStore();
+    const hook = makeProvenanceCleanupHook(() => store, "translator-provenance");
+    await hook(hookArg(42, "posts"));
+    expect(store.deleteByDocument).toHaveBeenCalledWith("posts", "42");
+  });
+
+  it("uses the deleted collection's slug from the hook arg", async () => {
+    const store = makeStore();
+    const hook = makeProvenanceCleanupHook(() => store, "translator-provenance");
+    await hook(hookArg("doc-1", "pages"));
+    expect(store.deleteByDocument).toHaveBeenCalledWith("pages", "doc-1");
+  });
+
+  it("swallows and logs a cleanup failure — never throws (best-effort)", async () => {
+    const store = makeStore();
+    store.deleteByDocument = vi.fn().mockRejectedValue(new Error("db down"));
+    const payload = makePayload();
+    const hook = makeProvenanceCleanupHook(() => store, "translator-provenance");
+    await expect(hook(hookArg("doc-1", "posts", payload))).resolves.toBeUndefined();
+    expect(payload.logger.error).toHaveBeenCalled();
+  });
+});
+
+describe("injectProvenanceCleanup", () => {
+  const config = (slugs: string[]): Config =>
+    ({ collections: slugs.map((slug) => ({ slug })) }) as unknown as Config;
+
+  it("attaches the hook only to managed collections", () => {
+    const store = makeStore();
+    const cfg = config(["posts", "media"]);
+    injectProvenanceCleanup(cfg, new Set(["posts"]), () => store, "translator-provenance");
+    const [posts, media] = cfg.collections as Array<Record<string, any>>;
+    expect(posts.hooks.afterDelete).toHaveLength(1);
+    expect(media.hooks?.afterDelete).toBeUndefined();
+  });
+
+  it("appends to a consumer-supplied afterDelete array, preserving existing hooks", () => {
+    const store = makeStore();
+    const existing = vi.fn();
+    const cfg = {
+      collections: [{ slug: "posts", hooks: { afterDelete: [existing] } }],
+    } as unknown as Config;
+    injectProvenanceCleanup(cfg, new Set(["posts"]), () => store, "translator-provenance");
+    const posts = cfg.collections?.[0] as Record<string, any>;
+    expect(posts.hooks.afterDelete).toHaveLength(2);
+    expect(posts.hooks.afterDelete[0]).toBe(existing);
+  });
+
+  it("is idempotent per slug — running twice with the same slug does not stack duplicate hooks", () => {
+    const store = makeStore();
+    const cfg = config(["posts"]);
+    injectProvenanceCleanup(cfg, new Set(["posts"]), () => store, "translator-provenance");
+    injectProvenanceCleanup(cfg, new Set(["posts"]), () => store, "translator-provenance");
+    const posts = cfg.collections?.[0] as Record<string, any>;
+    expect(posts.hooks.afterDelete).toHaveLength(1);
+  });
+
+  it("attaches a separate hook per slug — two instances with different slugs both clean up", () => {
+    const store = makeStore();
+    const cfg = config(["posts"]);
+    injectProvenanceCleanup(cfg, new Set(["posts"]), () => store, "provenance-a");
+    injectProvenanceCleanup(cfg, new Set(["posts"]), () => store, "provenance-b");
+    const posts = cfg.collections?.[0] as Record<string, any>;
+    expect(posts.hooks.afterDelete).toHaveLength(2);
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCleanupHook.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCleanupHook.ts
@@ -1,0 +1,67 @@
+import type { CollectionAfterDeleteHook, Config, Payload } from "payload";
+
+import type { ProvenanceStore } from "../../../core/provenance";
+
+/**
+ * Marks the plugin's own provenance cleanup hook so a repeated `init()` can recognise an
+ * already-injected hook and stay idempotent. Same idea as `isProvenanceCollection`, but a hook is a
+ * bare function with no `custom` bag, so the marker lives as a property on the function itself
+ * (safe because the config is mutated in place — no JSON clone strips it between `init()` runs). The
+ * marker holds the provenance *slug*, so two plugin instances with different slugs each attach their
+ * own hook (mirrors the per-slug sidecar guard in `plugin.ts`), while a repeated run of the same slug
+ * is deduped.
+ */
+type MarkedHook = CollectionAfterDeleteHook & { __translatorProvenanceCleanup?: string };
+
+/**
+ * Build the `afterDelete` hook that cascade-deletes a document's provenance rows for `provenanceSlug`.
+ *
+ * Best-effort by design: the store's delete runs in its own transaction (the store does not thread
+ * `req`), and any failure is swallowed and logged — so cleanup can never roll back or fail the user's
+ * document delete. `id` is `number | string`, so it is stringified to match the stored `documentId`.
+ */
+export function makeProvenanceCleanupHook(
+  storeFactory: (payload: Payload) => ProvenanceStore,
+  provenanceSlug: string
+): CollectionAfterDeleteHook {
+  const hook: MarkedHook = async ({ id, collection, req }) => {
+    try {
+      const store = storeFactory(req.payload);
+      await store.deleteByDocument(collection.slug, String(id));
+    } catch (error) {
+      req.payload.logger.error({
+        err: error,
+        collection: collection.slug,
+        documentId: String(id),
+        msg: "translator: failed to clean up provenance records after document delete",
+      });
+    }
+  };
+  hook.__translatorProvenanceCleanup = provenanceSlug;
+  return hook;
+}
+
+/**
+ * Attach the provenance cleanup hook to every managed (translatable) collection on `config`, appending
+ * to any consumer-supplied `afterDelete` array. Idempotent per `provenanceSlug`: a collection that
+ * already carries this slug's cleanup hook is skipped, so a repeated `init()` never stacks duplicates,
+ * yet a second instance with a different slug still attaches its own hook. The sidecar collection is
+ * never in `managedSlugs`, so it is never hooked (no recursion).
+ */
+export function injectProvenanceCleanup(
+  config: Config,
+  managedSlugs: Set<string>,
+  storeFactory: (payload: Payload) => ProvenanceStore,
+  provenanceSlug: string
+): void {
+  const hook = makeProvenanceCleanupHook(storeFactory, provenanceSlug);
+  for (const collection of config.collections ?? []) {
+    if (!managedSlugs.has(collection.slug)) continue;
+    collection.hooks ??= {};
+    collection.hooks.afterDelete ??= [];
+    const alreadyInjected = collection.hooks.afterDelete.some(
+      (existing) => (existing as MarkedHook).__translatorProvenanceCleanup === provenanceSlug
+    );
+    if (!alreadyInjected) collection.hooks.afterDelete.push(hook);
+  }
+}

--- a/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCleanupHook.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCleanupHook.ts
@@ -1,6 +1,6 @@
-import type { CollectionAfterDeleteHook, Config, Payload } from "payload";
+import type { CollectionAfterDeleteHook, Config } from "payload";
 
-import type { ProvenanceStore } from "../../../core/provenance";
+import type { ProvenanceStoreFactory } from "./PayloadProvenanceStore";
 
 /**
  * Marks the plugin's own provenance cleanup hook so a repeated `init()` can recognise an
@@ -21,7 +21,7 @@ type MarkedHook = CollectionAfterDeleteHook & { __translatorProvenanceCleanup?: 
  * document delete. `id` is `number | string`, so it is stringified to match the stored `documentId`.
  */
 export function makeProvenanceCleanupHook(
-  storeFactory: (payload: Payload) => ProvenanceStore,
+  storeFactory: ProvenanceStoreFactory,
   provenanceSlug: string
 ): CollectionAfterDeleteHook {
   const hook: MarkedHook = async ({ id, collection, req }) => {
@@ -51,7 +51,7 @@ export function makeProvenanceCleanupHook(
 export function injectProvenanceCleanup(
   config: Config,
   managedSlugs: Set<string>,
-  storeFactory: (payload: Payload) => ProvenanceStore,
+  storeFactory: ProvenanceStoreFactory,
   provenanceSlug: string
 ): void {
   const hook = makeProvenanceCleanupHook(storeFactory, provenanceSlug);

--- a/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCollection.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCollection.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { makeProvenanceCollection, DEFAULT_PROVENANCE_SLUG } from "./provenanceCollection";
+
+describe("makeProvenanceCollection", () => {
+  it("defaults to the translator-provenance slug", () => {
+    expect(DEFAULT_PROVENANCE_SLUG).toBe("translator-provenance");
+    expect(makeProvenanceCollection().slug).toBe("translator-provenance");
+  });
+
+  it("honours a slug override", () => {
+    expect(makeProvenanceCollection("custom-provenance").slug).toBe("custom-provenance");
+  });
+
+  it("is hidden from the admin UI", () => {
+    expect(makeProvenanceCollection().admin?.hidden).toBe(true);
+  });
+
+  it("declares all provenance fields with portable types", () => {
+    const collection = makeProvenanceCollection();
+    const byName = new Map(
+      collection.fields
+        .filter((f): f is typeof f & { name: string } => "name" in f)
+        .map((f) => [f.name, f.type])
+    );
+    expect(byName.get("collectionSlug")).toBe("text");
+    expect(byName.get("documentId")).toBe("text");
+    expect(byName.get("targetLocale")).toBe("text");
+    expect(byName.get("sourceLocale")).toBe("text");
+    expect(byName.get("sourceFingerprint")).toBe("text");
+    expect(byName.get("translatedAt")).toBe("date");
+    expect(byName.get("dismissedFingerprint")).toBe("text");
+  });
+
+  it("has a composite unique index on the upsert key", () => {
+    const collection = makeProvenanceCollection();
+    const composite = collection.indexes?.find(
+      (idx) => idx.fields.length === 3 && idx.fields.includes("collectionSlug")
+    );
+    expect(composite).toBeDefined();
+    expect(composite?.fields).toEqual(["collectionSlug", "documentId", "targetLocale"]);
+    expect(composite?.unique).toBe(true);
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCollection.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCollection.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { makeProvenanceCollection, DEFAULT_PROVENANCE_SLUG } from "./provenanceCollection";
+import {
+  makeProvenanceCollection,
+  isProvenanceCollection,
+  DEFAULT_PROVENANCE_SLUG,
+} from "./provenanceCollection";
 
 describe("makeProvenanceCollection", () => {
   it("defaults to the translator-provenance slug", () => {
@@ -13,6 +17,10 @@ describe("makeProvenanceCollection", () => {
 
   it("is hidden from the admin UI", () => {
     expect(makeProvenanceCollection().admin?.hidden).toBe(true);
+  });
+
+  it("carries a marker so plugin wiring can recognise its own collection (idempotent re-runs)", () => {
+    expect(makeProvenanceCollection().custom?.translatorProvenance).toBe(true);
   });
 
   it("declares all provenance fields with portable types", () => {
@@ -39,5 +47,27 @@ describe("makeProvenanceCollection", () => {
     expect(composite).toBeDefined();
     expect(composite?.fields).toEqual(["collectionSlug", "documentId", "targetLocale"]);
     expect(composite?.unique).toBe(true);
+  });
+});
+
+describe("isProvenanceCollection", () => {
+  it("returns false for a collection with no custom field at all", () => {
+    expect(isProvenanceCollection({ slug: "posts" } as { custom?: unknown })).toBe(false);
+  });
+
+  it("returns false for an empty custom object", () => {
+    expect(isProvenanceCollection({ custom: {} })).toBe(false);
+  });
+
+  it("returns false for an unrelated custom key", () => {
+    expect(isProvenanceCollection({ custom: { someOtherKey: true } })).toBe(false);
+  });
+
+  it("returns true when the translatorProvenance marker is true", () => {
+    expect(isProvenanceCollection({ custom: { translatorProvenance: true } })).toBe(true);
+  });
+
+  it("returns false for a non-boolean truthy marker value", () => {
+    expect(isProvenanceCollection({ custom: { translatorProvenance: "true" } })).toBe(false);
   });
 });

--- a/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCollection.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCollection.ts
@@ -1,0 +1,32 @@
+import type { CollectionConfig } from "payload";
+
+/** Default slug for the provenance sidecar collection. Overridable via `provenance.slug`. */
+export const DEFAULT_PROVENANCE_SLUG = "translator-provenance";
+
+/**
+ * Build the Payload config for the provenance sidecar collection.
+ *
+ * Deliberately minimal and DB-portable — only `text`/`date` fields and one composite index — so the
+ * same config yields a trivial migration on SQL (Postgres/SQLite) and an inferred collection on
+ * MongoDB. The collection is hidden from the admin UI: it is plugin-managed bookkeeping, not editor
+ * content. The composite index on `(collectionSlug, documentId, targetLocale)` is the upsert key.
+ *
+ * The plugin ships only this config; the consumer's Payload creates the table (see the design doc's
+ * SQL-migration note). Enabled only when the consumer opts in via `provenance` (wired in slice B).
+ */
+export function makeProvenanceCollection(slug: string = DEFAULT_PROVENANCE_SLUG): CollectionConfig {
+  return {
+    slug,
+    admin: { hidden: true },
+    fields: [
+      { name: "collectionSlug", type: "text", required: true, index: true },
+      { name: "documentId", type: "text", required: true, index: true },
+      { name: "targetLocale", type: "text", required: true },
+      { name: "sourceLocale", type: "text", required: true },
+      { name: "sourceFingerprint", type: "text", required: true },
+      { name: "translatedAt", type: "date", required: true },
+      { name: "dismissedFingerprint", type: "text" },
+    ],
+    indexes: [{ fields: ["collectionSlug", "documentId", "targetLocale"], unique: true }],
+  };
+}

--- a/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCollection.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/provenanceCollection.ts
@@ -3,6 +3,18 @@ import type { CollectionConfig } from "payload";
 /** Default slug for the provenance sidecar collection. Overridable via `provenance.slug`. */
 export const DEFAULT_PROVENANCE_SLUG = "translator-provenance";
 
+/** The `custom` marker tagging the plugin's own provenance sidecar (set + read in this module). */
+const PROVENANCE_MARKER = "translatorProvenance";
+
+/**
+ * True for the plugin's own provenance sidecar collection. Recognised by the {@link PROVENANCE_MARKER}
+ * on `custom` (not the slug, which is consumer-configurable), so plugin wiring can stay idempotent on
+ * a repeated run and the slug-collision guard can ignore an already-added sidecar.
+ */
+export function isProvenanceCollection(collection: { custom?: unknown }): boolean {
+  return (collection.custom as Record<string, unknown> | undefined)?.[PROVENANCE_MARKER] === true;
+}
+
 /**
  * Build the Payload config for the provenance sidecar collection.
  *
@@ -18,6 +30,9 @@ export function makeProvenanceCollection(slug: string = DEFAULT_PROVENANCE_SLUG)
   return {
     slug,
     admin: { hidden: true },
+    // Marker so plugin wiring can recognise its own collection ({@link isProvenanceCollection}) — lets
+    // a repeated plugin run stay idempotent and lets the slug-collision guard ignore its own sidecar.
+    custom: { [PROVENANCE_MARKER]: true },
     fields: [
       { name: "collectionSlug", type: "text", required: true, index: true },
       { name: "documentId", type: "text", required: true, index: true },

--- a/packages/payload-plugin-translator/src/server/modules/provenance/slugGuard.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/slugGuard.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { assertProvenanceSlugFree } from "./slugGuard";
+
+describe("assertProvenanceSlugFree", () => {
+  it("passes when the slug is not used by any collection", () => {
+    expect(() =>
+      assertProvenanceSlugFree("translator-provenance", [{ slug: "posts" }, { slug: "pages" }])
+    ).not.toThrow();
+  });
+
+  it("throws a clear error when the slug collides", () => {
+    expect(() => assertProvenanceSlugFree("posts", [{ slug: "posts" }, { slug: "pages" }])).toThrow(
+      /posts/u
+    );
+  });
+
+  it("tolerates an empty collection list", () => {
+    expect(() => assertProvenanceSlugFree("translator-provenance", [])).not.toThrow();
+  });
+});

--- a/packages/payload-plugin-translator/src/server/modules/provenance/slugGuard.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/slugGuard.ts
@@ -1,0 +1,24 @@
+/**
+ * Fail fast if the provenance sidecar slug collides with a collection the consumer already defines.
+ * Sharing a table would silently corrupt both — better a clear startup error telling the consumer to
+ * set `provenance.slug`.
+ *
+ * Compares by exact slug: this catches the common footgun — a consumer collection already using this
+ * slug — and is correct on every adapter (on MongoDB the slug IS the collection name). It does NOT
+ * try to model SQL table-name derivation: `@payloadcms/drizzle` snake-cases slugs and honours
+ * `dbName` overrides, so case/separator variants (`translatorProvenance` vs `translator-provenance`)
+ * or `dbName` collisions are not detected here. Robust table-name collision detection, if it proves
+ * necessary, belongs at plugin init where the full `CollectionConfig` (including `dbName`) is
+ * available — not in this slug-only helper.
+ */
+export function assertProvenanceSlugFree(
+  slug: string,
+  collections: ReadonlyArray<{ slug: string }>
+): void {
+  if (collections.some((collection) => collection.slug === slug)) {
+    throw new Error(
+      `[payload-plugin-translator] provenance slug "${slug}" collides with an existing collection. ` +
+        "Set a distinct slug via the plugin's provenance.slug option."
+    );
+  }
+}


### PR DESCRIPTION
Implements **#47** — record translation provenance and emit lifecycle events. Phase 2, built on the framework-agnostic core extracted in #60.

Design doc: `packages/payload-plugin-translator/docs/plans/2026-06-26-translation-provenance-and-lifecycle-design.md` (finalized — all 7 open questions resolved).

## Key decisions
- **Provenance collection is opt-in** (default OFF, enabled by a `provenance` config key). A new collection needs a consumer SQL migration we can't run for them, so it must not be forced silently.
- **Lifecycle callbacks are always-on** — no schema, no migration.
- Non-breaking → ships as **`feat` minor `0.7.0`**; public API additions get `@since 0.7.0`.
- Fingerprint reuses the core `projectTranslatableContent` + `fingerprint` (no new algorithm).
- Sidecar slug `translator-provenance` (hidden, `provenance.slug` override, fail-fast on collision).

## Plan (slices — TDD, each via `/sp-finalize` before its commit)
- [x] **Slice A** — `ProvenanceStore` port + record type in `@core`; sidecar collection factory; Payload-backed store (upsert / find / deleteByDocument); startup collision guard. No wiring.
- [x] **Slice B** — write provenance on successful translation, **behind the opt-in flag**; wire the collection + store into `plugin.ts`; compute `sourceFingerprint` and upsert.
- [x] **Slice C** — lifecycle callbacks (`lifecycle: { onQueued, onCompleted, onFailed }`) + `TranslationTask` type; fire queued/completed/failed; swallow-and-log callback errors. Always-on.
- [x] **Slice D** — `afterDelete` cascade-clean (when enabled) + README (opt-in config, required SQL migration step, callbacks API, `@since 0.7.0`).

## Acceptance criteria (from #47)
- [x] After a translation completes, provenance for `(doc, locale)` is queryable.
- [x] Provenance captures enough to later detect source drift (fingerprint + source locale + timestamp).
- [x] Config callbacks fire on queued / completed / failed with the task descriptor.
- [x] Storage is namespaced and does not force schema changes on consumer collections.

## Pending confirmation
Four decisions carry recommended defaults, marked `[pending confirm]` in the design doc (scope, sidecar slug, callback-error semantics, delete cleanup). Will lock before the relevant slice is coded.

Closes #47.



