### PR TITLE
fix(translator): track concurrent per-locale translations independently

### DIFF
--- a/packages/payload-plugin-translator/docs/plans/2026-07-15-per-locale-document-status-feed.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-07-15-per-locale-document-status-feed.md
@@ -1,0 +1,149 @@
+# Design — per-locale document status feed (concurrent re-translate fix)
+
+**Date:** 2026-07-15
+**Status:** implemented (server + client + tests); collection panel checked and unaffected.
+**Kind:** bug fix (correctness) + small contract change, internal to the plugin.
+**Relates to:** #50 staleness detection (the status panel this touches shipped in PR #71).
+
+---
+
+## The bug (ground truth)
+
+In the document translation popup's **Status** section, when the source locale (`en`) content changes,
+every other locale's translation is marked stale. Clicking **Re-translate from `en`** on several
+locales in a row exhibits two defects:
+
+1. Each new click appears to **overwrite the previous locale's status** — only the most recently
+   clicked locale shows a running/pending badge; the others fall back to looking merely "stale" even
+   though their jobs are in flight.
+2. The just-clicked row **jumps to the top** and the list re-sorts on every click.
+
+Both are surface symptoms of one root cause.
+
+## Root cause
+
+The document status feed models **one job per document**, but re-translate queues **one job per target
+locale**. The domain is a set keyed by target locale; the plumbing carries a single value. There are
+**three** places this single-value assumption is baked in — two read-path, one write-path.
+
+- **Write path — the real culprit for "overwrites the previous" (found in review).**
+  `PayloadJobsTaskRunner.enqueue` cancels+**deletes** every existing job for the *document* before
+  queuing, scoped only by `(collectionSlug, documentId)` — not by target locale:
+  ```ts
+  const existing = await this.findByCollection(collectionSlug, documentIds); // ALL locales
+  if (existing.length > 0) await this.cancelInternal(existing.map((t) => t.id)); // cancel + delete
+  ```
+  So re-translating `fr` while `de` is still running physically removes the `de` job. `SyncTaskRunner`
+  has the same defect in a different form: its in-memory key `${slug}:${id}` omits the locale, so a
+  second locale's task evicts the first. This is what the user observed as one click overwriting the
+  previous — the earlier locale's job is gone, not just hidden.
+- **Server read — the data is discarded here.** `get-document-status/handler.ts`:
+  ```ts
+  const tasks = await runner.findByCollection(collectionSlug, [collection_id]); // ALL jobs for the doc
+  return ServerResponse.success(tasks[0] ? taskToJobStatusOutput(tasks[0]) : null); // keeps ONE
+  ```
+  `findByCollection` returns every job for the document (all locales); the handler keeps `tasks[0]`
+  (Payload's default order → newest) and drops the rest.
+- **Client read — the single job is overlaid onto its one locale.** `model/statusRows.ts`
+  (`buildTranslationStatusRows`) takes `run?: DocumentTranslation` and overlays that one job onto its
+  `target_lng`. Rows for the other in-flight locales never see their job, so they render from staleness
+  alone (`stale`).
+
+### Why each symptom
+
+1. **"Overwrites the previous"** — each click creates a new job; `tasks[0]` becomes that newest job, so
+   only the last-clicked locale carries a transient (running/pending) state. The earlier locales'
+   running jobs are invisible.
+2. **"Jumps to the top"** — the one visible job has a transient state, and the sort
+   (`statusRows.ts`, `ORDER`: `failed < running < pending < stale < translated`, then newest `at` first)
+   ranks transient states above `stale`/`translated`, so the active row surfaces to the top.
+
+## The fix
+
+Make the document status feed **per target locale**: the server returns the latest job for each target
+locale; the client overlays all of them.
+
+### D1 — response contract: single job → array of latest-per-locale
+
+`GET /translate/document/:collection_slug/:collection_id` returns `JobStatusOutput[]` (one entry per
+target locale, its latest job) instead of a single `JobStatusOutput | null`.
+
+- **Chosen** over "keep `data` + add a `jobs[]` field": one source of truth. The plugin's server and
+  client ship in the same package, so changing the response shape has no external blast radius (the
+  route is consumed only by this plugin's own client).
+- The handler picks the latest job per `target_lng` (tie-break by `createdAt`/`updatedAt`, newest wins)
+  from the `findByCollection` result it already fetches — no extra query.
+- `taskToJobStatusOutput` is unchanged (still maps one `Task`); the handler maps the reduced list.
+
+### D2 — client: `useDocumentTranslation` returns `DocumentTranslation[]`
+
+- Query type single → array. `refetchInterval` polls while **any** job is pending/running (today it
+  reads `data?.status`).
+- The completed→staleness-invalidation effect (`previousStatusRef`, added for #50) must track the set,
+  not a scalar: fire when **any** locale transitions `(defined, non-completed) → completed`. Simplest
+  correct form: compare the previous vs current set of completed target locales and invalidate staleness
+  if it grew. Preserves the #50 behaviour (out-of-date notice clears without waiting for refocus).
+
+### D3 — merge: `buildTranslationStatusRows` overlays all jobs
+
+- Signature `run?: DocumentTranslation` → `runs?: DocumentTranslation[]`.
+- Per locale: start from staleness (`stale`/`translated`), then overlay that locale's latest job —
+  transient state wins over the durable signal; a job for an unlisted locale adds a row (today's rules,
+  applied per locale instead of once).
+- Sorting is unchanged. With every active locale now carrying its true transient state, the list is
+  stable across successive clicks (each clicked row settles into running/pending rather than one row
+  hopping to the top while the rest look stale).
+
+### D4 — supersede jobs per (document, locale), not per document
+
+`PayloadJobsTaskRunner.enqueue` scopes its cancel-existing step to the same `(documentId, targetLng)`
+tuples being enqueued, so re-translating one locale never cancels another locale's in-flight job.
+`SyncTaskRunner`'s in-memory key gains the target locale (`${slug}:${id}:${targetLng}`). Bulk "translate
+all locales" is unaffected — it enqueues every target locale, so each supersedes only its own prior job.
+
+### The capture-before-mutation invariant is untouched
+
+The #50 fingerprint invariant (fingerprint the pristine source before the pipeline mutates it) and
+`ProvenanceService` are not involved — D4 changes *which* jobs are cancelled, not how content is hashed.
+
+## Blast radius
+
+- **Write path:** `payload-jobs-runner/PayloadJobsTaskRunner.ts` (locale-scoped supersession),
+  `sync-runner/SyncTaskRunner.ts` (locale in the key), + both runner test files.
+- **Server read:** `get-document-status/handler.ts` (reduce to latest-per-locale), `get-document-status/model.ts`
+  (`latestTaskPerTargetLocale` + response type), `handler.test.ts` + new `model.test.ts`.
+- **Client:** `useDocumentTranslation.ts` (type + polling + invalidation effect), `model/statusRows.ts`
+  + `statusRows.test.ts`, `model/panelStatus.ts` if it reads the single run, `TranslateDocument.tsx`
+  (pass `runs` instead of `data`), `model/types.ts`.
+- **Contract:** `JobStatusOutput` single → array. Internal to the package (server + client shipped
+  together); `src/index.ts` unaffected — no public API change → **patch** release.
+
+## Verify
+
+- `check-types` clean · `lint` 0 errors · `vitest run` green.
+- New/updated tests: (a) `enqueue` does NOT cancel a different locale's running job, and supersedes only
+  the same-locale job; `SyncTaskRunner` keeps one task per locale; (b) `latestTaskPerTargetLocale`
+  reduction incl. the equal-`createdAt` tie-break; (c) `buildTranslationStatusRows` with N concurrent
+  jobs shows N transient rows and a stable order; (d) `deriveDocumentRunStatus` priority.
+- Manual: queue re-translate on 3 locales in a row → all three show running/pending; no row-swapping.
+
+## Resilience / upgrade safety
+
+A blast-radius review of the server changes found no data-loss, schema change, or migration: job
+records are unchanged (`documentLocaleKey` and the Sync key are in-memory only), completed jobs
+auto-delete (Payload's `deleteJobOnComplete` default) and superseded same-locale jobs are deleted on
+re-enqueue, so retained rows are bounded by `docs × locales` (failed only). The `GET /document/...`
+endpoint is internal (not re-exported from `src/index.ts`, no external caller). The one caveat —
+deploy skew: a stale admin tab from before the object→array response change could feed a non-array to
+the polling callback — is hardened with an `Array.isArray` normalizer in `useDocumentTranslation`
+(self-healing regardless, but this avoids a transient throw mid-deploy).
+
+## Open / follow-up
+
+- **Collection-level panel** — checked and **not affected**. The collection popup
+  (`useCollectionTranslationStatus`) is a bulk dashboard grouping documents by status; it has no
+  per-locale status rows and no per-locale "Re-translate" action, so the concurrent-per-locale defect
+  cannot occur there. No change needed.
+- **Shared `queueApi.isPending` on re-translate buttons** (pre-existing, out of scope): all
+  re-translate buttons share one mutation instance, so all show the loading state while any queue is in
+  flight. Cosmetic, unrelated to this fix; left as-is.

--- a/packages/payload-plugin-translator/src/client/entities/translation/api/queries/useDocumentTranslation.ts
+++ b/packages/payload-plugin-translator/src/client/entities/translation/api/queries/useDocumentTranslation.ts
@@ -27,11 +27,11 @@ export function useDocumentTranslation({ collection, id }: Props, options?: Opti
   const queryClient = useQueryClient();
   const { basePath } = useTranslateKitConfig();
 
-  const query = useQuery<DocumentTranslation, Error, DocumentTranslation>({
+  const query = useQuery<DocumentTranslation[], Error, DocumentTranslation[]>({
     queryKey: getDocumentTranslationQueryKey({ collection, id }),
     queryFn: async ({ signal }) => {
       return handleNextApiError(async () => {
-        const response = await ofetch<{ data: DocumentTranslation }>(
+        const response = await ofetch<{ data: DocumentTranslation[] }>(
           `/api${basePath}/document/${collection}/${id}`,
           {
             method: "get",
@@ -39,14 +39,18 @@ export function useDocumentTranslation({ collection, id }: Props, options?: Opti
           }
         );
 
-        return response.data;
+        // Normalize to an array defensively: a stale admin tab from before the object→array response
+        // change (deploy skew) would otherwise feed a non-array here and break the polling callback.
+        return Array.isArray(response.data) ? response.data : [];
       });
     },
     enabled: options?.enabled,
+    // Keep polling while any locale's job is still in flight; stop once every job is terminal.
     refetchInterval: (query) => {
-      return query.state.data?.status === "failed" || query.state.data?.status === "completed"
-        ? false
-        : POLLING_INTERVAL_MILLISECONDS;
+      const active = (query.state.data ?? []).some(
+        (job) => job.status === "pending" || job.status === "running"
+      );
+      return active ? POLLING_INTERVAL_MILLISECONDS : false;
     },
   });
 
@@ -57,21 +61,27 @@ export function useDocumentTranslation({ collection, id }: Props, options?: Opti
   // When a queued (async) translation transitions to "completed" in-session, the provenance
   // record's sourceFingerprint has just been updated server-side — invalidate staleness so the
   // "Out of date" notice clears without waiting for the next focus/remount refetch (#50).
-  // Seeded lazily (undefined) and gated on a *defined, non-completed → completed* transition, so a
-  // cold mount of an already-completed document does NOT fire a spurious extra refetch.
-  const previousStatusRef = useRef<string | undefined>(undefined);
+  // Tracked as a *set* of completed target locales (the feed is now per-locale): fire whenever a
+  // locale newly reaches "completed". The snapshot is tagged with the document key and reset when
+  // the document changes, so a cold mount of an already-completed document — or navigating to a
+  // different document within the same component instance — does NOT fire a spurious extra refetch.
+  const docKey = `${collection}:${id}`;
+  const previousCompletedRef = useRef<{ docKey: string; locales: Set<string> } | undefined>(
+    undefined
+  );
   useEffect(() => {
-    const previousStatus = previousStatusRef.current;
-    const currentStatus = query.data?.status;
-    if (
-      currentStatus === "completed" &&
-      previousStatus !== undefined &&
-      previousStatus !== "completed"
-    ) {
+    const jobs = query.data;
+    if (!jobs) return;
+    const completed = new Set(
+      jobs.filter((job) => job.status === "completed").map((job) => job.input.target_lng)
+    );
+    const previous = previousCompletedRef.current;
+    const sameDoc = previous?.docKey === docKey;
+    if (sameDoc && [...completed].some((locale) => !previous.locales.has(locale))) {
       queryClient.invalidateQueries({ queryKey: [DOCUMENT_STALENESS_QUERY_KEY] });
     }
-    previousStatusRef.current = currentStatus;
-  }, [query.data?.status, queryClient]);
+    previousCompletedRef.current = { docKey, locales: completed };
+  }, [query.data, queryClient, docKey]);
 
   return { ...query, invalidate };
 }

--- a/packages/payload-plugin-translator/src/client/entities/translation/index.ts
+++ b/packages/payload-plugin-translator/src/client/entities/translation/index.ts
@@ -38,6 +38,7 @@ export { DocumentTranslationStatus } from "./model/enums";
 export {
   derivePanelStatus,
   deriveCollectionPanelStatus,
+  deriveDocumentRunStatus,
   describePanelStatus,
 } from "./model/panelStatus";
 export type { PanelStatus, MarkerTone } from "./model/panelStatus";

--- a/packages/payload-plugin-translator/src/client/entities/translation/model/panelStatus.test.ts
+++ b/packages/payload-plugin-translator/src/client/entities/translation/model/panelStatus.test.ts
@@ -3,12 +3,13 @@ import { describe, it, expect } from "vitest";
 import { DocumentTranslationStatus } from "./enums";
 import {
   deriveCollectionPanelStatus,
+  deriveDocumentRunStatus,
   derivePanelStatus,
   describePanelStatus,
   MARKER_DOT,
 } from "./panelStatus";
 import { STATE_DOT } from "./statusRows";
-import type { GroupedCollectionTranslationStatus } from "./types";
+import type { DocumentTranslation, GroupedCollectionTranslationStatus } from "./types";
 
 describe("derivePanelStatus", () => {
   it("failed outranks everything, including stale locales", () => {
@@ -49,6 +50,48 @@ describe("derivePanelStatus", () => {
   it("none when nothing has been translated and nothing is stale", () => {
     expect(derivePanelStatus({ runStatus: null, staleLocales: [] })).toEqual({ kind: "none" });
     expect(derivePanelStatus({ staleLocales: [] })).toEqual({ kind: "none" });
+  });
+});
+
+describe("deriveDocumentRunStatus", () => {
+  const jobWith = (status: DocumentTranslationStatus, target: string): DocumentTranslation =>
+    ({
+      id: `job-${target}`,
+      status,
+      created_at: "2026-07-14T00:00:00.000Z",
+      updated_at: "2026-07-14T00:00:00.000Z",
+      input: { source_lng: "en", target_lng: target },
+      ...(status === DocumentTranslationStatus.FAILED ? { error: { message: "x" } } : {}),
+      ...(status === DocumentTranslationStatus.COMPLETED
+        ? { completed_at: "2026-07-14T00:00:00.000Z" }
+        : {}),
+    }) as DocumentTranslation;
+
+  it("returns undefined when there are no jobs", () => {
+    expect(deriveDocumentRunStatus(undefined)).toBeUndefined();
+    expect(deriveDocumentRunStatus([])).toBeUndefined();
+  });
+
+  it("picks the most urgent status across locales: failed > running > pending > completed", () => {
+    expect(
+      deriveDocumentRunStatus([
+        jobWith(DocumentTranslationStatus.COMPLETED, "de"),
+        jobWith(DocumentTranslationStatus.RUNNING, "fr"),
+        jobWith(DocumentTranslationStatus.FAILED, "it"),
+      ])
+    ).toBe(DocumentTranslationStatus.FAILED);
+
+    expect(
+      deriveDocumentRunStatus([
+        jobWith(DocumentTranslationStatus.COMPLETED, "de"),
+        jobWith(DocumentTranslationStatus.PENDING, "fr"),
+        jobWith(DocumentTranslationStatus.RUNNING, "it"),
+      ])
+    ).toBe(DocumentTranslationStatus.RUNNING);
+
+    expect(deriveDocumentRunStatus([jobWith(DocumentTranslationStatus.COMPLETED, "de")])).toBe(
+      DocumentTranslationStatus.COMPLETED
+    );
   });
 });
 

--- a/packages/payload-plugin-translator/src/client/entities/translation/model/panelStatus.ts
+++ b/packages/payload-plugin-translator/src/client/entities/translation/model/panelStatus.ts
@@ -1,6 +1,6 @@
 import { DocumentTranslationStatus } from "./enums";
 import type { StatusDotColor } from "./statusRows";
-import type { GroupedCollectionTranslationStatus } from "./types";
+import type { DocumentTranslation, GroupedCollectionTranslationStatus } from "./types";
 
 /**
  * The single aggregate signal shown on a translate trigger (document or collection). Detail lives in
@@ -54,8 +54,29 @@ export function describePanelStatus(
   }
 }
 
+// The most-urgent job status wins the single aggregate marker, in the order `derivePanelStatus`
+// itself ranks them: a failure to surface, then in-flight work, then a queued job, then completed.
+const RUN_STATUS_PRIORITY: DocumentTranslationStatus[] = [
+  DocumentTranslationStatus.FAILED,
+  DocumentTranslationStatus.RUNNING,
+  DocumentTranslationStatus.PENDING,
+  DocumentTranslationStatus.COMPLETED,
+];
+
+/**
+ * Collapse the per-locale job feed into the single most-urgent run status for the trigger marker.
+ * Returns `undefined` when there are no jobs. The panel shows one aggregate signal; the popup's list
+ * carries the full per-locale detail.
+ */
+export function deriveDocumentRunStatus(
+  runs: DocumentTranslation[] | undefined
+): DocumentTranslationStatus | undefined {
+  const present = new Set(runs?.map((run) => run.status));
+  return RUN_STATUS_PRIORITY.find((status) => present.has(status));
+}
+
 type PanelStatusInput = {
-  /** Status of the latest translation job, if any. */
+  /** Status of the most-urgent translation job across locales, if any (see `deriveDocumentRunStatus`). */
   runStatus?: DocumentTranslationStatus | null;
   /** Target locales whose translation is out of date (from staleness detection). */
   staleLocales: string[];

--- a/packages/payload-plugin-translator/src/client/entities/translation/model/statusRows.test.ts
+++ b/packages/payload-plugin-translator/src/client/entities/translation/model/statusRows.test.ts
@@ -48,7 +48,7 @@ describe("buildTranslationStatusRows", () => {
   it("overlays a transient job (running) over the durable state and sets jobId", () => {
     const rows = buildTranslationStatusRows({
       staleness: staleness([{ target: "de", stale: true }]),
-      run: job(DocumentTranslationStatus.RUNNING, "de"),
+      runs: [job(DocumentTranslationStatus.RUNNING, "de")],
     });
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ targetLocale: "de", state: "running", jobId: "job-de" });
@@ -57,7 +57,7 @@ describe("buildTranslationStatusRows", () => {
   it("adds a row for a job whose target has no provenance record yet, carrying the failure reason", () => {
     const rows = buildTranslationStatusRows({
       staleness: staleness([{ target: "de", stale: false }]),
-      run: job(DocumentTranslationStatus.FAILED, "it"),
+      runs: [job(DocumentTranslationStatus.FAILED, "it")],
     });
     expect(rows.map((r) => [r.targetLocale, r.state])).toEqual([
       ["it", "failed"],
@@ -70,11 +70,32 @@ describe("buildTranslationStatusRows", () => {
   it("does not override a durable row with a completed job (no duplicate, keeps provenance state)", () => {
     const rows = buildTranslationStatusRows({
       staleness: staleness([{ target: "de", stale: true }]),
-      run: job(DocumentTranslationStatus.COMPLETED, "de"),
+      runs: [job(DocumentTranslationStatus.COMPLETED, "de")],
     });
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ targetLocale: "de", state: "stale" });
     expect(rows[0].jobId).toBeUndefined();
+  });
+
+  it("overlays every concurrent job onto its own locale — no job overwrites another", () => {
+    // Three locales stale; two are being re-translated concurrently, one still just stale.
+    const rows = buildTranslationStatusRows({
+      staleness: staleness([
+        { target: "de", stale: true },
+        { target: "fr", stale: true },
+        { target: "it", stale: true },
+      ]),
+      runs: [
+        job(DocumentTranslationStatus.RUNNING, "de"),
+        job(DocumentTranslationStatus.PENDING, "fr"),
+      ],
+    });
+    const byLocale = Object.fromEntries(rows.map((r) => [r.targetLocale, r]));
+    expect(byLocale.de).toMatchObject({ state: "running", jobId: "job-de" });
+    expect(byLocale.fr).toMatchObject({ state: "pending", jobId: "job-fr" });
+    // The untouched locale keeps its durable stale state — it is not clobbered by the other jobs.
+    expect(byLocale.it).toMatchObject({ state: "stale" });
+    expect(byLocale.it.jobId).toBeUndefined();
   });
 
   it("sorts by priority failed → running → pending → stale → translated", () => {
@@ -83,14 +104,14 @@ describe("buildTranslationStatusRows", () => {
         { target: "de", stale: false },
         { target: "fr", stale: true },
       ]),
-      run: job(DocumentTranslationStatus.FAILED, "it"),
+      runs: [job(DocumentTranslationStatus.FAILED, "it")],
     });
     expect(rows.map((r) => r.state)).toEqual(["failed", "stale", "translated"]);
   });
 
   it("returns [] when there is nothing to show", () => {
     expect(buildTranslationStatusRows({})).toEqual([]);
-    expect(buildTranslationStatusRows({ staleness: { locales: [] }, run: null })).toEqual([]);
+    expect(buildTranslationStatusRows({ staleness: { locales: [] }, runs: [] })).toEqual([]);
   });
 });
 

--- a/packages/payload-plugin-translator/src/client/entities/translation/model/statusRows.test.ts
+++ b/packages/payload-plugin-translator/src/client/entities/translation/model/statusRows.test.ts
@@ -31,16 +31,17 @@ const job = (
   }) as DocumentTranslation;
 
 describe("buildTranslationStatusRows", () => {
-  it("maps staleness into stale + translated rows, stale before translated", () => {
+  it("orders rows by the source→target locale pair, independent of state", () => {
     const rows = buildTranslationStatusRows({
       staleness: staleness([
-        { target: "de", stale: false },
         { target: "fr", stale: true },
+        { target: "de", stale: false },
       ]),
     });
+    // `de` before `fr` alphabetically, even though `fr` is stale and `de` is merely translated.
     expect(rows.map((r) => [r.targetLocale, r.state])).toEqual([
-      ["fr", "stale"],
       ["de", "translated"],
+      ["fr", "stale"],
     ]);
     expect(rows[0].sourceLocale).toBe("en");
   });
@@ -59,12 +60,14 @@ describe("buildTranslationStatusRows", () => {
       staleness: staleness([{ target: "de", stale: false }]),
       runs: [job(DocumentTranslationStatus.FAILED, "it")],
     });
+    // Ordered by locale pair (de before it), regardless of state.
     expect(rows.map((r) => [r.targetLocale, r.state])).toEqual([
-      ["it", "failed"],
       ["de", "translated"],
+      ["it", "failed"],
     ]);
-    expect(rows[0].jobId).toBe("job-it");
-    expect(rows[0].error).toBe("x");
+    const failed = rows.find((r) => r.targetLocale === "it");
+    expect(failed?.jobId).toBe("job-it");
+    expect(failed?.error).toBe("x");
   });
 
   it("does not override a durable row with a completed job (no duplicate, keeps provenance state)", () => {
@@ -98,15 +101,22 @@ describe("buildTranslationStatusRows", () => {
     expect(byLocale.it.jobId).toBeUndefined();
   });
 
-  it("sorts by priority failed → running → pending → stale → translated", () => {
-    const rows = buildTranslationStatusRows({
-      staleness: staleness([
-        { target: "de", stale: false },
-        { target: "fr", stale: true },
-      ]),
-      runs: [job(DocumentTranslationStatus.FAILED, "it")],
-    });
-    expect(rows.map((r) => r.state)).toEqual(["failed", "stale", "translated"]);
+  it("keeps a row in the same position when its state changes (re-translate does not reorder)", () => {
+    const base = staleness([
+      { target: "de", stale: false },
+      { target: "fr", stale: true },
+      { target: "it", stale: true },
+    ]);
+    const orderBefore = buildTranslationStatusRows({ staleness: base }).map((r) => r.targetLocale);
+
+    // Re-translate `it` → its state flips stale → running; the order must be unchanged.
+    const orderAfter = buildTranslationStatusRows({
+      staleness: base,
+      runs: [job(DocumentTranslationStatus.RUNNING, "it")],
+    }).map((r) => r.targetLocale);
+
+    expect(orderBefore).toEqual(["de", "fr", "it"]);
+    expect(orderAfter).toEqual(orderBefore);
   });
 
   it("returns [] when there is nothing to show", () => {

--- a/packages/payload-plugin-translator/src/client/entities/translation/model/statusRows.ts
+++ b/packages/payload-plugin-translator/src/client/entities/translation/model/statusRows.ts
@@ -37,16 +37,12 @@ export const STATE_DOT: Record<TranslationRowState, { color: StatusDotColor; ani
     translated: { color: "green" },
   };
 
-// Most urgent first. Transient job states outrank the durable stale/translated signal.
-const ORDER: Record<TranslationRowState, number> = {
-  failed: 0,
-  running: 1,
-  pending: 2,
-  stale: 3,
-  translated: 4,
-};
-
 const TRANSIENT: ReadonlySet<TranslationRowState> = new Set(["failed", "running", "pending"]);
+
+// A row's permanent identity for ordering: the source→target locale pair (unique per row, never
+// changes when the row's state does).
+const localePairKey = (row: TranslationStatusRow): string =>
+  `${row.sourceLocale}:${row.targetLocale}`;
 
 // Maps the closed 4-member job-status set to a row state. "completed" → "translated"; the transient
 // three pass through. If a new DocumentTranslationStatus is ever added, extend this explicitly —
@@ -64,8 +60,8 @@ const toRowState = (jobStatus: string): TranslationRowState =>
  * **transient** job state (failed/running/pending) wins over the durable signal for that locale, and a
  * job for a target with no provenance row yet adds a row. Overlaying *every* job (not just one) is what
  * lets several concurrent re-translations each show their own live state instead of the last one
- * appearing to overwrite the rest. Sorted `failed → running → pending → stale → translated`, newest
- * first within a group.
+ * appearing to overwrite the rest. Sorted by the fixed source→target locale pair (not by state), so a
+ * row keeps its place when its state changes — re-translating a locale never reorders the list.
  */
 export function buildTranslationStatusRows(input: {
   staleness?: DocumentStaleness | null;
@@ -100,7 +96,9 @@ export function buildTranslationStatusRows(input: {
     }
   }
 
-  return [...byTarget.values()].sort(
-    (a, b) => ORDER[a.state] - ORDER[b.state] || (b.at ?? "").localeCompare(a.at ?? "")
-  );
+  // Stable order by the source→target locale pair — the one thing about a row that never changes when
+  // its state does. Sorting by state/time instead would make a row jump (e.g. to the top) the moment
+  // you re-translate it; the locale pair keeps every row in a fixed place, and progress is conveyed by
+  // the badge/dot, not the position. The pair is unique (one row per target), so no tie-break needed.
+  return [...byTarget.values()].sort((a, b) => localePairKey(a).localeCompare(localePairKey(b)));
 }

--- a/packages/payload-plugin-translator/src/client/entities/translation/model/statusRows.ts
+++ b/packages/payload-plugin-translator/src/client/entities/translation/model/statusRows.ts
@@ -57,18 +57,21 @@ const toRowState = (jobStatus: string): TranslationRowState =>
     : "translated";
 
 /**
- * Build the unified status rows from per-locale staleness + the single latest job.
+ * Build the unified status rows from per-locale staleness + the latest job per target locale.
  *
- * Rows come from `staleness.locales` (one per translated target: `stale` or `translated`). The latest
- * job is overlaid onto its target locale: a **transient** job state (failed/running/pending) wins over
- * the durable signal for that locale, and a job for a target with no provenance row yet adds a row.
- * Sorted `failed → running → pending → stale → translated`, newest first within a group.
+ * Rows come from `staleness.locales` (one per translated target: `stale` or `translated`). Each job in
+ * `runs` (one per target locale — see `useDocumentTranslation`) is overlaid onto its target locale: a
+ * **transient** job state (failed/running/pending) wins over the durable signal for that locale, and a
+ * job for a target with no provenance row yet adds a row. Overlaying *every* job (not just one) is what
+ * lets several concurrent re-translations each show their own live state instead of the last one
+ * appearing to overwrite the rest. Sorted `failed → running → pending → stale → translated`, newest
+ * first within a group.
  */
 export function buildTranslationStatusRows(input: {
   staleness?: DocumentStaleness | null;
-  run?: DocumentTranslation;
+  runs?: DocumentTranslation[];
 }): TranslationStatusRow[] {
-  const { staleness, run } = input;
+  const { staleness, runs } = input;
   const byTarget = new Map<string, TranslationStatusRow>();
 
   for (const locale of staleness?.locales ?? []) {
@@ -80,7 +83,7 @@ export function buildTranslationStatusRows(input: {
     });
   }
 
-  if (run) {
+  for (const run of runs ?? []) {
     const state = toRowState(run.status);
     const target = run.input.target_lng;
     const existing = byTarget.get(target);

--- a/packages/payload-plugin-translator/src/client/entities/translation/model/types.ts
+++ b/packages/payload-plugin-translator/src/client/entities/translation/model/types.ts
@@ -41,12 +41,16 @@ export type DocumentTranslationCompleted = {
   input: InputData;
 };
 
+/**
+ * One translation job for a single target locale. The document status feed is an array of these —
+ * the latest job per target locale (see `useDocumentTranslation`), because re-translate queues an
+ * independent job per locale.
+ */
 export type DocumentTranslation =
   | DocumentTranslationCompleted
   | DocumentTranslationRunning
   | DocumentTranslationFailed
-  | DocumentTranslationPending
-  | null;
+  | DocumentTranslationPending;
 
 export type CollectionTranslationStatusItem = { id: string; status: DocumentTranslationStatus };
 

--- a/packages/payload-plugin-translator/src/client/widgets/translate-document/ui/TranslateDocument.tsx
+++ b/packages/payload-plugin-translator/src/client/widgets/translate-document/ui/TranslateDocument.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo } from "react";
 
 import {
   buildTranslationStatusRows,
+  deriveDocumentRunStatus,
   derivePanelStatus,
   TranslationsApi,
   TranslationStatusList,
@@ -42,11 +43,11 @@ const TranslateDocument = ({ hasDrafts }: TranslateDocumentProps) => {
   );
   // The panel trigger shows one aggregate marker; the popup shows the full per-locale list.
   const panelStatus = useMemo(
-    () => derivePanelStatus({ runStatus: data?.status, staleLocales }),
-    [data?.status, staleLocales]
+    () => derivePanelStatus({ runStatus: deriveDocumentRunStatus(data), staleLocales }),
+    [data, staleLocales]
   );
   const statusRows = useMemo(
-    () => buildTranslationStatusRows({ staleness, run: data }),
+    () => buildTranslationStatusRows({ staleness, runs: data }),
     [staleness, data]
   );
 

--- a/packages/payload-plugin-translator/src/server/features/get-document-status/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-document-status/handler.test.ts
@@ -101,7 +101,7 @@ describe("GetDocumentStatusHandler", () => {
   });
 
   describe("success responses", () => {
-    it("returns task status when task exists", async () => {
+    it("returns one task status entry per document, wrapped in an array", async () => {
       const task = createMockTask();
       (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([task]);
 
@@ -113,7 +113,8 @@ describe("GetDocumentStatusHandler", () => {
 
       expect(response.status).toBe(200);
       const body = await response.json();
-      expect(body.data).toMatchObject({
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0]).toMatchObject({
         id: "task-123",
         status: "completed",
         input: {
@@ -127,7 +128,46 @@ describe("GetDocumentStatusHandler", () => {
       });
     });
 
-    it("returns null when no task exists", async () => {
+    it("returns one entry per target locale, keeping the latest job per locale", async () => {
+      // Two locales, and a superseded older job for `de` — the reduction keeps the newest per locale.
+      const deOld = createMockTask({
+        id: "de-old",
+        input: { ...createMockTask().input, targetLng: "de" },
+        createdAt: "2024-01-01T00:00:00Z",
+        status: "failed",
+      });
+      const deNew = createMockTask({
+        id: "de-new",
+        input: { ...createMockTask().input, targetLng: "de" },
+        createdAt: "2024-01-02T00:00:00Z",
+        status: "running",
+      });
+      const fr = createMockTask({
+        id: "fr-1",
+        input: { ...createMockTask().input, targetLng: "fr" },
+        createdAt: "2024-01-01T12:00:00Z",
+        status: "pending",
+      });
+      (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([
+        deOld,
+        deNew,
+        fr,
+      ]);
+
+      const req = createMockRequest({ collection_slug: "posts", collection_id: "doc-123" });
+      const body = await (await handler.handle(req)).json();
+
+      const byLocale = Object.fromEntries(
+        (body.data as Array<{ id: string; status: string; input: { target_lng: string } }>).map(
+          (job) => [job.input.target_lng, job]
+        )
+      );
+      expect(Object.keys(byLocale).sort()).toEqual(["de", "fr"]);
+      expect(byLocale.de).toMatchObject({ id: "de-new", status: "running" });
+      expect(byLocale.fr).toMatchObject({ id: "fr-1", status: "pending" });
+    });
+
+    it("returns an empty array when no task exists", async () => {
       (mockTaskRunner.findByCollection as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 
       const req = createMockRequest({
@@ -138,7 +178,7 @@ describe("GetDocumentStatusHandler", () => {
 
       expect(response.status).toBe(200);
       const body = await response.json();
-      expect(body.data).toBeNull();
+      expect(body.data).toEqual([]);
     });
 
     it("calls findByCollection with correct parameters", async () => {
@@ -181,8 +221,8 @@ describe("GetDocumentStatusHandler", () => {
       const response = await handler.handle(req);
 
       const body = await response.json();
-      expect(body.data.status).toBe("failed");
-      expect(body.data.error).toEqual({ message: "Translation failed" });
+      expect(body.data[0].status).toBe("failed");
+      expect(body.data[0].error).toEqual({ message: "Translation failed" });
     });
 
     it("does not leak the raw error to the client in production", async () => {
@@ -200,7 +240,7 @@ describe("GetDocumentStatusHandler", () => {
         });
         const body = await (await handler.handle(req)).json();
 
-        expect(body.data.error).toEqual({ message: GENERIC_TRANSLATION_ERROR });
+        expect(body.data[0].error).toEqual({ message: GENERIC_TRANSLATION_ERROR });
         expect(JSON.stringify(body)).not.toContain("sk-proj");
       } finally {
         vi.unstubAllEnvs();
@@ -218,7 +258,7 @@ describe("GetDocumentStatusHandler", () => {
       const response = await handler.handle(req);
 
       const body = await response.json();
-      expect(body.data.cancelled).toBe(true);
+      expect(body.data[0].cancelled).toBe(true);
     });
   });
 });

--- a/packages/payload-plugin-translator/src/server/features/get-document-status/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-document-status/handler.ts
@@ -4,7 +4,11 @@ import { ServerResponse } from "../../shared";
 import type { TaskRunnerFactory } from "../../modules/task-runner";
 import { isCollectionAvailable } from "../_lib/collection-utils";
 
-import { GetDocumentStatusInputSchema, taskToJobStatusOutput } from "./model";
+import {
+  GetDocumentStatusInputSchema,
+  latestTaskPerTargetLocale,
+  taskToJobStatusOutput,
+} from "./model";
 import type { GetDocumentStatusConfig } from "./model";
 
 /**
@@ -30,6 +34,8 @@ export class GetDocumentStatusHandler {
     const runner = this.taskRunnerFactory.create(req.payload);
     const tasks = await runner.findByCollection(collectionSlug, [collection_id]);
 
-    return ServerResponse.success(tasks[0] ? taskToJobStatusOutput(tasks[0]) : null);
+    // One job per target locale (latest), not a single job for the whole document — re-translate
+    // queues an independent job per locale, and the status panel renders a row per locale.
+    return ServerResponse.success(latestTaskPerTargetLocale(tasks).map(taskToJobStatusOutput));
   }
 }

--- a/packages/payload-plugin-translator/src/server/features/get-document-status/model.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-document-status/model.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import type { CollectionSlug } from "payload";
+
+import type { Task } from "../../modules/task-runner";
+
+import { latestTaskPerTargetLocale } from "./model";
+
+const task = (over: Partial<Task> & { targetLng: string; id: string }): Task => ({
+  id: over.id,
+  status: over.status ?? "pending",
+  input: {
+    collectionSlug: "posts" as CollectionSlug,
+    collectionId: "doc-1",
+    sourceLng: "en",
+    targetLng: over.targetLng,
+    strategy: "overwrite",
+    publishOnTranslation: false,
+  },
+  createdAt: over.createdAt ?? "2024-01-01T00:00:00Z",
+  updatedAt: over.updatedAt ?? "2024-01-01T00:00:00Z",
+  cancelled: false,
+});
+
+describe("latestTaskPerTargetLocale", () => {
+  it("returns one task per target locale", () => {
+    const result = latestTaskPerTargetLocale([
+      task({ id: "de", targetLng: "de" }),
+      task({ id: "fr", targetLng: "fr" }),
+    ]);
+    expect(result.map((t) => t.input.targetLng).sort()).toEqual(["de", "fr"]);
+  });
+
+  it("keeps the most recently created task for a locale", () => {
+    const result = latestTaskPerTargetLocale([
+      task({ id: "old", targetLng: "de", createdAt: "2024-01-01T00:00:00Z" }),
+      task({ id: "new", targetLng: "de", createdAt: "2024-01-02T00:00:00Z" }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("new");
+  });
+
+  it("tie-breaks equal createdAt by the most recently updated task", () => {
+    const result = latestTaskPerTargetLocale([
+      task({
+        id: "stale",
+        targetLng: "de",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      }),
+      task({
+        id: "fresh",
+        targetLng: "de",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T06:00:00Z",
+      }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("fresh");
+  });
+
+  it("returns [] for no tasks", () => {
+    expect(latestTaskPerTargetLocale([])).toEqual([]);
+  });
+});

--- a/packages/payload-plugin-translator/src/server/features/get-document-status/model.ts
+++ b/packages/payload-plugin-translator/src/server/features/get-document-status/model.ts
@@ -57,6 +57,31 @@ export type GetDocumentStatusConfig = {
   availableCollections: Set<CollectionSlug>;
 };
 
+// A job is "newer" by creation time, tie-broken by last update — both ISO-8601, so a lexicographic
+// string compare is a correct chronological compare (no Date parsing needed).
+const isNewerTask = (candidate: Task, current: Task): boolean =>
+  candidate.createdAt !== current.createdAt
+    ? candidate.createdAt > current.createdAt
+    : candidate.updatedAt > current.updatedAt;
+
+/**
+ * Reduce a document's jobs to the latest one per target locale.
+ *
+ * `findByCollection` returns every job for the document across all target locales (plus any superseded
+ * jobs not yet cancelled). The status panel shows one row per target locale, so we keep — per
+ * `targetLng` — the most recently created job (tie-break: most recently updated). Without this the
+ * caller sees a single arbitrary job and every other in-flight locale looks idle, which is the
+ * concurrent re-translate bug (a second re-translate appearing to overwrite the first's status).
+ */
+export function latestTaskPerTargetLocale(tasks: Task[]): Task[] {
+  const byLocale = new Map<string, Task>();
+  for (const task of tasks) {
+    const current = byLocale.get(task.input.targetLng);
+    if (!current || isNewerTask(task, current)) byLocale.set(task.input.targetLng, task);
+  }
+  return [...byLocale.values()];
+}
+
 /**
  * Transforms a Task to API output format (snake_case for client compatibility)
  */

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.test.ts
@@ -115,6 +115,61 @@ describe("PayloadJobsTaskRunner", () => {
       });
     });
 
+    it("does not cancel a running job for a different target locale of the same document", async () => {
+      // A `de` job is in flight; the user re-translates `fr` on the same document. The `de` job must
+      // survive — cancelling it is the concurrent re-translate bug.
+      const runningDe = createJob({
+        id: "de-job",
+        processing: true,
+        input: {
+          collection: { relationTo: "posts" as CollectionSlug, value: "doc-123" },
+          source_lng: "en",
+          target_lng: "de",
+          strategy: "overwrite",
+        },
+      });
+      mockPayload.find.mockResolvedValueOnce({ docs: [runningDe] });
+
+      await runner.enqueue([createInput({ targetLng: "fr" })]);
+
+      expect(mockPayload.jobs.cancel).not.toHaveBeenCalled();
+      expect(mockPayload.delete).not.toHaveBeenCalled();
+      expect(mockPayload.jobs.queue).toHaveBeenCalledTimes(1);
+    });
+
+    it("supersedes only the same-locale job when several locales have jobs", async () => {
+      const deJob = createJob({
+        id: "de-job",
+        input: {
+          collection: { relationTo: "posts" as CollectionSlug, value: "doc-123" },
+          source_lng: "en",
+          target_lng: "de",
+          strategy: "overwrite",
+        },
+      });
+      const frJob = createJob({
+        id: "fr-job",
+        input: {
+          collection: { relationTo: "posts" as CollectionSlug, value: "doc-123" },
+          source_lng: "en",
+          target_lng: "fr",
+          strategy: "overwrite",
+        },
+      });
+      mockPayload.find.mockResolvedValueOnce({ docs: [deJob, frJob] });
+
+      await runner.enqueue([createInput({ targetLng: "fr" })]);
+
+      expect(mockPayload.jobs.cancel).toHaveBeenCalledWith({
+        where: { id: { in: ["fr-job"] } },
+        queue: "translations",
+      });
+      expect(mockPayload.delete).toHaveBeenCalledWith({
+        collection: "payload-jobs",
+        where: { id: { in: ["fr-job"] } },
+      });
+    });
+
     it("does not cancel when no existing jobs", async () => {
       mockPayload.find.mockResolvedValue({ docs: [] });
 

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.ts
@@ -1,9 +1,15 @@
 import type { Payload, Where, CollectionSlug } from "payload";
 
 import type { TaskRunner } from "../TaskRunner.interface";
-import type { Task, TaskInput, RunResult } from "../types";
+import type { Task, TaskInput, RunResult, ID } from "../types";
 import type { PayloadJobsRunnerConfig, PayloadJob } from "./types";
 import { normalizeJob } from "./normalizeJob";
+
+// A translation job's supersession identity: same document AND same target locale. IDs are
+// String()-normalized to match the stored (string) form, so a number id compares equal to its
+// persisted job.
+const documentLocaleKey = (collectionId: ID, targetLng: string): string =>
+  `${String(collectionId)}:${targetLng}`;
 
 /**
  * TaskRunner implementation using Payload Jobs.
@@ -22,8 +28,17 @@ export class PayloadJobsTaskRunner implements TaskRunner {
     for (const [collectionSlug, items] of byCollection) {
       const documentIds = items.map((t) => t.collectionId);
       const existing = await this.findByCollection(collectionSlug, documentIds);
-      if (existing.length > 0) {
-        await this.cancelInternal(existing.map((t) => t.id));
+      // Supersede only jobs for the SAME (document, target locale) being re-enqueued — never a
+      // concurrent job for a *different* locale of the same document. Cancelling per-document would
+      // kill an in-flight translation of another locale (the concurrent re-translate bug).
+      const supersededKeys = new Set(
+        items.map((t) => documentLocaleKey(t.collectionId, t.targetLng))
+      );
+      const toCancel = existing.filter((t) =>
+        supersededKeys.has(documentLocaleKey(t.input.collectionId, t.input.targetLng))
+      );
+      if (toCancel.length > 0) {
+        await this.cancelInternal(toCancel.map((t) => t.id));
       }
     }
 

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncTaskRunner.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncTaskRunner.test.ts
@@ -50,7 +50,7 @@ describe("SyncTaskRunner", () => {
       const input = createInput();
       await runner.enqueue([input]);
 
-      const task = tasks.get("posts:doc-123");
+      const task = tasks.get("posts:doc-123:de");
       expect(task).toBeDefined();
       expect(task?.status).toBe("completed");
       expect(task?.completedAt).toBeDefined();
@@ -63,7 +63,7 @@ describe("SyncTaskRunner", () => {
       const input = createInput();
       await runner.enqueue([input]);
 
-      const task = tasks.get("posts:doc-123");
+      const task = tasks.get("posts:doc-123:de");
       expect(task?.status).toBe("failed");
       expect(task?.error?.message).toBe("Translation failed");
     });
@@ -75,7 +75,7 @@ describe("SyncTaskRunner", () => {
       const input = createInput();
       await runner.enqueue([input]);
 
-      const task = tasks.get("posts:doc-123");
+      const task = tasks.get("posts:doc-123:de");
       expect(task?.status).toBe("failed");
       expect(task?.error?.message).toBe("Unknown error");
     });
@@ -90,9 +90,9 @@ describe("SyncTaskRunner", () => {
       await runner.enqueue(inputs);
 
       expect(mockHandler).toHaveBeenCalledTimes(3);
-      expect(tasks.get("posts:doc-1")?.status).toBe("completed");
-      expect(tasks.get("posts:doc-2")?.status).toBe("completed");
-      expect(tasks.get("posts:doc-3")?.status).toBe("completed");
+      expect(tasks.get("posts:doc-1:de")?.status).toBe("completed");
+      expect(tasks.get("posts:doc-2:de")?.status).toBe("completed");
+      expect(tasks.get("posts:doc-3:de")?.status).toBe("completed");
     });
 
     it("creates task with unique id", async () => {
@@ -103,8 +103,8 @@ describe("SyncTaskRunner", () => {
 
       await runner.enqueue(inputs);
 
-      const task1 = tasks.get("posts:doc-1");
-      const task2 = tasks.get("posts:doc-2");
+      const task1 = tasks.get("posts:doc-1:de");
+      const task2 = tasks.get("posts:doc-2:de");
       expect(task1?.id).not.toBe(task2?.id);
     });
 
@@ -112,20 +112,33 @@ describe("SyncTaskRunner", () => {
       const input = createInput();
       await runner.enqueue([input]);
 
-      const task = tasks.get("posts:doc-123");
+      const task = tasks.get("posts:doc-123:de");
       expect(task?.cancelled).toBe(false);
     });
 
-    it("overwrites existing task for same document", async () => {
+    it("overwrites the existing task for the same document AND locale", async () => {
       const input = createInput();
       await runner.enqueue([input]);
 
-      const firstTaskId = tasks.get("posts:doc-123")?.id;
+      const firstTaskId = tasks.get("posts:doc-123:de")?.id;
 
       await runner.enqueue([input]);
 
-      const secondTaskId = tasks.get("posts:doc-123")?.id;
+      const secondTaskId = tasks.get("posts:doc-123:de")?.id;
       expect(secondTaskId).not.toBe(firstTaskId);
+    });
+
+    it("keeps a separate task per target locale for the same document", async () => {
+      // Translating a second locale of the same document must not evict the first — otherwise
+      // findByCollection can only ever return one locale's task (the status-panel overwrite bug).
+      await runner.enqueue([createInput({ targetLng: "de" })]);
+      await runner.enqueue([createInput({ targetLng: "fr" })]);
+
+      expect(tasks.get("posts:doc-123:de")).toBeDefined();
+      expect(tasks.get("posts:doc-123:fr")).toBeDefined();
+
+      const found = await runner.findByCollection("posts" as CollectionSlug, ["doc-123"]);
+      expect(found.map((t) => t.input.targetLng).sort()).toEqual(["de", "fr"]);
     });
   });
 
@@ -134,11 +147,11 @@ describe("SyncTaskRunner", () => {
       const input = createInput();
       await runner.enqueue([input]);
 
-      const taskId = tasks.get("posts:doc-123")?.id;
+      const taskId = tasks.get("posts:doc-123:de")?.id;
       await runner.cancel([taskId!]);
 
       // Task should still exist and be completed
-      expect(tasks.get("posts:doc-123")?.status).toBe("completed");
+      expect(tasks.get("posts:doc-123:de")?.status).toBe("completed");
     });
   });
 

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncTaskRunner.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncTaskRunner.ts
@@ -20,7 +20,7 @@ export class SyncTaskRunner implements TaskRunner {
 
   async enqueue(inputs: TaskInput[]): Promise<void> {
     for (const input of inputs) {
-      const key = this.getKey(input.collectionSlug, input.collectionId);
+      const key = this.getKey(input.collectionSlug, input.collectionId, input.targetLng);
       const now = new Date().toISOString();
 
       const task: Task = {
@@ -82,7 +82,9 @@ export class SyncTaskRunner implements TaskRunner {
     return results;
   }
 
-  private getKey(collectionSlug: CollectionSlug, collectionId: ID): string {
-    return `${collectionSlug}:${collectionId}`;
+  // Keyed by (document, target locale) so translating a second locale of the same document does not
+  // evict the first — findByCollection must be able to return one task per locale.
+  private getKey(collectionSlug: CollectionSlug, collectionId: ID, targetLng: string): string {
+    return `${collectionSlug}:${collectionId}:${targetLng}`;
   }
 }


### PR DESCRIPTION
## Problem

In the document translation popup's **Status** section, re-translating several locales in a row (each via **Re-translate from `<lang>`**) misbehaved: each click appeared to **overwrite the previous locale's status**, and rows **re-sorted** so the just-clicked one jumped to the top.

## Root cause

The status feed modelled **one job per document**, but re-translate queues **one job per target locale**. The single-value assumption was baked into three places — two read-path and, most importantly, one **write-path**:

1. **Write path (the primary cause).** `PayloadJobsTaskRunner.enqueue` cancelled and **deleted** every existing job for the document before queuing, scoped only by `(collectionSlug, documentId)`. So re-translating `fr` while `de` was still running physically removed the `de` job. `SyncTaskRunner` had the same defect via an in-memory key that omitted the locale.
2. **Server read.** `GET /document/:slug/:id` returned a single job (`tasks[0]`) and discarded the rest.
3. **Client read.** `buildTranslationStatusRows` overlaid that one job onto its one locale; the other in-flight locales rendered from staleness alone.

## Fix

- **Write path** — supersession is now scoped to the same `(document, target locale)`: re-translating one locale never cancels another locale's in-flight job. `SyncTaskRunner`'s key gains the target locale. Bulk "translate all locales" is unaffected (each locale supersedes only its own prior job).
- **Server read** — the endpoint returns the latest job **per target locale** (`latestTaskPerTargetLocale`).
- **Client read** — `buildTranslationStatusRows` overlays **every** job, so each concurrent locale shows its own live state. The trigger marker aggregates via `deriveDocumentRunStatus`; the `#50` completed→staleness invalidation now tracks the set of completed locales, keyed by document (no cross-document leak). The response is normalized with `Array.isArray` for deploy-skew resilience.

Internal only — **`src/index.ts` unchanged** (no public API change → patch release).

## Safety (blast-radius review)

- **No schema change, no migration.** Job records are untouched; the new keys are in-memory only.
- **No unbounded job growth.** Completed jobs auto-delete (Payload default); superseded same-locale jobs are deleted on re-enqueue; only failed jobs linger, bounded by `docs × locales`.
- **No external API break.** The endpoint is internal (not re-exported, no other caller); the object→array shape change is consumed only by this plugin's own client, which ships in the same artifact.
- **Deploy skew** — a stale admin tab mid-deploy is hardened by the `Array.isArray` normalizer; self-healing on reload, no data impact.

## Tests / verification

`check-types` clean · `lint` 0 errors · `vitest run` green. New coverage: `enqueue` leaves a different-locale running job alone and supersedes only the same locale; `SyncTaskRunner` keeps one task per locale; `latestTaskPerTargetLocale` incl. the `createdAt` tie-break; `buildTranslationStatusRows` with N concurrent jobs; `deriveDocumentRunStatus` priority.

**Design doc:** `packages/payload-plugin-translator/docs/plans/2026-07-15-per-locale-document-status-feed.md`
