### PR TITLE
fix(translator): keep block/array id for shared rows to stop source wipe

### DIFF
--- a/packages/payload-plugin-translator/docs/plans/2026-06-12-cross-locale-block-identity.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-06-12-cross-locale-block-identity.md
@@ -92,9 +92,21 @@ change.
 
 **Honest limit:** this removes the *corruption / wrong skip*, but it does not make `skip_existing`
 preserve per-block target edits for genuinely-independent localized blocks — there is no identity to
-preserve them by, and the reconciler strips `id` on output (Postgres rejects it on update) so a
+preserve them by, and for those (localized) containers the reconciler strips `id` on output so a
 re-translated target gets fresh ids anyway. For independent localized blocks, re-translation
 effectively re-mirrors source. That is the correct, consistent behaviour given no identity.
+
+> **Correction (2026-07-07, patch — `docs/plans/2026-07-07-blocks-id-retention-dataloss-fix.md`).**
+> The original patch stripped `id` from **every** array/block element, justified as "Postgres rejects
+> it on update". That was **wrong for the recommended regime** (Decision 1: non-localized container,
+> localized leaves). Those rows are **shared** across locales; an id-less `payload.update({ locale })`
+> can't match them, so Payload **deletes + recreates** the rows and **wipes every other locale's leaf
+> values — including the source** (a critical data-loss bug, reproduced on SQLite *and* Postgres).
+> Postgres does **not** reject a kept `id` for a shared row — it updates in place. The id-strip is only
+> needed for **per-locale** rows (a `localized` container or any `localized` ancestor), where keeping
+> the source row's id would collide on insert. So id retention is now **conditional**: keep `id` for a
+> shared row (no localized ancestor and the container itself non-localized); strip it for a per-locale
+> row. See the fix doc for the rule + regression tests.
 
 ### 3. Field level: guard, don't pretend (ships with the field-level feature)
 

