### PR TITLE
feature/seo rework design tokens

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -207,7 +207,7 @@
     },
     "packages/payload-plugin-analytics": {
       "name": "@focus-reactive/payload-plugin-analytics",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "dependencies": {
         "@google-analytics/data": "^5.2.2",
         "class-variance-authority": "0.7.1",
@@ -244,7 +244,7 @@
         "@payloadcms/ui": "^3.0.0",
         "@tanstack/react-query": "^5.59.0",
         "lucide-react": "^0.469.0",
-        "next": "^14.0.0 || ^15.0.0",
+        "next": "^14.1.0 || ^15.0.0",
         "payload": "^3.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-day-picker": "^9.0.0",
@@ -259,7 +259,7 @@
     },
     "packages/payload-plugin-comments": {
       "name": "@focus-reactive/payload-plugin-comments",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@tanstack/react-query": "5.0.0",
@@ -301,7 +301,7 @@
     },
     "packages/payload-plugin-presets": {
       "name": "@focus-reactive/payload-plugin-presets",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
         "@radix-ui/react-popover": "1.1.15",
       },
@@ -341,7 +341,7 @@
     },
     "packages/payload-plugin-seo": {
       "name": "@focus-reactive/payload-plugin-seo",
-      "version": "1.5.0",
+      "version": "1.9.0",
       "dependencies": {
         "@yoast/search-metadata-previews": "^3.0.0",
         "class-variance-authority": "0.7.1",
@@ -354,7 +354,7 @@
         "@payloadcms/richtext-lexical": "3.84.1",
         "@payloadcms/ui": "3.84.1",
         "@tailwindcss/postcss": "^4.0.0",
-        "@types/node": "^25.7.0",
+        "@types/node": "^26.1.0",
         "@types/react": "19.2.9",
         "@types/react-dom": "19.2.3",
         "lucide-react": "^0.469.0",
@@ -387,7 +387,7 @@
     },
     "packages/payload-plugin-translator": {
       "name": "@focus-reactive/payload-plugin-translator",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-popover": "^1.1.0",
@@ -3664,7 +3664,7 @@
 
     "@focus-reactive/payload-plugin-scheduling/typescript": ["typescript@5.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw=="],
 
-    "@focus-reactive/payload-plugin-seo/@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+    "@focus-reactive/payload-plugin-seo/@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "@focus-reactive/payload-plugin-seo/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
@@ -4668,7 +4668,7 @@
 
     "@focus-reactive/payload-plugin-comments/@tanstack/react-query/@tanstack/query-core": ["@tanstack/query-core@5.0.0", "", {}, "sha512-Y1BpiA6BblJd/UlVqxEVeAG7IACn568YJuTTItAiecBI7En+33g780kg+/8lhgl+BzcUPN7o+NjBrSRGJoemyQ=="],
 
-    "@focus-reactive/payload-plugin-seo/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "@focus-reactive/payload-plugin-seo/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "@focus-reactive/payload-plugin-translator/vitest/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 

--- a/packages/payload-plugin-seo/package.json
+++ b/packages/payload-plugin-seo/package.json
@@ -60,7 +60,7 @@
     }
   },
   "scripts": {
-    "build": "tsup && tsc --emitDeclarationOnly --declarationMap",
+    "build": "tsup && tsc -p tsconfig.build.json --emitDeclarationOnly --declarationMap",
     "dev": "tsup --watch",
     "lint": "ultracite check",
     "lint:fix": "ultracite fix",
@@ -102,7 +102,7 @@
     "@payloadcms/richtext-lexical": "3.84.1",
     "@payloadcms/ui": "3.84.1",
     "@tailwindcss/postcss": "^4.0.0",
-    "@types/node": "^25.7.0",
+    "@types/node": "^26.1.0",
     "@types/react": "19.2.9",
     "@types/react-dom": "19.2.3",
     "lucide-react": "^0.469.0",

--- a/packages/payload-plugin-seo/scripts/prefix-classes.ts
+++ b/packages/payload-plugin-seo/scripts/prefix-classes.ts
@@ -1,3 +1,7 @@
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+
 const PREFIX = "frseo";
 
 const COMPONENT_CLASS_PREFIX = "frseo-";
@@ -15,4 +19,180 @@ export function prefixClassList(classList: string): string {
       return `${PREFIX}:${part}`;
     })
     .join("");
