### PR TITLE
docs(translator): actualize README — 0.7.0 exports + roadmap

### DIFF
--- a/packages/payload-plugin-translator/README.md
+++ b/packages/payload-plugin-translator/README.md
@@ -370,6 +370,9 @@ import type {
   FieldTranslationConfig,
   AccessGuard,
   AccessGuardRequest,
+  TranslationTask, // descriptor passed to the lifecycle callbacks — Since v0.7.0
+  TranslationLifecycleCallbacks, // shape of the `lifecycle` config — Since v0.7.0
+  TranslationProvenanceRecord, // a stored provenance row — Since v0.7.0
 } from "@focus-reactive/payload-plugin-translator";
 ```
 
@@ -379,9 +382,11 @@ Every public API is annotated with `@since x.y.z` in its JSDoc, and features car
 
 ## Roadmap
 
+Planned features building on the v0.7.0 provenance foundation:
+
+- **Stale-translation detection** — surface which target locales are out of sync with their source, using the recorded provenance fingerprint.
 - **Global translation dashboard** — translate across all collections from one place, with project-wide progress.
-- **Vercel Cron runner** — a built-in runner for serverless deploys without manual API-route wiring.
-- **Auto-translate on source change** — trigger translation automatically when default-locale content changes.
+- **Auto-translate on source change** — retranslate automatically when default-locale content changes.
 
 ## License
 


### PR DESCRIPTION
Actualize the translator package README after the v0.7.0 provenance/lifecycle release.

## What
- **TypeScript exports** — add the three types shipped in 0.7.0 that were missing from the exported-types list: `TranslationTask`, `TranslationLifecycleCallbacks`, `TranslationProvenanceRecord`.
- **Roadmap** — grounded in the actual issue tracker:
  - add **stale-translation detection** (#50) — the immediate next step on the 0.7.0 provenance foundation;
  - drop **"Vercel Cron runner"** — not a tracked/planned item (serverless is already covered by `autoRun: false`);
  - keep **global dashboard** (#49) and **auto-translate on source change** (#51).

Rest of the README was reviewed and is accurate (peer-deps, provenance/lifecycle sections, providers, runners, levels).

`docs:` → patch **0.7.1**, which is what refreshes the README shown on npmjs.com.