--- a/packages/payload-plugin-translator/docs/plans/2026-07-07-blocks-id-retention-dataloss-fix.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-07-07-blocks-id-retention-dataloss-fix.md
@@ -1,0 +1,89 @@
+# Blocks/array `id` retention — critical data-loss fix
+
+**Date:** 2026-07-07
+**Type:** `fix:` (patch). **Severity:** CRITICAL — silent source-content data loss.
+**Scope:** `DataReconciler` output only. No public API change, no `@since`. Corrects a decision in
+[`2026-06-12-cross-locale-block-identity.md`](./2026-06-12-cross-locale-block-identity.md).
+
+## Symptom
+
+Translating a whole document **erases the source-locale content** inside a **non-localized**
+`blocks`/`array` container (the recommended regime: non-localized container, localized leaves — e.g.
+`apps/dev` `Playground.layout` + `DeepNest`). After translating `en → de`, the `en` blocks come back
+empty and the block `id` has changed.
+
+## Root cause
+
+`DataReconciler` (`src/core/translation-pipeline/stages/data-reconciler/DataReconciler.ts`)
+**unconditionally stripped `id`** from every array/block element on output (`combine`, kind
+`"element"`), justified by a comment "Postgres rejects it on update".
+
+The reconciler output is saved via `payload.update({ locale: targetLng, data })`. For a
+**non-localized** container the array rows are **shared across locales** (one row, per-locale leaf
+columns). Without `id`, Payload cannot match the existing shared rows on that update, so it
+**deletes and recreates** them — and the recreated rows only carry the target locale's values, so
+**every other locale's leaf values (the source) are destroyed.**
+
+The "Postgres rejects id" premise was a **misdiagnosis**: the reject only happens for a **localized**
+container, where each element is an independent **per-locale** row and re-sending the source row's
+`id` collides on insert. The fix over-generalized that strip to all containers, breaking the
+non-localized (shared-row) case.
+
+### Verified on a live DB (SQLite + Postgres), both adapters identical
+
+| container | current (strip id) | fix (conditional id) |
+| --- | --- | --- |
+| **non-localized** blocks/array (shared rows) | ✗ EN source **wiped**, block id changes | ✓ EN survives, DE translated, id stable (in-place update) |
+| **localized** container (per-locale rows) | ✓ correct | ✓ correct (still stripped — keeping id collides on insert, confirmed) |
+
+## The rule
+
+Keep `id` **iff the element's row is shared across locales** — i.e. neither the container nor any
+ancestor is `localized`. Strip it otherwise (per-locale rows).
+
+- **Shared row** (no `localized` on the path) → Payload stores one row with per-locale leaf columns;
+  `id` is a stable cross-locale key → **keep it** so `update({ locale })` matches and updates in place.
+- **Per-locale row** (`localized` container or any `localized` ancestor group/blocks/array/tab) →
+  independent rows per locale → **strip** `id` (re-sending the source id would collide on insert).
+
+## Implementation
+
+Thread a `sharedRow: boolean` through the reconcile walker `Cursor` (root `true`):
+
+- `enterObject` / `enterList`: `childShared = cursor.sharedRow && !field.localized` — a `localized`
+  group/tab/array/blocks flips the whole subtree to per-locale.
+- `combine` (kind `"element"`): `if (cursor.sharedRow && cursor.source.id != null) result.id = cursor.source.id`.
+  Guard against `id: undefined` when a shared element genuinely has no id.
+
+`matchElementById` is untouched — it reads `id` from the intact **source**, so target pairing is
+unaffected. The `localized` flag reaches the reconciler because it walks the **original**
+(un-sanitized) schema, which preserves `localized`.
+
+## Tests (regression / data-loss guard, red-first)
+
+Fast reconciler unit tests on the output shape (`DataReconciler.test.ts`, describe
+"id retention by shared-vs-per-locale row (data-loss guard)"):
+
+1. non-localized blocks → `id` **kept** (the bug). ← main guard
+2. non-localized array → `id` **kept**.
+3. localized blocks container → `id` **stripped**.
+4. localized array container → `id` **stripped**.
+5. non-localized array nested under a **localized** blocks ancestor → `id` **stripped**.
+6. non-localized under a **localized group** ancestor → `id` **stripped**.
+7. non-localized under a **localized named-tab** ancestor → `id` **stripped**.
+8. deeply-nested all-non-localized (Playground `layout → nested → leaves`) → `id` kept at every level.
+9. shared element with no id → **no `id` key** added (guard against `id: undefined`).
+10. non-localized blocks **with an existing target** → `id` kept + target-priority merge.
+11. unknown-`blockType` passthrough element → `id` kept (shared) / stripped (per-locale).
+
+Pre-existing reconciler/pipeline tests that asserted stripped id for **non-localized** fixtures were
+corrected to expect `id`; the "cross-locale block identity" fixtures were marked `localized: true`
+(they model per-locale independent blocks — the only regime where reordering / diverging ids occur),
+so their stripped-id expectations stay correct.
+
+## Out of scope / notes
+
+- Cross-DB behaviour confirmed by a local-API reproduction on SQLite and Postgres (both wiped before,
+  both correct after). No new automated DB test harness is added in this patch — the reconciler-output
+  contract is the fast, deterministic guard.
+- No change to fingerprint/provenance (they use the id-path projection, not the reconciler output).