+}
+
+type Replacement = {
+  start: number;
+  end: number;
+  text: string;
+};
+
+export function transformSource(
+  code: string,
+  fileName: string
+): { code: string; changed: boolean } {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    code,
+    ts.ScriptTarget.ES2022,
+    true,
+    ts.ScriptKind.JS
+  );
+  const replacements: Replacement[] = [];
+
+  const fail = (node: ts.Node, message: string): never => {
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+    throw new Error(`[prefix-classes] ${fileName}:${line + 1}:${character + 1} — ${message}`);
+  };
+
+  const replaceLiteral = (node: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral): void => {
+    const next = prefixClassList(node.text);
+    if (next !== node.text) {
+      replacements.push({
+        start: node.getStart(sourceFile),
+        end: node.getEnd(),
+        text: JSON.stringify(next),
+      });
+    }
+  };
+
+  const transformClassSubtree = (node: ts.Node): void => {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      replaceLiteral(node);
+      return;
+    }
+    if (ts.isTemplateExpression(node)) {
+      fail(
+        node,
+        "template literal with substitutions in a class-list position; use cn() with string literals"
+      );
+    }
+    if (ts.isConditionalExpression(node)) {
+      transformClassSubtree(node.whenTrue);
+      transformClassSubtree(node.whenFalse);
+      return;
+    }
+    if (ts.isBinaryExpression(node)) {
+      const op = node.operatorToken.kind;
+      if (
+        op === ts.SyntaxKind.AmpersandAmpersandToken ||
+        op === ts.SyntaxKind.BarBarToken ||
+        op === ts.SyntaxKind.QuestionQuestionToken
+      ) {
+        transformClassSubtree(node.right);
+      }
+      return;
+    }
+    if (ts.isParenthesizedExpression(node)) {
+      transformClassSubtree(node.expression);
+      return;
+    }
+    if (ts.isArrayLiteralExpression(node)) {
+      for (const element of node.elements) {
+        transformClassSubtree(element);
+      }
+      return;
+    }
+    if (ts.isObjectLiteralExpression(node)) {
+      for (const prop of node.properties) {
+        if (ts.isPropertyAssignment(prop) && ts.isStringLiteral(prop.name)) {
+          replaceLiteral(prop.name);
+        }
+      }
+      return;
+    }
+    // Calls, identifiers, property access, etc.: never descend.
+  };
+
+  const propName = (name: ts.PropertyName): string | undefined => {
+    if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+      return name.text;
+    }
+    return undefined;
+  };
+
+  const transformCva = (call: ts.CallExpression): void => {
+    const [base, config] = call.arguments;
+    if (base) {
+      transformClassSubtree(base);
+    }
+    if (!(config && ts.isObjectLiteralExpression(config))) {
+      return;
+    }
+    for (const prop of config.properties) {
+      if (!ts.isPropertyAssignment(prop)) {
+        continue;
+      }
+      const key = propName(prop.name);
+      if (key === "variants" && ts.isObjectLiteralExpression(prop.initializer)) {
+        for (const group of prop.initializer.properties) {
+          if (ts.isPropertyAssignment(group) && ts.isObjectLiteralExpression(group.initializer)) {
+            for (const option of group.initializer.properties) {
+              if (ts.isPropertyAssignment(option)) {
+                transformClassSubtree(option.initializer);
+              }
+            }
+          }
+        }
+      }
+      if (key === "compoundVariants" && ts.isArrayLiteralExpression(prop.initializer)) {
+        for (const entry of prop.initializer.elements) {
+          if (!ts.isObjectLiteralExpression(entry)) {
+            continue;
+          }
+          for (const entryProp of entry.properties) {
+            if (
+              ts.isPropertyAssignment(entryProp) &&
+              (propName(entryProp.name) === "class" || propName(entryProp.name) === "className")
+            ) {
+              transformClassSubtree(entryProp.initializer);
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isPropertyAssignment(node) && propName(node.name) === "className") {
+      transformClassSubtree(node.initializer);
+    }
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      if (node.expression.text === "cn") {
+        for (const arg of node.arguments) {
+          transformClassSubtree(arg);
+        }
+      } else if (node.expression.text === "cva") {
+        transformCva(node);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  if (replacements.length === 0) {
+    return { code, changed: false };
+  }
+  let result = code;
+  for (const { start, end, text } of replacements.sort((a, b) => b.start - a.start)) {
+    result = result.slice(0, start) + text + result.slice(end);
+  }
+  return { code: result, changed: true };
+}
+
+export function transformDistDirectory(dir: string): number {
+  let changedCount = 0;
+  for (const entry of readdirSync(dir, { recursive: true, withFileTypes: true })) {
+    if (!(entry.isFile() && entry.name.endsWith(".js"))) {
+      continue;
+    }
+    const filePath = join(entry.parentPath, entry.name);
+    const source = readFileSync(filePath, "utf-8");
+    const { code: nextCode, changed } = transformSource(source, filePath);
+    if (changed) {
+      writeFileSync(filePath, nextCode);
+      changedCount += 1;
+    }
+  }
+  return changedCount;
 }

--- a/packages/payload-plugin-seo/scripts/prefix-classes.ts
+++ b/packages/payload-plugin-seo/scripts/prefix-classes.ts
@@ -1,0 +1,18 @@
+const PREFIX = "frseo";
+
+const COMPONENT_CLASS_PREFIX = "frseo-";
+
+export function prefixClassList(classList: string): string {
+  return classList
+    .split(/(\s+)/u)
+    .map((part) => {
+      if (part === "" || /^\s+$/u.test(part)) {
+        return part;
+      }
+      if (part.startsWith(`${PREFIX}:`) || part.startsWith(COMPONENT_CLASS_PREFIX)) {
+        return part;
+      }
+      return `${PREFIX}:${part}`;
+    })
+    .join("");
+}

--- a/packages/payload-plugin-seo/scripts/verify-dist.ts
+++ b/packages/payload-plugin-seo/scripts/verify-dist.ts
@@ -1,0 +1,38 @@
+const UNPREFIXED_DECLARATION =
+  /(?:^|[{;])\s*--(?:color-|spacing|radius-|animate-|font-|text-|tracking-|shadow-|default-)/mu;
+const UNPREFIXED_REFERENCE = /var\(--(?:color-|spacing|radius-)/u;
+const UNPREFIXED_SELECTOR = /^\s*\.(?!frseo(?:\\:|-))[A-Za-z]/mu;
+
+export function verifyCss(css: string): string[] {
+  const errors: string[] = [];
+  if (!css.includes(".frseo\\:")) {
+    errors.push("expected prefixed utility selectors (.frseo\\:*) — prefix(frseo) did not apply");
+  }
+  if (!css.includes("--frseo-color-")) {
+    errors.push(
+      "expected prefixed theme variables (--frseo-color-*) — prefix(frseo) did not apply"
+    );
+  }
+  const declaration = css.match(UNPREFIXED_DECLARATION);
+  if (declaration) {
+    errors.push(`unprefixed design-token declaration in output: "${declaration[0].trim()}"`);
+  }
+  const reference = css.match(UNPREFIXED_REFERENCE);
+  if (reference) {
+    errors.push(`unprefixed design-token reference in output: "${reference[0]}"`);
+  }
+  const selector = css.match(UNPREFIXED_SELECTOR);
+  if (selector) {
+    errors.push(`class selector without frseo namespace in output: "${selector[0].trim()}"`);
+  }
+  return errors;
+}
+
+const UNPREFIXED_CLASSNAME = /className:\s*["'](?!["']|frseo[:-])/u;
+
+export function verifyJs(code: string, fileName: string): string[] {
+  if (UNPREFIXED_CLASSNAME.test(code)) {
+    return [`${fileName}: className string literal without frseo prefix survived the codemod`];
+  }
+  return [];
+}

--- a/packages/payload-plugin-seo/src/admin.css
+++ b/packages/payload-plugin-seo/src/admin.css
@@ -18,6 +18,7 @@
   --color-neutral-600: var(--theme-elevation-600);
   --color-neutral-700: var(--theme-elevation-700);
   --color-neutral-800: var(--theme-elevation-800);
+  --color-neutral-900: var(--theme-elevation-900);
   --color-neutral-1000: var(--theme-elevation-1000);
 
   --color-seo-good: var(--seo-good);
@@ -28,6 +29,8 @@
   --color-seo-bad: var(--seo-bad);
   --color-seo-bad-100: var(--seo-bad-100);
   --color-seo-bad-200: var(--seo-bad-200);
+
+  --color-seo-badge-fg: #fff;
 
   --color-serp-title: var(--serp-title);
   --color-serp-title-mobile: var(--serp-title-mobile);
@@ -43,6 +46,7 @@
 
   --shadow-popover:
     0 12px 32px -12px var(--seo-shadow-strong), 0 2px 6px -2px var(--seo-shadow-soft);
+  --shadow-card: 0 1px 5px var(--seo-shadow-medium);
 
   --animate-seo-fade-in: seo-fade-in 0.18s ease;
 
@@ -55,6 +59,7 @@
 
 :root {
   --seo-shadow-strong: oklch(0.2 0.01 70 / 0.14);
+  --seo-shadow-medium: oklch(0.2 0.01 70 / 0.09);
   --seo-shadow-soft: oklch(0.2 0.01 70 / 0.06);
 
   --serp-title: #1a0dab;
@@ -78,6 +83,7 @@
 
 [data-theme="dark"] {
   --seo-shadow-strong: oklch(0.97 0 0 / 0.2);
+  --seo-shadow-medium: oklch(0.97 0 0 / 0.13);
   --seo-shadow-soft: oklch(0.97 0 0 / 0.09);
 
   --serp-title: #99c3ff;

--- a/packages/payload-plugin-seo/src/admin.css
+++ b/packages/payload-plugin-seo/src/admin.css
@@ -105,38 +105,38 @@
   --seo-bad-200: #4a201c;
 }
 
-.seo-drawer .drawer__content-children {
+.frseo-drawer .drawer__content-children {
   display: flex;
   flex-direction: column;
 }
 
-.seo-root {
+.frseo-root {
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
   min-height: 0;
 }
 
-.seo-tabpanel {
+.frseo-tabpanel {
   flex: 1 1 auto;
   min-height: 0;
 }
 
-.seo-root button {
+.frseo-root button {
   border: none;
 }
 
-.seo-root [role="tab"] {
+.frseo-root [role="tab"] {
   border: 0;
   border-bottom: 2px solid transparent;
 }
 
-.seo-root [role="tab"][aria-selected="true"] {
+.frseo-root [role="tab"][aria-selected="true"] {
   border-bottom-color: var(--theme-elevation-1000);
 }
 
 @layer components {
-  .seo-docbar {
+  .frseo-docbar {
     background: repeating-linear-gradient(
       90deg,
       var(--theme-elevation-100) 0 2px,
@@ -144,18 +144,18 @@
     );
   }
 
-  .seo-doc-btn .btn__content {
+  .frseo-doc-btn .btn__content {
     display: inline-flex;
   }
 
-  .seo-doc-btn .btn__icon {
+  .frseo-doc-btn .btn__icon {
     width: 17px;
     height: 17px;
     border: 0;
     padding: 0;
   }
 
-  .seo-doc-btn .btn__icon svg {
+  .frseo-doc-btn .btn__icon svg {
     width: 100%;
     height: 100%;
   }

--- a/packages/payload-plugin-seo/src/admin.css
+++ b/packages/payload-plugin-seo/src/admin.css
@@ -1,14 +1,8 @@
 @layer theme, base, components, utilities;
-@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/theme.css" layer(theme) prefix(frseo);
 @import "tailwindcss/utilities.css" layer(utilities);
 
-@source "./**/*.{ts,tsx}";
-
-@layer utilities {
-  .table {
-    display: revert-layer;
-  }
-}
+@source "../dist/**/*.js";
 
 @custom-variant dark ([data-theme="dark"] &);
 

--- a/packages/payload-plugin-seo/src/components/SeoButton/ScoreBadge.tsx
+++ b/packages/payload-plugin-seo/src/components/SeoButton/ScoreBadge.tsx
@@ -5,7 +5,7 @@ import { cva } from "class-variance-authority";
 import { cn } from "../../utils/style";
 
 const badgeVariants = cva(
-  "absolute -top-1 -right-1 min-w-[14px] h-[14px] px-[3px] rounded-full text-white text-[9px] font-semibold leading-[14px] text-center pointer-events-none select-none",
+  "absolute -top-1 -right-1 min-w-[14px] h-[14px] px-[3px] rounded-full text-seo-badge-fg text-[9px] font-semibold leading-[14px] text-center pointer-events-none select-none",
   {
     variants: {
       status: {

--- a/packages/payload-plugin-seo/src/components/SeoButton/SeoButtonInner.tsx
+++ b/packages/payload-plugin-seo/src/components/SeoButton/SeoButtonInner.tsx
@@ -81,7 +81,7 @@ export function SeoButtonInner({
       <Button
         aria-label="SEO Analytics"
         buttonStyle="none"
-        className="seo-doc-btn m-0 w-[calc(var(--base)*1.6)] h-[calc(var(--base)*1.6)] inline-flex items-center justify-center border border-[var(--theme-elevation-100)] rounded-rs bg-transparent text-neutral-800 transition-[border-color,background-color] duration-100 hover:border-neutral-300 hover:bg-neutral-100"
+        className="frseo-doc-btn m-0 w-[calc(var(--base)*1.6)] h-[calc(var(--base)*1.6)] inline-flex items-center justify-center border border-[var(--theme-elevation-100)] rounded-rs bg-transparent text-neutral-800 transition-[border-color,background-color] duration-100 hover:border-neutral-300 hover:bg-neutral-100"
         extraButtonProps={{ title: undefined }}
         icon={<Gauge />}
         iconStyle="without-border"

--- a/packages/payload-plugin-seo/src/components/SeoDrawer/components/HeadingsSection/HeadingTree/index.tsx
+++ b/packages/payload-plugin-seo/src/components/SeoDrawer/components/HeadingsSection/HeadingTree/index.tsx
@@ -10,7 +10,7 @@ export interface HeadingTreeProps {
   tree: HeadingNode[];
 }
 
-const SUB_LABEL = "text-[9.5px] font-semibold uppercase tracking-[0.05em] text-neutral-500";
+const SUB_LABEL = cn("text-[9.5px] font-semibold uppercase tracking-[0.05em] text-neutral-500");
 
 export function HeadingTree({ tree }: HeadingTreeProps) {
   const parentIds = useMemo(() => collectParentIds(tree), [tree]);

--- a/packages/payload-plugin-seo/src/components/SeoDrawer/index.tsx
+++ b/packages/payload-plugin-seo/src/components/SeoDrawer/index.tsx
@@ -61,13 +61,13 @@ export const SeoDrawer = memo(function SeoDrawer({
   return (
     <Drawer
       slug={drawerSlug}
-      className="seo-drawer"
+      className="frseo-drawer"
       Header={<Header drawerSlug={drawerSlug} total={total} totalStatus={totalStatus} />}
     >
-      <div className="seo-root relative text-neutral-800" data-status={totalStatus}>
+      <div className="frseo-root relative text-neutral-800" data-status={totalStatus}>
         <TabsNav active={tab} onChange={setTab} />
 
-        <div className="seo-tabpanel">
+        <div className="frseo-tabpanel">
           {result === null && tab !== "keyphrase" ? (
             <div
               className="flex items-center gap-[8px] text-neutral-500 text-[13px]"

--- a/packages/payload-plugin-seo/src/components/SeoDrawer/tabs/keyphrase/KeyphraseCard.tsx
+++ b/packages/payload-plugin-seo/src/components/SeoDrawer/tabs/keyphrase/KeyphraseCard.tsx
@@ -38,9 +38,7 @@ export function KeyphraseCard({ entry, isFocus, selected, state, onSelect }: Key
       onClick={() => onSelect(entry.id)}
       className={cn(
         "flex items-center gap-[10px] p-[8px] rounded-rs w-full text-left bg-neutral-0 border cursor-pointer",
-        selected
-          ? "border-neutral-300 shadow-[0_1px_5px_rgba(30,25,20,0.09)]"
-          : "border-transparent hover:border-neutral-150"
+        selected ? "border-neutral-300 shadow-card" : "border-transparent hover:border-neutral-150"
       )}
     >
       <MiniRing state={state} />

--- a/packages/payload-plugin-seo/src/components/SeoDrawer/tabs/keyphrase/SynonymsField.tsx
+++ b/packages/payload-plugin-seo/src/components/SeoDrawer/tabs/keyphrase/SynonymsField.tsx
@@ -44,7 +44,7 @@ export function SynonymsField({ synonyms, onAdd, onRemove }: SynonymsFieldProps)
               <button
                 type="button"
                 aria-label={`Remove synonym ${synonym} (${index + 1})`}
-                className="grid place-items-center p-0.5 text-[#a9adb4] rounded-full bg-transparent hover:text-neutral-0 hover:bg-neutral-900! [&_svg]:size-[1em] cursor-pointer"
+                className="grid place-items-center p-0.5 text-neutral-400 rounded-full bg-transparent hover:text-neutral-0 hover:bg-neutral-800 [&_svg]:size-[1em] cursor-pointer"
                 onClick={() => onRemove(index)}
               >
                 <X aria-hidden="true" />
@@ -57,7 +57,7 @@ export function SynonymsField({ synonyms, onAdd, onRemove }: SynonymsFieldProps)
             onClick={commit}
             className={cn(
               "inline-flex items-center gap-[5px] rounded-[15px] px-[11px] py-[5px] text-[11.5px] font-semibold [&_svg]:size-[13px] not-disabled:cursor-pointer transition-colors duration-150",
-              "bg-neutral-1000 text-neutral-0 not-disabled:hover:bg-neutral-900",
+              "bg-neutral-1000 text-neutral-0 not-disabled:hover:bg-neutral-800",
               "disabled:bg-neutral-100 disabled:text-neutral-300 disabled:cursor-not-allowed"
             )}
           >

--- a/packages/payload-plugin-seo/src/components/SeoDrawer/variants.ts
+++ b/packages/payload-plugin-seo/src/components/SeoDrawer/variants.ts
@@ -3,10 +3,10 @@ import { cva } from "class-variance-authority";
 export const statusVar = cva("", {
   variants: {
     status: {
-      good: "[--seo-c:var(--color-seo-good)]",
-      warn: "[--seo-c:var(--color-seo-warn)]",
-      bad: "[--seo-c:var(--color-seo-bad)]",
-      idle: "[--seo-c:var(--color-neutral-300)]",
+      good: "[--seo-c:var(--seo-good)]",
+      warn: "[--seo-c:var(--seo-warn)]",
+      bad: "[--seo-c:var(--seo-bad)]",
+      idle: "[--seo-c:var(--theme-elevation-300)]",
     },
   },
 });

--- a/packages/payload-plugin-seo/src/components/SeoField/index.tsx
+++ b/packages/payload-plugin-seo/src/components/SeoField/index.tsx
@@ -26,8 +26,9 @@ interface SeoFieldProps {
   range?: RangeOverride;
 }
 
-const GEN_BTN_CLASS =
-  "inline-flex items-center gap-[6px] rounded-rs border border-neutral-200 bg-transparent px-[9px] py-[4px] text-[12px] font-semibold text-neutral-800 transition-colors hover:border-neutral-300 hover:bg-neutral-100 disabled:cursor-default disabled:text-neutral-400 cursor-pointer";
+const GEN_BTN_CLASS = cn(
+  "inline-flex items-center gap-[6px] rounded-rs border border-neutral-200 bg-transparent px-[9px] py-[4px] text-[12px] font-semibold text-neutral-800 transition-colors hover:border-neutral-300 hover:bg-neutral-100 disabled:cursor-default disabled:text-neutral-400 cursor-pointer"
+);
 
 interface InjectedComponents {
   Label?: ReactNode;

--- a/packages/payload-plugin-seo/src/ui/CheckRow/CheckVisualization/visualizations/DistributionBar.tsx
+++ b/packages/payload-plugin-seo/src/ui/CheckRow/CheckVisualization/visualizations/DistributionBar.tsx
@@ -5,7 +5,7 @@ import type { DistributionModel } from "../../../../engine/types/visualization";
 export function DistributionBar({ positions }: DistributionModel) {
   return (
     <>
-      <div className="seo-docbar relative h-[24px] rounded-rs border border-neutral-200">
+      <div className="frseo-docbar relative h-[24px] rounded-rs border border-neutral-200">
         {positions.map((p, i) => (
           <i
             key={`${p}-${i}`}

--- a/packages/payload-plugin-seo/src/utils/style.ts
+++ b/packages/payload-plugin-seo/src/utils/style.ts
@@ -1,6 +1,8 @@
 import { clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
 import type { ClassValue } from "clsx";
+
+const twMerge = extendTailwindMerge({ prefix: "frseo" });
 
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));

--- a/packages/payload-plugin-seo/src/utils/style.ts
+++ b/packages/payload-plugin-seo/src/utils/style.ts
@@ -6,5 +6,6 @@ export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }
 
-export const ROW_SEPARATOR =
-  "not-last:after:content-[''] not-last:after:absolute not-last:after:inset-x-[15px] not-last:after:bottom-0 not-last:after:h-px not-last:after:bg-neutral-200";
+export const ROW_SEPARATOR = cn(
+  "not-last:after:content-[''] not-last:after:absolute not-last:after:inset-x-[15px] not-last:after:bottom-0 not-last:after:h-px not-last:after:bg-neutral-200"
+);

--- a/packages/payload-plugin-seo/tests/components/build-analysis-input.test.ts
+++ b/packages/payload-plugin-seo/tests/components/build-analysis-input.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { buildAnalysisInput } from "../../src/components/SeoDrawer/build-analysis-input";
-import type { ContentExtractor } from "../../src/types/config";
+import type { ContentNode } from "../../src/content/schema/nodes";
+import type { ContentExtractor, ExtractToolkit } from "../../src/types/config";
 
 describe("buildAnalysisInput", () => {
   it("returns empty content when no extractor is provided", async () => {
@@ -18,9 +19,9 @@ describe("buildAnalysisInput", () => {
   });
 
   it("serializes the extractor's IR into contentHtml and sets has.content", async () => {
-    const extractor: ContentExtractor = vi.fn(async () => [
-      { type: "heading", level: 1, text: "Reg" },
-    ]);
+    const extractor: ContentExtractor = vi.fn(
+      async (): Promise<ContentNode[]> => [{ type: "heading", level: 1, text: "Reg" }]
+    );
     const out = await buildAnalysisInput({
       values: {},
       locale: "en",
@@ -40,7 +41,7 @@ describe("buildAnalysisInput", () => {
     let received: {
       values: unknown;
       ctx: unknown;
-      toolkit: { resolveDocs: unknown; helpers: Record<string, unknown> };
+      toolkit: ExtractToolkit;
     } | null = null;
     const extractor: ContentExtractor = async (values, ctx, toolkit) => {
       received = { values, ctx, toolkit };

--- a/packages/payload-plugin-seo/tests/engine/deriveSerp.test.ts
+++ b/packages/payload-plugin-seo/tests/engine/deriveSerp.test.ts
@@ -9,6 +9,7 @@ const base: AnalysisInput = {
   description: "Discover the best running shoes for every surface.",
   contentHtml: "",
   keyphrase: "running shoes",
+  keyphrases: [],
   locale: "en_US",
   site: { name: "RunShop", baseUrl: "https://runshop.com" },
   has: { seoTitle: true, metaDescription: true, slug: true, content: true },

--- a/packages/payload-plugin-seo/tests/plugin-validation.test.ts
+++ b/packages/payload-plugin-seo/tests/plugin-validation.test.ts
@@ -12,7 +12,7 @@ afterEach(() => {
 describe("seoPlugin config validation", () => {
   it("warns + returns incoming (no throw) when collections empty", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    let result: Config | undefined;
+    let result: Config | Promise<Config> | undefined;
     expect(() => {
       result = seoPlugin({ collections: [] } as unknown as SeoPluginConfig)(incoming);
     }).not.toThrow();

--- a/packages/payload-plugin-seo/tests/scripts/prefix-class-list.test.ts
+++ b/packages/payload-plugin-seo/tests/scripts/prefix-class-list.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { prefixClassList } from "../../scripts/prefix-classes";
+
+describe("prefixClassList", () => {
+  it("prefixes every plain utility token", () => {
+    expect(prefixClassList("flex items-center gap-2")).toBe(
+      "frseo:flex frseo:items-center frseo:gap-2"
+    );
+  });
+
+  it("prefixes variant chains as a whole", () => {
+    expect(prefixClassList("hover:bg-neutral-100 motion-reduce:animate-none")).toBe(
+      "frseo:hover:bg-neutral-100 frseo:motion-reduce:animate-none"
+    );
+    expect(prefixClassList("dark:text-seo-good")).toBe("frseo:dark:text-seo-good");
+  });
+
+  it("prefixes arbitrary values", () => {
+    expect(prefixClassList("w-[calc(var(--base)*1.6)]")).toBe("frseo:w-[calc(var(--base)*1.6)]");
+    expect(prefixClassList("not-last:after:content-['']")).toBe(
+      "frseo:not-last:after:content-['']"
+    );
+  });
+
+  it("skips plugin component classes (seo- prefix)", () => {
+    expect(prefixClassList("frseo-root relative text-neutral-800")).toBe(
+      "frseo-root frseo:relative frseo:text-neutral-800"
+    );
+    expect(prefixClassList("frseo-doc-btn m-0")).toBe("frseo-doc-btn frseo:m-0");
+  });
+
+  it("is idempotent", () => {
+    const once = prefixClassList("flex frseo-root hover:bg-neutral-100");
+    expect(prefixClassList(once)).toBe(once);
+  });
+
+  it("preserves original whitespace and empty strings", () => {
+    expect(prefixClassList("")).toBe("");
+    expect(prefixClassList("  flex  gap-2 ")).toBe("  frseo:flex  frseo:gap-2 ");
+  });
+});

--- a/packages/payload-plugin-seo/tests/scripts/transform-source.test.ts
+++ b/packages/payload-plugin-seo/tests/scripts/transform-source.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { transformSource } from "../../scripts/prefix-classes";
+
+const t = (code: string) => transformSource(code, "dist/fake.js").code;
+
+describe("transformSource", () => {
+  it("transforms className string props in jsx calls", () => {
+    expect(t(`jsx("div", { className: "flex gap-2" });`)).toBe(
+      `jsx("div", { className: "frseo:flex frseo:gap-2" });`
+    );
+  });
+
+  it("keeps frseo- component classes in className", () => {
+    expect(t(`jsx("div", { className: "frseo-root relative" });`)).toBe(
+      `jsx("div", { className: "frseo-root frseo:relative" });`
+    );
+  });
+
+  it("transforms ternary branches in className but not conditions", () => {
+    expect(t(`jsx("div", { className: mode === "desktop" ? "flex" : "hidden" });`)).toBe(
+      `jsx("div", { className: mode === "desktop" ? "frseo:flex" : "frseo:hidden" });`
+    );
+  });
+
+  it("transforms cn() args: literals, ternaries, && right side only", () => {
+    expect(t(`cn("mt-[8px] flex-col", open ? "flex" : "hidden");`)).toBe(
+      `cn("frseo:mt-[8px] frseo:flex-col", open ? "frseo:flex" : "frseo:hidden");`
+    );
+    expect(t(`cn(status === "good" && "bg-seo-good");`)).toBe(
+      `cn(status === "good" && "frseo:bg-seo-good");`
+    );
+  });
+
+  it("does not descend into non-cn calls inside cn args", () => {
+    expect(t(`cn(statusVar({ status: "good" }), "flex");`)).toBe(
+      `cn(statusVar({ status: "good" }), "frseo:flex");`
+    );
+  });
+
+  it("transforms cva base and variant values but not variant keys or defaultVariants", () => {
+    const input = `const v = cva("rounded-full grid", {
+  variants: { size: { medium: "w-4 h-4", large: "w-8" } },
+  defaultVariants: { size: "medium" },
+});`;
+    const output = `const v = cva("frseo:rounded-full frseo:grid", {
+  variants: { size: { medium: "frseo:w-4 frseo:h-4", large: "frseo:w-8" } },
+  defaultVariants: { size: "medium" },
+});`;
+    expect(t(input)).toBe(output);
+  });
+
+  it("transforms only class/className values in compoundVariants", () => {
+    const input = `cva("base-x", { variants: { a: { on: "p-1" } }, compoundVariants: [{ a: "on", class: "m-2" }] });`;
+    const output = `cva("frseo:base-x", { variants: { a: { on: "frseo:p-1" } }, compoundVariants: [{ a: "on", class: "frseo:m-2" }] });`;
+    expect(t(input)).toBe(output);
+  });
+
+  it("transforms string keys in clsx object syntax, not values", () => {
+    expect(t(`cn({ "flex gap-2": isOpen });`)).toBe(`cn({ "frseo:flex frseo:gap-2": isOpen });`);
+  });
+
+  it("leaves unrelated strings untouched", () => {
+    const input = `const PKG = "@focus-reactive/payload-plugin-seo"; jsx("div", { "aria-label": "flex layout" });`;
+    expect(t(input)).toBe(input);
+  });
+
+  it("is idempotent", () => {
+    const once = t(`jsx("div", { className: "flex frseo-root" });`);
+    expect(t(once)).toBe(once);
+  });
+
+  it("reports changed=false for untouched files", () => {
+    expect(transformSource(`const x = 1;`, "dist/x.js").changed).toBe(false);
+  });
+
+  it("throws with file:line:col on template literals with substitutions", () => {
+    const substitution = "$".concat("{extra}");
+    expect(() => t(`jsx("div", { className: \`flex ${substitution}\` });`)).toThrow(
+      /dist\/fake\.js:1:\d+/u
+    );
+  });
+});

--- a/packages/payload-plugin-seo/tests/scripts/verify-dist.test.ts
+++ b/packages/payload-plugin-seo/tests/scripts/verify-dist.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { verifyCss, verifyJs } from "../../scripts/verify-dist";
+
+const GOOD_CSS = `@layer theme {
+  :root, :host {
+    --frseo-color-neutral-100: var(--theme-elevation-100);
+    --frseo-radius-rs: var(--style-radius-s);
+    --frseo-shadow-popover: 0 12px 32px -12px var(--seo-shadow-strong);
+  }
+}
+:root {
+  --seo-shadow-strong: oklch(0.2 0.01 70 / 0.14);
+  --serp-title: #1a0dab;
+}
+@layer utilities {
+  .frseo\\:flex {
+    display: flex;
+  }
+  .frseo\\:gap-2 {
+    gap: calc(var(--frseo-spacing) * 2);
+  }
+}
+.frseo-root button {
+  border: none;
+}
+.frseo-drawer .drawer__content-children {
+  display: flex;
+}`;
+
+describe("verifyCss", () => {
+  it("accepts fully prefixed output", () => {
+    expect(verifyCss(GOOD_CSS)).toEqual([]);
+  });
+
+  it("rejects css without prefixed utilities or variables", () => {
+    expect(verifyCss(":root { color: red }").length).toBeGreaterThan(0);
+  });
+
+  it("rejects unprefixed utility selectors", () => {
+    expect(verifyCss(`${GOOD_CSS}\n.bg-neutral-100 {\n  background: red;\n}`)).not.toEqual([]);
+    expect(verifyCss(`${GOOD_CSS}\n.table {\n  display: table;\n}`)).not.toEqual([]);
+  });
+
+  it("rejects unprefixed token declarations", () => {
+    expect(verifyCss(`${GOOD_CSS}\n:root {\n  --color-neutral-100: red;\n}`)).not.toEqual([]);
+    expect(verifyCss(`${GOOD_CSS}\n:root {\n  --spacing: 1rem;\n}`)).not.toEqual([]);
+  });
+
+  it("rejects unprefixed token references", () => {
+    expect(verifyCss(`${GOOD_CSS}\n.frseo\\:x {\n  gap: calc(var(--spacing) * 2);\n}`)).not.toEqual(
+      []
+    );
+  });
+});
+
+describe("verifyJs", () => {
+  it("accepts prefixed and component-class literals", () => {
+    expect(verifyJs(`jsx("div", { className: "frseo:flex frseo:gap-2" });`, "a.js")).toEqual([]);
+    expect(verifyJs(`jsx("div", { className: "frseo-root frseo:relative" });`, "a.js")).toEqual([]);
+    expect(verifyJs(`jsx("div", { className: cn("x") });`, "a.js")).toEqual([]);
+  });
+
+  it("flags unprefixed className literals", () => {
+    expect(verifyJs(`jsx("div", { className: "flex gap-2" });`, "a.js")).not.toEqual([]);
+  });
+});

--- a/packages/payload-plugin-seo/tests/tsconfig.json
+++ b/packages/payload-plugin-seo/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": false
+  },
+  "include": [".", "../src/**/*.d.ts"],
+  "exclude": ["__fixtures__"]
+}

--- a/packages/payload-plugin-seo/tests/utils/cn.test.ts
+++ b/packages/payload-plugin-seo/tests/utils/cn.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { cn } from "../../src/utils/style";
+
+describe("cn with frseo prefix", () => {
+  it("resolves conflicts between frseo-prefixed utilities", () => {
+    expect(cn("frseo:p-2", "frseo:p-4")).toBe("frseo:p-4");
+    expect(cn("frseo:hover:bg-neutral-100", "frseo:hover:bg-neutral-200")).toBe(
+      "frseo:hover:bg-neutral-200"
+    );
+  });
+
+  it("keeps consumer (unprefixed) classes untouched alongside plugin classes", () => {
+    expect(cn("frseo:px-2", "consumer-card")).toBe("frseo:px-2 consumer-card");
+  });
+
+  it("still flattens conditional inputs", () => {
+    expect(cn("frseo:flex", false, undefined, "frseo:gap-2")).toBe("frseo:flex frseo:gap-2");
+  });
+});

--- a/packages/payload-plugin-seo/tsconfig.build.json
+++ b/packages/payload-plugin-seo/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/payload-plugin-seo/tsconfig.json
+++ b/packages/payload-plugin-seo/tsconfig.json
@@ -13,12 +13,9 @@
     "jsx": "react-jsx",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "outDir": "dist",
-    "rootDir": "src",
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true
+    "noEmit": true,
+    "types": ["node"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests", "__fixtures__", "vitest.config.ts"]
+  "include": ["src", "scripts", "tsup.config.ts", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist", "__fixtures__"]
 }

--- a/packages/payload-plugin-seo/tsup.config.ts
+++ b/packages/payload-plugin-seo/tsup.config.ts
@@ -2,7 +2,11 @@
 
 import { defineConfig } from "tsup";
 import { spawn } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
 import { createRequire } from "node:module";
+import { join } from "node:path";
+import { transformDistDirectory } from "./scripts/prefix-classes";
+import { verifyCss, verifyJs } from "./scripts/verify-dist";
 
 const postcssCli = createRequire(import.meta.url).resolve("postcss-cli");
 
@@ -48,6 +52,21 @@ export default defineConfig({
     "@yoast/search-metadata-previews",
   ],
   async onSuccess() {
+    const changed = transformDistDirectory("dist");
+    console.log(`[prefix-classes] prefixed class literals in ${changed} files`);
+
     await compileCss();
+
+    const errors = verifyCss(readFileSync("dist/admin.css", "utf-8"));
+    for (const entry of readdirSync("dist", { recursive: true, withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith(".js")) {
+        const filePath = join(entry.parentPath, entry.name);
+        errors.push(...verifyJs(readFileSync(filePath, "utf-8"), filePath));
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new Error(`[verify-dist] style isolation regressed:\n- ${errors.join("\n- ")}`);
+    }
   },
 });


### PR DESCRIPTION
- **refactor(seo): namespace classes under frseo and add class-prefix transform**
- **build(seo): split tsconfig to type-check scripts and tests**
- **feat(seo): add AST codemod that prefixes class literals in compiled JS**
- **feat(seo): route standalone class-string constants through cn()**
- **feat(seo): configure tailwind-merge for the frseo prefix**
- **feat(seo): add dist output isolation verifier**
- **fix(seo): compile admin styles with frseo prefix to isolate from consumer css**
- **refactor(seo): replace hardcoded colors and shadows with design tokens**