--- a/packages/payload-plugin-translator/src/core/field-traversal/types.ts
+++ b/packages/payload-plugin-translator/src/core/field-traversal/types.ts
@@ -12,13 +12,15 @@ export interface BlockLike {
 
 /**
  * A tab as this layer needs to read it: an optional `name` (present → it opens a data boundary;
- * absent → it flattens into the parent scope) and its child `fields`. Payload's `Tab`
- * (`NamedTab | UnnamedTab`) is assignable to this.
+ * absent → it flattens into the parent scope), its child `fields`, and `localized` (a *named* tab
+ * may be `localized`, partitioning its subtree per locale — Payload's sanitizer propagates it the
+ * same as a group). Payload's `Tab` (`NamedTab | UnnamedTab`) is assignable to this.
  *
  * @public
  */
 export interface TabLike {
   name?: string;
+  localized?: boolean;
   fields: FieldLike[];
 }
 

--- a/packages/payload-plugin-translator/src/core/translation-pipeline/TranslationPipeline.test.ts
+++ b/packages/payload-plugin-translator/src/core/translation-pipeline/TranslationPipeline.test.ts
@@ -131,9 +131,12 @@ describe("TranslationPipeline", () => {
       });
 
       expect(result).not.toBeNull();
-      // Note: id is not included in result - Postgres rejects it on update
+      // Non-localized array → shared rows → id kept so Payload updates them in place.
       expect(result!.translatedData).toEqual({
-        items: [{ label: "TR_First" }, { label: "TR_Second" }],
+        items: [
+          { id: "1", label: "TR_First" },
+          { id: "2", label: "TR_Second" },
+        ],
       });
     });
   });
@@ -667,10 +670,10 @@ describe("TranslationPipeline", () => {
         targetLng: "ru",
       });
 
-      // Note: id is not included in result - Postgres rejects it on update
+      // Non-localized array → shared rows → id kept.
       expect(result!.translatedData.items).toEqual([
-        { label: "Translated" },
-        { label: "TR_Second" },
+        { id: "1", label: "Translated" },
+        { id: "2", label: "TR_Second" },
       ]);
     });
 
@@ -748,10 +751,10 @@ describe("TranslationPipeline", () => {
         targetLng: "ru",
       });
 
-      // Note: id is not included in result - Postgres rejects it on update
+      // Non-localized blocks → shared rows → id kept.
       expect(result!.translatedData.layout).toEqual([
-        { blockType: "text", content: "Translated" },
-        { blockType: "text", content: "TR_World" },
+        { id: "1", blockType: "text", content: "Translated" },
+        { id: "2", blockType: "text", content: "TR_World" },
       ]);
     });
   });

--- a/packages/payload-plugin-translator/src/core/translation-pipeline/stages/data-reconciler/DataReconciler.test.ts
+++ b/packages/payload-plugin-translator/src/core/translation-pipeline/stages/data-reconciler/DataReconciler.test.ts
@@ -112,11 +112,11 @@ describe("DataReconciler", () => {
       };
 
       const reconciler = new DataReconciler(schema);
-      // Note: id is not included in result - Postgres rejects it on update
+      // Non-localized array → shared rows → id kept so Payload updates them in place.
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
         items: [
-          { label: "Translated", value: "one" },
-          { label: "Second", value: "y" },
+          { id: "1", label: "Translated", value: "one" },
+          { id: "2", label: "Second", value: "y" },
         ],
       });
     });
@@ -145,9 +145,9 @@ describe("DataReconciler", () => {
       };
 
       const reconciler = new DataReconciler(schema);
-      // Note: id is not included in result - Postgres rejects it on update
+      // Non-localized blocks → shared rows → id kept.
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        layout: [{ blockType: "text", content: "Existing", style: "bold" }],
+        layout: [{ id: "1", blockType: "text", content: "Existing", style: "bold" }],
       });
     });
 
@@ -172,9 +172,9 @@ describe("DataReconciler", () => {
       };
 
       const reconciler = new DataReconciler(schema);
-      // Note: id is not included in result - Postgres rejects it on update
+      // Non-localized blocks → shared rows → id kept.
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        layout: [{ blockType: "text", content: "Hello" }],
+        layout: [{ id: "1", blockType: "text", content: "Hello" }],
       });
     });
   });
@@ -355,9 +355,12 @@ describe("DataReconciler", () => {
       const targetData = { items: [{ id: "1", label: "T" }] };
 
       const reconciler = new DataReconciler(schema);
-      // id 1 → target "T" wins; id 2 → no counterpart → source "B"
+      // id 1 → target "T" wins; id 2 → no counterpart → source "B". Non-localized → ids kept.
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        items: [{ label: "T" }, { label: "B" }],
+        items: [
+          { id: "1", label: "T" },
+          { id: "2", label: "B" },
+        ],
       });
     });
 
@@ -433,9 +436,12 @@ describe("DataReconciler", () => {
       };
 
       const reconciler = new DataReconciler(schema);
-      // id 1 ↔ "T1", id 2 ↔ "T2"; output follows source order
+      // id 1 ↔ "T1", id 2 ↔ "T2"; output follows source order. Non-localized → ids kept.
       expect(reconciler.reconcile(sourceData, targetData)).toEqual({
-        items: [{ label: "T1" }, { label: "T2" }],
+        items: [
+          { id: "1", label: "T1" },
+          { id: "2", label: "T2" },
+        ],
       });
     });
 
@@ -456,16 +462,22 @@ describe("DataReconciler", () => {
       };
 
       const reconciler = new DataReconciler(schema);
-      // output is driven by source → only id 1 survives, id-1 target value wins
-      expect(reconciler.reconcile(sourceData, targetData)).toEqual({ items: [{ label: "T" }] });
+      // output is driven by source → only id 1 survives, id-1 target value wins. Non-localized → id kept.
+      expect(reconciler.reconcile(sourceData, targetData)).toEqual({
+        items: [{ id: "1", label: "T" }],
+      });
     });
   });
 
   describe("cross-locale block identity", () => {
+    // Per-locale independent blocks (reordering / diverging ids) only occur for a LOCALIZED
+    // container — Payload stores an independent array per locale. So the id is stripped on output
+    // (per-locale rows); these cases assert the merge/pairing logic, not id retention.
     const blocksSchema: Field[] = [
       {
         name: "layout",
         type: "blocks",
+        localized: true,
         blocks: [
           { slug: "text", fields: [{ name: "content", type: "text", localized: true }] },
           { slug: "quote", fields: [{ name: "content", type: "text", localized: true }] },
@@ -532,6 +544,303 @@ describe("DataReconciler", () => {
       const reconciler = new DataReconciler(schema);
       // non-object source for a group → the group is skipped entirely
       expect(reconciler.reconcile(sourceData, {})).toEqual({ keep: "K" });
+    });
+  });
+
+  // Data-loss guard (critical): the reconciler output feeds payload.update({ locale }). For a
+  // NON-localized array/blocks container the rows are SHARED across locales, so the element `id`
+  // MUST survive — without it Payload can't match the shared rows on a localized update and
+  // deletes + recreates them, wiping every other locale's leaf values (the source). For a
+  // LOCALIZED container (or any localized ancestor) the rows are per-locale, so the id is stripped
+  // (keeping it would collide with the source locale's row on insert).
+  describe("id retention by shared-vs-per-locale row (data-loss guard)", () => {
+    it("KEEPS id on a non-localized blocks container (shared rows)", () => {
+      const schema: Field[] = [
+        {
+          name: "layout",
+          type: "blocks",
+          blocks: [{ slug: "text", fields: [{ name: "content", type: "text", localized: true }] }],
+        },
+      ];
+      const sourceData = { layout: [{ id: "b1", blockType: "text", content: "Hello" }] };
+
+      expect(new DataReconciler(schema).reconcile(sourceData, {})).toEqual({
+        layout: [{ id: "b1", blockType: "text", content: "Hello" }],
+      });
+    });
+
+    it("KEEPS id on a non-localized array container (shared rows)", () => {
+      const schema: Field[] = [
+        {
+          name: "items",
+          type: "array",
+          fields: [{ name: "label", type: "text", localized: true }],
+        },
+      ];
+      const sourceData = { items: [{ id: "a1", label: "One" }] };
+
+      expect(new DataReconciler(schema).reconcile(sourceData, {})).toEqual({
+        items: [{ id: "a1", label: "One" }],
+      });
+    });
+
+    it("STRIPS id on a localized blocks container (independent per-locale rows)", () => {
+      const schema: Field[] = [
+        {
+          name: "layout",
+          type: "blocks",
+          localized: true,
+          blocks: [{ slug: "text", fields: [{ name: "content", type: "text", localized: true }] }],
+        },
+      ];
+      const sourceData = { layout: [{ id: "b1", blockType: "text", content: "Hello" }] };
+
+      expect(new DataReconciler(schema).reconcile(sourceData, {})).toEqual({
+        layout: [{ blockType: "text", content: "Hello" }],
+      });
+    });
+
+    it("STRIPS id on a localized array container", () => {
+      const schema: Field[] = [
+        {
+          name: "items",
+          type: "array",
+          localized: true,
+          fields: [{ name: "label", type: "text", localized: true }],
+        },
+      ];
+      const sourceData = { items: [{ id: "a1", label: "One" }] };
+
+      expect(new DataReconciler(schema).reconcile(sourceData, {})).toEqual({
+        items: [{ label: "One" }],
+      });
+    });
+
+    it("STRIPS id on a non-localized array nested under a localized blocks ancestor", () => {
+      const schema: Field[] = [
+        {
+          name: "layout",
+          type: "blocks",
+          localized: true,
+          blocks: [
+            {
+              slug: "row",
+              fields: [
+                {
+                  name: "items",
+                  type: "array",
+                  fields: [{ name: "label", type: "text", localized: true }],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+      const sourceData = {
+        layout: [{ id: "b1", blockType: "row", items: [{ id: "a1", label: "One" }] }],
+      };
+
+      // localized ancestor → the whole subtree is per-locale → every element id stripped.
+      expect(new DataReconciler(schema).reconcile(sourceData, {})).toEqual({
+        layout: [{ blockType: "row", items: [{ label: "One" }] }],
+      });
+    });
+
+    it("STRIPS id under a localized group ancestor", () => {
+      const schema: Field[] = [
+        {
+          name: "panel",
+          type: "group",
+          localized: true,
+          fields: [
+            {
+              name: "items",
+              type: "array",
+              fields: [{ name: "label", type: "text", localized: true }],
+            },
+          ],
+        },
+      ];
+      const sourceData = { panel: { items: [{ id: "a1", label: "One" }] } };
+
+      expect(new DataReconciler(schema).reconcile(sourceData, {})).toEqual({
+        panel: { items: [{ label: "One" }] },
+      });
+    });
+
+    it("STRIPS id under a localized named-tab ancestor", () => {
+      const schema: Field[] = [
+        {
+          type: "tabs",
+          tabs: [
+            {
+              name: "meta",
+              localized: true,
+              fields: [
+                {
+                  name: "items",
+                  type: "array",
+                  fields: [{ name: "label", type: "text", localized: true }],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+      const sourceData = { meta: { items: [{ id: "a1", label: "One" }] } };
+
+      expect(new DataReconciler(schema).reconcile(sourceData, {})).toEqual({
+        meta: { items: [{ label: "One" }] },
+      });
+    });
+
+    it("KEEPS id at every level of a deeply-nested all-non-localized tree (Playground shape)", () => {
+      const schema: Field[] = [
+        {
+          name: "layout",
+          type: "blocks",
+          blocks: [
+            {
+              slug: "deepNest",
+              fields: [
+                {
+                  name: "nested",
+                  type: "blocks",
+                  blocks: [
+                    {
+                      slug: "inner",
+                      fields: [
+                        { name: "innerText", type: "text", localized: true },
+                        {
+                          name: "leaves",
+                          type: "blocks",
+                          blocks: [
+                            {
+                              slug: "leaf",
+                              fields: [{ name: "deepText", type: "text", localized: true }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+      const sourceData = {
+        layout: [
+          {
+            id: "L1",
+            blockType: "deepNest",
+            nested: [
+              {
+                id: "N1",
+                blockType: "inner",
+                innerText: "inner en",
+                leaves: [{ id: "F1", blockType: "leaf", deepText: "deep en" }],
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(new DataReconciler(schema).reconcile(sourceData, {})).toEqual({
+        layout: [
+          {
+            id: "L1",
+            blockType: "deepNest",
+            nested: [
+              {
+                id: "N1",
+                blockType: "inner",
+                innerText: "inner en",
+                leaves: [{ id: "F1", blockType: "leaf", deepText: "deep en" }],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it("KEEPS id and merges on a non-localized blocks container with an existing target", () => {
+      const schema: Field[] = [
+        {
+          name: "layout",
+          type: "blocks",
+          blocks: [
+            {
+              slug: "text",
+              fields: [
+                { name: "content", type: "text", localized: true },
+                { name: "style", type: "text", localized: false },
+              ],
+            },
+          ],
+        },
+      ];
+      const sourceData = {
+        layout: [{ id: "b1", blockType: "text", content: "Hello", style: "bold" }],
+      };
+      const targetData = {
+        layout: [{ id: "b1", blockType: "text", content: "Existing", style: "" }],
+      };
+
+      // shared row: target content wins, source style fills, id kept so the row updates in place.
+      expect(new DataReconciler(schema).reconcile(sourceData, targetData)).toEqual({
+        layout: [{ id: "b1", blockType: "text", content: "Existing", style: "bold" }],
+      });
+    });
+
+    it("STRIPS id on a passthrough (unknown blockType) element under a localized container", () => {
+      // Unknown blockType → element skips the reconcile walk and passes through raw; it must still
+      // obey the per-locale id rule, or it leaks the source row's id and collides on insert.
+      const schema: Field[] = [
+        {
+          name: "layout",
+          type: "blocks",
+          localized: true,
+          blocks: [{ slug: "text", fields: [{ name: "content", type: "text", localized: true }] }],
+        },
+      ];
+      const sourceData = { layout: [{ id: "b1", blockType: "ghost", body: "X" }] };
+
+      expect(new DataReconciler(schema).reconcile(sourceData, {})).toEqual({
+        layout: [{ blockType: "ghost", body: "X" }],
+      });
+    });
+
+    it("KEEPS id on a passthrough (unknown blockType) element in a non-localized container", () => {
+      const schema: Field[] = [
+        {
+          name: "layout",
+          type: "blocks",
+          blocks: [{ slug: "text", fields: [{ name: "content", type: "text", localized: true }] }],
+        },
+      ];
+      const sourceData = { layout: [{ id: "b1", blockType: "ghost", body: "X" }] };
+
+      // shared row → the raw passthrough keeps its id.
+      expect(new DataReconciler(schema).reconcile(sourceData, {})).toEqual({
+        layout: [{ id: "b1", blockType: "ghost", body: "X" }],
+      });
+    });
+
+    it("adds no id key when a non-localized element carries no id (guard against id:undefined)", () => {
+      const schema: Field[] = [
+        {
+          name: "items",
+          type: "array",
+          fields: [{ name: "label", type: "text", localized: true }],
+        },
+      ];
+      const sourceData = { items: [{ label: "One" }] };
+
+      expect(new DataReconciler(schema).reconcile(sourceData, {})).toEqual({
+        items: [{ label: "One" }],
+      });
     });
   });
 });

--- a/packages/payload-plugin-translator/src/core/translation-pipeline/stages/data-reconciler/DataReconciler.ts
+++ b/packages/payload-plugin-translator/src/core/translation-pipeline/stages/data-reconciler/DataReconciler.ts
@@ -3,17 +3,31 @@ import { isObject } from "../../../utils/isObject";
 import type { ChildCursor, FieldLike, FieldWalker } from "../../../field-traversal";
 import { matchElementById, resolveBlockFields, walkFields } from "../../../field-traversal";
 
-/** Data position for the reconcile walk: the source + target objects at the current level. */
-type Cursor = { source: Record<string, unknown>; target: Record<string, unknown> };
+/**
+ * Data position for the reconcile walk: the source + target objects at the current level, plus
+ * whether the current row is SHARED across locales.
+ *
+ * `sharedRow` decides array/block `id` retention on output — the data-loss-critical bit. A row is
+ * shared when neither the container nor any ancestor is `localized`: Payload then stores ONE row
+ * with per-locale leaf columns, so its `id` is a stable cross-locale key and must survive
+ * `payload.update({ locale })` (else Payload can't match the row, deletes + recreates it, and wipes
+ * every other locale's values). Under a `localized` container/ancestor the rows are per-locale
+ * (independent ids), so the id is stripped — keeping it would collide with the source locale's row.
+ */
+type Cursor = {
+  source: Record<string, unknown>;
+  target: Record<string, unknown>;
+  sharedRow: boolean;
+};
 
 const asObject = (value: unknown): Record<string, unknown> => (isObject(value) ? value : {});
 
 /**
  * Reconcile walker: produces the full document shape from source + target, with target
  * priority (source fills empty target slots). Iteration is driven by `source`; a field with
- * no source value is dropped, `id` is stripped from array/block elements (Postgres rejects it
- * on update), `blockType` is preserved, and non-object array items / unknown blocks pass
- * through unchanged.
+ * no source value is dropped, `blockType` is preserved, non-object array items / unknown blocks
+ * pass through unchanged, and array/block `id` is kept for shared rows but stripped for per-locale
+ * rows (see {@link Cursor.sharedRow} — the data-loss-critical bit).
  *
  * Array/block elements are paired with their target counterpart by `id`, not by position (see
  * {@link matchElementById}); output order always follows `source`.
@@ -22,7 +36,13 @@ const reconcileWalker: FieldWalker<Cursor, unknown> = {
   enterObject(field, cursor) {
     const sourceValue = cursor.source[field.name];
     if (!isObject(sourceValue)) return "skip"; // undefined / non-object source → drop the field
-    return { source: sourceValue, target: asObject(cursor.target[field.name]) };
+    // A localized group or named tab partitions its whole subtree per locale → descendants are
+    // per-locale rows (Payload's sanitizer propagates `tab.localized` the same as a group).
+    return {
+      source: sourceValue,
+      target: asObject(cursor.target[field.name]),
+      sharedRow: cursor.sharedRow && !field.localized,
+    };
   },
 
   enterList(field, cursor) {
@@ -31,6 +51,8 @@ const reconcileWalker: FieldWalker<Cursor, unknown> = {
     const targetValue = cursor.target[field.name];
     const targetArr: unknown[] = Array.isArray(targetValue) ? targetValue : [];
     const isBlocks = field.type === "blocks";
+    // Elements are shared rows only when this container AND every ancestor is non-localized.
+    const childShared = cursor.sharedRow && !field.localized;
 
     const children: ChildCursor<Cursor>[] = [];
     sourceValue.forEach((item, index) => {
@@ -39,7 +61,11 @@ const reconcileWalker: FieldWalker<Cursor, unknown> = {
       if (!fields) return; // unknown blockType → passthrough
       // Pair by id, not position: target[index] may be a different element under per-locale ordering.
       children.push({
-        cursor: { source: item, target: matchElementById(targetArr, item, isBlocks) },
+        cursor: {
+          source: item,
+          target: matchElementById(targetArr, item, isBlocks),
+          sharedRow: childShared,
+        },
         fields,
         key: index,
       });
@@ -60,14 +86,30 @@ const reconcileWalker: FieldWalker<Cursor, unknown> = {
       // source items (non-object / unknown block) otherwise.
       const sourceArr = (cursor.source[container.key] ?? []) as unknown[];
       const byIndex = new Map(children.map((child) => [child.key, child.out]));
-      return sourceArr.map((item, index) => (byIndex.has(index) ? byIndex.get(index) : item));
+      // Passthrough items (unknown blockType / unresolved fields) never reach the element branch's
+      // id guard, so apply the same rule here: strip a per-locale row's id to avoid an insert
+      // collision. Elements are shared only when this container and every ancestor is non-localized.
+      const childShared = cursor.sharedRow && !container.field.localized;
+      return sourceArr.map((item, index) => {
+        if (byIndex.has(index)) return byIndex.get(index);
+        if (!childShared && isObject(item) && item.id != null) {
+          const { id: _dropped, ...rest } = item;
+          return rest;
+        }
+        return item;
+      });
     }
 
     const result: Record<string, unknown> = {};
     for (const child of children) result[child.key] = child.out;
-    // Block elements keep their blockType; id is intentionally stripped (Postgres rejects it on update).
-    if (container.kind === "element" && container.field.type === "blocks") {
-      result.blockType = cursor.source.blockType;
+    if (container.kind === "element") {
+      // Block elements keep their blockType.
+      if (container.field.type === "blocks") result.blockType = cursor.source.blockType;
+      // Keep `id` only for a shared (non-localized, no localized ancestor) row so Payload updates it
+      // in place; stripping it there makes Payload recreate the row and wipe other locales. Under a
+      // localized container/ancestor the rows are per-locale, so the id is dropped to avoid an
+      // insert collision with the source locale's row. Guard against writing `id: undefined`.
+      if (cursor.sharedRow && cursor.source.id != null) result.id = cursor.source.id;
     }
     return result;
   },
@@ -97,7 +139,7 @@ export class DataReconciler {
     sourceData: Record<string, unknown>,
     targetData: Record<string, unknown>
   ): Record<string, unknown> {
-    const root: Cursor = { source: sourceData, target: targetData ?? {} };
+    const root: Cursor = { source: sourceData, target: targetData ?? {}, sharedRow: true };
     return (
       (walkFields(this.schema, root, reconcileWalker) as Record<string, unknown> | undefined) ?? {}
     );


### PR DESCRIPTION
## Summary

**Critical data-loss fix.** Translating a whole document erased the **source-locale content** inside a **non-localized** `blocks`/`array` container (the recommended shape — non-localized container, localized leaves; e.g. `apps/dev` `Playground.layout`).

## WHY

`DataReconciler` stripped `id` from every array/block element on output. For a **shared row** (non-localized container) an id-less `payload.update({ locale })` can't match the existing row, so Payload **deletes + recreates** it — and the new row only carries the target locale, so **every other locale's leaf values, including the source, are wiped**. Reproduced live on **SQLite and Postgres**. The old "Postgres rejects id on update" rationale was a misdiagnosis — that only holds for **per-locale** (localized) rows.

## WHAT

- **`DataReconciler`**: strip `id` only for **per-locale** rows (the container or any ancestor is `localized`); **keep** it for **shared** rows so Payload updates in place. Threaded a `sharedRow` flag through the reconcile-walker cursor; applied in both the element-combine and the unknown-`blockType` list-passthrough branches.
- **`FieldLike`**: `TabLike` gains `localized?` (a named tab can be localized and partitions its subtree per locale, like a group).
- **Docs**: new fix design doc; corrected the id-strip decision in `2026-06-12-cross-locale-block-identity.md`.

## TESTS

New `DataReconciler` "data-loss guard" describe: keep id for non-localized blocks/array (incl. deep nest, existing-target merge, unknown-`blockType` passthrough); strip under a localized container / group / named-tab ancestor; `id: undefined` guard. Pre-existing reconciler/pipeline expectations updated to the conditional rule.

## Verification

- `bun run test` — **965 pass** (75 files)
- `bun run check-types` — translator clean (pre-existing unrelated `cms` errors are not touched by this PR)
- `bun run lint` — 0 errors
- **End-to-end on SQLite + Postgres**: source survives, target translates, block `id` stable (in-place update).

## Release

`fix:` → patch (**0.7.2**).

Closes #70.