### PR TITLE
refactor(translator): typed FieldLike projection for schemaMap (replaces JSON round-trip)

### DIFF
--- a/packages/payload-plugin-translator/docs/plans/2026-07-15-schemamap-fieldlike-projection.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-07-15-schemamap-fieldlike-projection.md
@@ -1,9 +1,9 @@
 # Task — Replace the `schemaMap` JSON round-trip with a typed `FieldLike` projection
 
-**Date:** 2026-07-15
-**Status:** backlog (internal). Deferred out of the `TranslateCollectionPlugin` reshape
-(`2026-07-14-translate-collection-plugin-reshape.md`) as a separate, test-backed task.
-**Scope:** internal only — no public API change.
+**Date:** 2026-07-15 · **implemented:** 2026-07-17 (after the core/ layering redesign).
+**Status:** implemented. Preceded by a read-only code investigation that de-risked the property
+contract, the Payload-sanitize premise, and placement (findings folded in below).
+**Scope:** internal only — no public API change. Ships as `refactor:` (patch).
 
 ## Problem
 
@@ -41,8 +41,31 @@ properties the pipeline uses (`name`, `type`, `localized`, `fields`, `blocks`, `
 every nesting level, and build `schemaMap` from it instead of the JSON round-trip. This makes the
 schema contract explicit and typed.
 
-`FieldLike` already exists in `core/field-traversal` (see `fieldLike.types.test.ts`) and the pipeline
+`FieldLike` already exists in `core/kernel/field-traversal` (post-refactor location) and the pipeline
 already operates on it — the gap is only the `schemaMap` construction in `plugin.ts`.
+
+## Findings from the pre-implementation investigation (evidence-based)
+
+- **Contract is complete but `blocks`/`tabs` are not scalars.** Every `schemaMap` consumer (pipeline,
+  provenance fingerprint, auto-translate drift gate, field-path resolver) reads only
+  `type` · `name` · `localized` · `custom` (just `custom.translateKit.exclude`) · `fields` · `blocks` ·
+  `tabs`. Nothing else is read (`editor`/`admin`/`relationTo`/`validate` — none; `relationTo` appears only
+  in dead code). BUT the projector must recurse into sub-shapes: **`block.slug` is load-bearing**
+  (block-type dispatch) and `tab.name`/`tab.fields` (+`tab.localized`) are required — copying `blocks`/`tabs`
+  opaquely would silently break translation. This corrected the doc's original flat property list.
+- **Premise confirmed in Payload source.** `sanitizeFields` does `delete field.localized` **in place** on
+  any field under a localized ancestor (propagated via `parentIsLocalized`). The pipeline reads per-field
+  `localized` (no inherited computation), so a **deep** pre-sanitize copy is mandatory — a shared reference
+  re-introduces the silent no-translate bug.
+- **richText needs no schema data.** The lexical config lives in `field.editor` (async functions), but the
+  pipeline reads the lexical tree from the **document value** at runtime, never from the field schema — so
+  dropping `editor` (and all functions) is safe. This is exactly why `structuredClone` was impossible and
+  the projection is sound.
+- **Placement without breaking payload-free core.** The projector is a pure `FieldLike[] → FieldLike[]`
+  deep copy living in `core/kernel/field-traversal/projectFieldLike.ts` — it never imports Payload. The
+  `Field[] → FieldLike[]` assignment happens at the call site in `plugin.ts` (where Payload types are
+  legal), since Payload's `Field` is structurally assignable to `FieldLike`. `custom` is copied by
+  reference (passthrough bag Payload never mutates; deep-copying it would hit the same function problem).
 
 ## Risk / why it's a separate task
 
@@ -56,15 +79,18 @@ This is content-projection work with a real data-correctness trap, not cosmetics
 
 ## Acceptance criteria
 
-- [ ] A typed `Field[] → FieldLike[]` projector replaces the JSON round-trip in `plugin.ts`.
-- [ ] `localized: true` is preserved on deeply-nested fields across group / array / blocks / named &
-      unnamed tabs / row / collapsible.
-- [ ] The projected schema is an independent deep copy — unaffected by later mutation of the source
-      collection objects (regression test simulating Payload's `localized` stripping).
-- [ ] `schemaMap` is typed as `FieldLike[]` (no `any` at the boundary).
-- [ ] Type-check + lint clean; existing translation/staleness tests unchanged and green.
+- [x] A typed `FieldLike[] → FieldLike[]` projector (`projectFieldsToFieldLike`) replaces the JSON
+      round-trip in `plugin.ts` (Payload's `Field[]` assigns structurally at the call site).
+- [x] `localized: true` is preserved on deeply-nested fields across group / array / blocks / named &
+      unnamed tabs / row / collapsible (copied by value at projection time).
+- [x] The projected schema is an independent deep copy — regression test simulates Payload's in-place
+      `delete field.localized` on the source and asserts the projection is unaffected.
+- [x] `schemaMap` (`CollectionSchemaMap`) is typed as `FieldLike[]` (no `any` at the boundary); the two
+      internal consumers that annotated `Field[]` (`resolveFieldSubtree`, `Provenance.service`) retyped to `FieldLike[]`.
+- [x] Type-check + lint clean (repo baseline, no new warnings); full suite green.
 
 ## References
 
-- `src/plugin.ts` — the `TODO` next to `schemaMap` marks this.
-- `src/core/field-traversal/` — existing `FieldLike` + traversal walkers to reuse.
+- `src/plugin.ts` — the JSON round-trip (now `projectFieldsToFieldLike`).
+- `src/core/kernel/field-traversal/projectFieldLike.ts` (+ `.test.ts`) — the projector + regression test.
+- `src/core/kernel/field-traversal/` — existing `FieldLike` types the projection produces.

--- a/packages/payload-plugin-translator/src/core/kernel/field-traversal/index.ts
+++ b/packages/payload-plugin-translator/src/core/kernel/field-traversal/index.ts
@@ -2,6 +2,7 @@ export { findFieldByPath } from "./findFieldByPath";
 export type { FieldPathResult } from "./findFieldByPath";
 export { hasFields, isBlockItem, isTabsField } from "./guards";
 export { classifyField, matchElementById, resolveBlockFields, tabScopes } from "./kernel";
+export { projectFieldsToFieldLike } from "./projectFieldLike";
 export {
   fieldAffectsData,
   fieldIsArrayType,

--- a/packages/payload-plugin-translator/src/core/kernel/field-traversal/projectFieldLike.test.ts
+++ b/packages/payload-plugin-translator/src/core/kernel/field-traversal/projectFieldLike.test.ts
@@ -3,118 +3,283 @@ import { describe, it, expect } from "vitest";
 import type { FieldLike } from "./types";
 import { projectFieldsToFieldLike } from "./projectFieldLike";
 
-describe("projectFieldsToFieldLike", () => {
-  it("keeps the whitelisted properties on a leaf and drops everything else", () => {
-    const fields = [
+// Tests are derived from the projection CONTRACT (design doc + Payload field model), not from the
+// implementation: the projector must deep-copy exactly { type, name, localized, custom, fields,
+// blocks(+slug), tabs(name/localized/fields) }, drop everything else, keep every field 1:1, and be
+// independent of later in-place mutation of the source (Payload's `delete field.localized`).
+
+const one = (fields: FieldLike[]): FieldLike => projectFieldsToFieldLike(fields)[0];
+
+describe("projectFieldsToFieldLike — property whitelist (leaf level)", () => {
+  it("keeps type, name, localized, and custom", () => {
+    const leaf = one([
       {
         type: "text",
         name: "title",
         localized: true,
         custom: { translateKit: { exclude: false } },
-        // properties the pipeline never reads — must not appear on the projection
-        required: true,
-        admin: { position: "sidebar" },
-        validate: () => true,
       },
-    ] as unknown as FieldLike[];
-
-    const [leaf] = projectFieldsToFieldLike(fields);
-
+    ]);
     expect(leaf).toEqual({
       type: "text",
       name: "title",
       localized: true,
       custom: { translateKit: { exclude: false } },
     });
-    expect(leaf).not.toHaveProperty("required");
-    expect(leaf).not.toHaveProperty("admin");
-    expect(leaf).not.toHaveProperty("validate");
   });
 
-  it("is an independent deep copy — Payload's in-place `delete field.localized` on the source does not affect it (the core regression)", () => {
-    // A field localized under a localized group: Payload's sanitizer deletes the nested `localized`.
-    const nested = { type: "text", name: "body", localized: true } as FieldLike;
-    const source: FieldLike[] = [{ type: "group", name: "seo", localized: true, fields: [nested] }];
-
-    const projected = projectFieldsToFieldLike(source);
-
-    // Simulate Payload sanitize mutating the ORIGINAL objects in place.
-    delete (source[0] as { localized?: boolean }).localized;
-    delete (nested as { localized?: boolean }).localized;
-    source[0].fields!.push({ type: "text", name: "injected" });
-
-    const group = projected[0];
-    expect(group.localized).toBe(true); // snapshot survived the source mutation
-    expect(group.fields).toHaveLength(1); // not affected by the push into the source
-    expect(group.fields?.[0]).toEqual({ type: "text", name: "body", localized: true });
-    // distinct object identities (deep copy, not shared references)
-    expect(group).not.toBe(source[0]);
-    expect(group.fields?.[0]).not.toBe(nested);
-  });
-
-  it("recurses array element fields (array is handled via the generic `fields` branch, not a special case)", () => {
-    const nestedLeaf = { type: "text", name: "label", localized: true } as FieldLike;
-    const source: FieldLike[] = [{ type: "array", name: "items", fields: [nestedLeaf] }];
-
-    const projected = projectFieldsToFieldLike(source);
-
-    // Simulate Payload sanitize stripping `localized` off the nested element field in place.
-    delete (nestedLeaf as { localized?: boolean }).localized;
-
-    const arrayField = projected[0];
-    expect(arrayField.type).toBe("array");
-    expect(arrayField.name).toBe("items");
-    expect(arrayField.fields).toEqual([{ type: "text", name: "label", localized: true }]);
-    expect(arrayField.fields?.[0]).not.toBe(nestedLeaf);
-  });
-
-  it("preserves block.slug and recurses block fields (slug is load-bearing for block dispatch)", () => {
-    const source: FieldLike[] = [
+  it("drops every non-whitelisted property (admin, required, validate, editor, hooks, defaultValue, access)", () => {
+    const leaf = one([
       {
-        type: "blocks",
-        name: "sections",
-        blocks: [{ slug: "hero", fields: [{ type: "text", name: "heading", localized: true }] }],
+        type: "richText",
+        name: "body",
+        localized: true,
+        required: true,
+        admin: { position: "sidebar" },
+        defaultValue: "x",
+        editor: { config: async () => ({}) },
+        validate: () => true,
+        hooks: { beforeChange: [() => undefined] },
+        access: { read: () => true },
       },
-    ];
-
-    const [blocksField] = projectFieldsToFieldLike(source);
-
-    expect(blocksField.blocks).toEqual([
-      { slug: "hero", fields: [{ type: "text", name: "heading", localized: true }] },
-    ]);
-    expect(blocksField.blocks?.[0]).not.toBe(source[0].blocks?.[0]);
+    ] as unknown as FieldLike[]);
+    expect(leaf).toEqual({ type: "richText", name: "body", localized: true });
+    for (const dropped of [
+      "required",
+      "admin",
+      "defaultValue",
+      "editor",
+      "validate",
+      "hooks",
+      "access",
+    ]) {
+      expect(leaf).not.toHaveProperty(dropped);
+    }
   });
 
-  it("preserves named and unnamed tabs with their fields", () => {
+  it("preserves `localized: false` verbatim (not dropped, not coerced)", () => {
+    const leaf = one([{ type: "text", name: "sku", localized: false }]);
+    expect(leaf.localized).toBe(false);
+    expect(leaf).toEqual({ type: "text", name: "sku", localized: false });
+  });
+
+  it("omits name/localized/custom keys when absent on the source", () => {
+    const leaf = one([{ type: "text" }]);
+    expect(leaf).toEqual({ type: "text" });
+    expect(leaf).not.toHaveProperty("name");
+    expect(leaf).not.toHaveProperty("localized");
+    expect(leaf).not.toHaveProperty("custom");
+  });
+
+  it("preserves arbitrary and empty custom contents", () => {
+    expect(one([{ type: "text", name: "a", custom: { k: 1, nested: { x: [2] } } }]).custom).toEqual(
+      {
+        k: 1,
+        nested: { x: [2] },
+      }
+    );
+    expect(one([{ type: "text", name: "b", custom: {} }]).custom).toEqual({});
+  });
+});
+
+describe("projectFieldsToFieldLike — containers (kept 1:1, recursed)", () => {
+  it("named group: keeps name, recurses fields", () => {
+    expect(
+      one([{ type: "group", name: "seo", fields: [{ type: "text", name: "title" }] }])
+    ).toEqual({
+      type: "group",
+      name: "seo",
+      fields: [{ type: "text", name: "title" }],
+    });
+  });
+
+  it("unnamed group: recurses fields, no name", () => {
+    const g = one([{ type: "group", fields: [{ type: "text", name: "loose" }] }]);
+    expect(g).toEqual({ type: "group", fields: [{ type: "text", name: "loose" }] });
+    expect(g).not.toHaveProperty("name");
+  });
+
+  it("array: keeps name, recurses element fields", () => {
+    expect(
+      one([{ type: "array", name: "items", fields: [{ type: "text", name: "label" }] }])
+    ).toEqual({
+      type: "array",
+      name: "items",
+      fields: [{ type: "text", name: "label" }],
+    });
+  });
+
+  it("blocks: keeps name and each block's slug + fields, across multiple blocks", () => {
+    expect(
+      one([
+        {
+          type: "blocks",
+          name: "sections",
+          blocks: [
+            { slug: "hero", fields: [{ type: "text", name: "heading", localized: true }] },
+            { slug: "cta", fields: [{ type: "text", name: "label" }] },
+          ],
+        },
+      ])
+    ).toEqual({
+      type: "blocks",
+      name: "sections",
+      blocks: [
+        { slug: "hero", fields: [{ type: "text", name: "heading", localized: true }] },
+        { slug: "cta", fields: [{ type: "text", name: "label" }] },
+      ],
+    });
+  });
+
+  it("tabs: keeps named (name/localized/fields) and unnamed (fields) tabs", () => {
+    expect(
+      one([
+        {
+          type: "tabs",
+          tabs: [
+            { name: "meta", localized: true, fields: [{ type: "text", name: "slug" }] },
+            { fields: [{ type: "text", name: "loose", localized: true }] },
+          ],
+        },
+      ])
+    ).toEqual({
+      type: "tabs",
+      tabs: [
+        { name: "meta", localized: true, fields: [{ type: "text", name: "slug" }] },
+        { fields: [{ type: "text", name: "loose", localized: true }] },
+      ],
+    });
+  });
+
+  it("presentational row/collapsible are transparent (fields recursed, no name)", () => {
+    const [row, collapsible] = projectFieldsToFieldLike([
+      { type: "row", fields: [{ type: "text", name: "a" }] },
+      { type: "collapsible", fields: [{ type: "text", name: "b" }] },
+    ]);
+    expect(row).toEqual({ type: "row", fields: [{ type: "text", name: "a" }] });
+    expect(collapsible).toEqual({ type: "collapsible", fields: [{ type: "text", name: "b" }] });
+  });
+
+  it("ui field is kept 1:1 with no fields", () => {
+    expect(one([{ type: "ui", name: "spacer" } as FieldLike])).toEqual({
+      type: "ui",
+      name: "spacer",
+    });
+  });
+
+  it("keeps an empty fields array as [] (does not drop the container)", () => {
+    expect(one([{ type: "group", name: "empty", fields: [] }])).toEqual({
+      type: "group",
+      name: "empty",
+      fields: [],
+    });
+  });
+
+  it("preserves sibling order and count at the root", () => {
+    const projected = projectFieldsToFieldLike([
+      { type: "text", name: "a" },
+      { type: "group", name: "b", fields: [] },
+      { type: "ui", name: "c" } as FieldLike,
+      { type: "array", name: "d", fields: [] },
+    ]);
+    expect(projected.map((f) => `${f.type}:${f.name ?? ""}`)).toEqual([
+      "text:a",
+      "group:b",
+      "ui:c",
+      "array:d",
+    ]);
+  });
+});
+
+describe("projectFieldsToFieldLike — deep independence (the localized-stripping trap)", () => {
+  it("nested `localized` survives Payload's in-place `delete` under a group", () => {
+    const leaf = { type: "text", name: "body", localized: true } as FieldLike;
+    const source: FieldLike[] = [{ type: "group", name: "g", localized: true, fields: [leaf] }];
+    const projected = projectFieldsToFieldLike(source);
+
+    delete (source[0] as { localized?: boolean }).localized;
+    delete (leaf as { localized?: boolean }).localized;
+
+    expect(projected[0].localized).toBe(true);
+    expect(projected[0].fields?.[0]).toEqual({ type: "text", name: "body", localized: true });
+  });
+
+  it("nested `localized` survives under an array element", () => {
+    const leaf = { type: "text", name: "label", localized: true } as FieldLike;
+    const source: FieldLike[] = [{ type: "array", name: "items", fields: [leaf] }];
+    const projected = projectFieldsToFieldLike(source);
+    delete (leaf as { localized?: boolean }).localized;
+    expect(projected[0].fields?.[0]?.localized).toBe(true);
+  });
+
+  it("nested `localized` survives inside a block and under a named tab", () => {
+    const blockLeaf = { type: "text", name: "heading", localized: true } as FieldLike;
+    const tabLeaf = { type: "text", name: "slug", localized: true } as FieldLike;
+    const source: FieldLike[] = [
+      { type: "blocks", name: "s", blocks: [{ slug: "hero", fields: [blockLeaf] }] },
+      { type: "tabs", tabs: [{ name: "meta", localized: true, fields: [tabLeaf] }] },
+    ];
+    const projected = projectFieldsToFieldLike(source);
+    delete (blockLeaf as { localized?: boolean }).localized;
+    delete (tabLeaf as { localized?: boolean }).localized;
+    expect(projected[0].blocks?.[0]?.fields?.[0]?.localized).toBe(true);
+    expect(projected[1].tabs?.[0]?.fields?.[0]?.localized).toBe(true);
+  });
+
+  it("deep mixed nesting (group > array > blocks > named tab > leaf) preserves the bottom `localized`", () => {
+    const deepLeaf = { type: "text", name: "text", localized: true } as FieldLike;
     const source: FieldLike[] = [
       {
-        type: "tabs",
-        tabs: [
-          { name: "meta", localized: true, fields: [{ type: "text", name: "slug" }] },
-          { fields: [{ type: "text", name: "loose", localized: true }] },
+        type: "group",
+        name: "g",
+        fields: [
+          {
+            type: "array",
+            name: "rows",
+            fields: [
+              {
+                type: "blocks",
+                name: "blk",
+                blocks: [
+                  {
+                    slug: "b",
+                    fields: [{ type: "tabs", tabs: [{ name: "t", fields: [deepLeaf] }] }],
+                  },
+                ],
+              },
+            ],
+          },
         ],
       },
     ];
+    const projected = projectFieldsToFieldLike(source);
+    delete (deepLeaf as { localized?: boolean }).localized;
 
-    const [tabsField] = projectFieldsToFieldLike(source);
-
-    expect(tabsField.tabs).toEqual([
-      { name: "meta", localized: true, fields: [{ type: "text", name: "slug" }] },
-      { fields: [{ type: "text", name: "loose", localized: true }] },
-    ]);
+    const bottom =
+      projected[0].fields?.[0]?.fields?.[0]?.blocks?.[0]?.fields?.[0]?.tabs?.[0]?.fields?.[0];
+    expect(bottom).toEqual({ type: "text", name: "text", localized: true });
   });
 
-  it("keeps presentational containers (row/collapsible/ui) 1:1 so downstream classification is unchanged", () => {
-    const source = [
-      { type: "row", fields: [{ type: "text", name: "a" }] },
-      { type: "collapsible", fields: [{ type: "text", name: "b" }] },
-      { type: "ui", name: "spacer" },
-    ] as unknown as FieldLike[];
-
+  it("adding a sibling to the source field list does not affect the projection", () => {
+    const source: FieldLike[] = [
+      { type: "group", name: "g", fields: [{ type: "text", name: "a" }] },
+    ];
     const projected = projectFieldsToFieldLike(source);
+    source[0].fields?.push({ type: "text", name: "injected" });
+    expect(projected[0].fields).toHaveLength(1);
+  });
 
-    expect(projected.map((f) => f.type)).toEqual(["row", "collapsible", "ui"]);
-    expect(projected[0].fields).toEqual([{ type: "text", name: "a" }]);
-    expect(projected[2]).toEqual({ type: "ui", name: "spacer" });
+  it("produces distinct object identities at every level (deep copy, not shared references)", () => {
+    const source: FieldLike[] = [
+      {
+        type: "blocks",
+        name: "s",
+        blocks: [{ slug: "hero", fields: [{ type: "text", name: "h" }] }],
+      },
+    ];
+    const projected = projectFieldsToFieldLike(source);
+    expect(projected[0]).not.toBe(source[0]);
+    expect(projected[0].blocks?.[0]).not.toBe(source[0].blocks?.[0]);
+    expect(projected[0].blocks?.[0]?.fields?.[0]).not.toBe(source[0].blocks?.[0]?.fields?.[0]);
   });
 });

--- a/packages/payload-plugin-translator/src/core/kernel/field-traversal/projectFieldLike.test.ts
+++ b/packages/payload-plugin-translator/src/core/kernel/field-traversal/projectFieldLike.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+
+import type { FieldLike } from "./types";
+import { projectFieldsToFieldLike } from "./projectFieldLike";
+
+describe("projectFieldsToFieldLike", () => {
+  it("keeps the whitelisted properties on a leaf and drops everything else", () => {
+    const fields = [
+      {
+        type: "text",
+        name: "title",
+        localized: true,
+        custom: { translateKit: { exclude: false } },
+        // properties the pipeline never reads — must not appear on the projection
+        required: true,
+        admin: { position: "sidebar" },
+        validate: () => true,
+      },
+    ] as unknown as FieldLike[];
+
+    const [leaf] = projectFieldsToFieldLike(fields);
+
+    expect(leaf).toEqual({
+      type: "text",
+      name: "title",
+      localized: true,
+      custom: { translateKit: { exclude: false } },
+    });
+    expect(leaf).not.toHaveProperty("required");
+    expect(leaf).not.toHaveProperty("admin");
+    expect(leaf).not.toHaveProperty("validate");
+  });
+
+  it("is an independent deep copy — Payload's in-place `delete field.localized` on the source does not affect it (the core regression)", () => {
+    // A field localized under a localized group: Payload's sanitizer deletes the nested `localized`.
+    const nested = { type: "text", name: "body", localized: true } as FieldLike;
+    const source: FieldLike[] = [{ type: "group", name: "seo", localized: true, fields: [nested] }];
+
+    const projected = projectFieldsToFieldLike(source);
+
+    // Simulate Payload sanitize mutating the ORIGINAL objects in place.
+    delete (source[0] as { localized?: boolean }).localized;
+    delete (nested as { localized?: boolean }).localized;
+    source[0].fields!.push({ type: "text", name: "injected" });
+
+    const group = projected[0];
+    expect(group.localized).toBe(true); // snapshot survived the source mutation
+    expect(group.fields).toHaveLength(1); // not affected by the push into the source
+    expect(group.fields?.[0]).toEqual({ type: "text", name: "body", localized: true });
+    // distinct object identities (deep copy, not shared references)
+    expect(group).not.toBe(source[0]);
+    expect(group.fields?.[0]).not.toBe(nested);
+  });
+
+  it("preserves block.slug and recurses block fields (slug is load-bearing for block dispatch)", () => {
+    const source: FieldLike[] = [
+      {
+        type: "blocks",
+        name: "sections",
+        blocks: [{ slug: "hero", fields: [{ type: "text", name: "heading", localized: true }] }],
+      },
+    ];
+
+    const [blocksField] = projectFieldsToFieldLike(source);
+
+    expect(blocksField.blocks).toEqual([
+      { slug: "hero", fields: [{ type: "text", name: "heading", localized: true }] },
+    ]);
+    expect(blocksField.blocks?.[0]).not.toBe(source[0].blocks?.[0]);
+  });
+
+  it("preserves named and unnamed tabs with their fields", () => {
+    const source: FieldLike[] = [
+      {
+        type: "tabs",
+        tabs: [
+          { name: "meta", localized: true, fields: [{ type: "text", name: "slug" }] },
+          { fields: [{ type: "text", name: "loose", localized: true }] },
+        ],
+      },
+    ];
+
+    const [tabsField] = projectFieldsToFieldLike(source);
+
+    expect(tabsField.tabs).toEqual([
+      { name: "meta", localized: true, fields: [{ type: "text", name: "slug" }] },
+      { fields: [{ type: "text", name: "loose", localized: true }] },
+    ]);
+  });
+
+  it("keeps presentational containers (row/collapsible/ui) 1:1 so downstream classification is unchanged", () => {
+    const source = [
+      { type: "row", fields: [{ type: "text", name: "a" }] },
+      { type: "collapsible", fields: [{ type: "text", name: "b" }] },
+      { type: "ui", name: "spacer" },
+    ] as unknown as FieldLike[];
+
+    const projected = projectFieldsToFieldLike(source);
+
+    expect(projected.map((f) => f.type)).toEqual(["row", "collapsible", "ui"]);
+    expect(projected[0].fields).toEqual([{ type: "text", name: "a" }]);
+    expect(projected[2]).toEqual({ type: "ui", name: "spacer" });
+  });
+});

--- a/packages/payload-plugin-translator/src/core/kernel/field-traversal/projectFieldLike.test.ts
+++ b/packages/payload-plugin-translator/src/core/kernel/field-traversal/projectFieldLike.test.ts
@@ -52,6 +52,22 @@ describe("projectFieldsToFieldLike", () => {
     expect(group.fields?.[0]).not.toBe(nested);
   });
 
+  it("recurses array element fields (array is handled via the generic `fields` branch, not a special case)", () => {
+    const nestedLeaf = { type: "text", name: "label", localized: true } as FieldLike;
+    const source: FieldLike[] = [{ type: "array", name: "items", fields: [nestedLeaf] }];
+
+    const projected = projectFieldsToFieldLike(source);
+
+    // Simulate Payload sanitize stripping `localized` off the nested element field in place.
+    delete (nestedLeaf as { localized?: boolean }).localized;
+
+    const arrayField = projected[0];
+    expect(arrayField.type).toBe("array");
+    expect(arrayField.name).toBe("items");
+    expect(arrayField.fields).toEqual([{ type: "text", name: "label", localized: true }]);
+    expect(arrayField.fields?.[0]).not.toBe(nestedLeaf);
+  });
+
   it("preserves block.slug and recurses block fields (slug is load-bearing for block dispatch)", () => {
     const source: FieldLike[] = [
       {

--- a/packages/payload-plugin-translator/src/core/kernel/field-traversal/projectFieldLike.ts
+++ b/packages/payload-plugin-translator/src/core/kernel/field-traversal/projectFieldLike.ts
@@ -1,0 +1,58 @@
+import type { FieldLike, TabLike } from "./types";
+
+function projectField(field: FieldLike): FieldLike {
+  const out: FieldLike = { type: field.type };
+  if (field.name !== undefined) out.name = field.name;
+  if (field.localized !== undefined) out.localized = field.localized;
+  if (field.custom !== undefined) out.custom = field.custom;
+  if (field.fields) out.fields = field.fields.map(projectField);
+  if (field.blocks) {
+    out.blocks = field.blocks.map((block) => ({
+      slug: block.slug,
+      fields: block.fields.map(projectField),
+    }));
+  }
+  if (field.tabs) {
+    out.tabs = field.tabs.map((tab) => {
+      const projected: TabLike = { fields: tab.fields.map(projectField) };
+      if (tab.name !== undefined) projected.name = tab.name;
+      if (tab.localized !== undefined) projected.localized = tab.localized;
+      return projected;
+    });
+  }
+  return out;
+}
+
+/**
+ * Deep-project a field schema into an independent {@link FieldLike} tree, copying ONLY the properties
+ * this layer reads. Replaces the `JSON.parse(JSON.stringify(fields))` clone the plugin used to snapshot
+ * a collection's schema before Payload's sanitizer mutates the originals.
+ *
+ * Why a bespoke projection rather than a structural clone:
+ * - **Independence is mandatory, not cosmetic.** Payload's `sanitizeFields` does `delete field.localized`
+ *   **in place** on any field nested under a localized ancestor (group/array/named tab). The pipeline
+ *   reads per-field `localized`, so a shared reference would silently lose it and the field would stop
+ *   being translated. Every field/container here is a NEW object, and `localized` is copied by value at
+ *   projection time (before sanitize runs), so the snapshot is preserved.
+ * - **`structuredClone` can't be used.** Field definitions embed Lexical editor configs containing async
+ *   functions, which `structuredClone` throws on. The old JSON round-trip "worked" only by silently
+ *   dropping every function; this projection drops them explicitly by copying a typed whitelist.
+ *
+ * The contract is exactly what the traversal/pipeline consumes: `type` (classify), `name`/`localized`
+ * (leaf data + translation gate), `custom` (only `custom.translateKit.exclude` is read), and the
+ * container members `fields` (group/array/row/collapsible/unnamed-group), `blocks` (with the
+ * load-bearing `block.slug` used for block-type dispatch), and `tabs` (named + unnamed). Every field is
+ * kept 1:1 (including presentational `ui`/`row`/`collapsible`) so downstream classification is unchanged;
+ * only the property set is narrowed.
+ *
+ * `custom` is copied by reference: it is a passthrough bag Payload does not mutate during sanitize (only
+ * `localized` is deleted, which we snapshot by value), and deep-copying it would re-introduce the
+ * `structuredClone`-on-functions problem this projection exists to avoid.
+ *
+ * @param fields - The source field list (Payload's `Field[]` is structurally assignable to `FieldLike[]`).
+ * @returns A new, independent `FieldLike[]` unaffected by later mutation of the source objects.
+ * @since 0.9.1
+ */
+export function projectFieldsToFieldLike(fields: FieldLike[]): FieldLike[] {
+  return fields.map(projectField);
+}

--- a/packages/payload-plugin-translator/src/plugin.ts
+++ b/packages/payload-plugin-translator/src/plugin.ts
@@ -4,6 +4,8 @@ import { CacheProviderExport } from "./client/app/cache/CacheProvider.export";
 import { configureAutoTranslate } from "./server/modules/auto-translate";
 import { configureProvenance } from "./server/modules/provenance";
 import type { AccessGuard } from "./types/AccessGuard";
+import type { CollectionSchemaMap } from "./types/CollectionSchemaMap";
+import { projectFieldsToFieldLike } from "./core/kernel/field-traversal";
 import type { TranslationProvider } from "./core/domain/translation-providers";
 import type { TaskRunnerProvider } from "./server/modules/task-runner";
 import { wireTranslateRunner } from "./server/features/translate-document";
@@ -106,16 +108,14 @@ export class TranslateCollectionPlugin {
         basePath: rawBasePath = "/translate",
       } = this.pluginConfig;
 
-      // Build schema map from deep-cloned collections.
-      // Deep clone is required because Payload mutates the original collection objects, removing
-      // `localized: true` from nested fields during sanitization. JSON round-trip (not
-      // structuredClone) because Lexical editor configs contain async functions structuredClone
-      // cannot handle.
-      // TODO: Consider introducing a FieldLike interface with only the properties used by the
-      // pipeline (name, type, localized, fields, blocks, tabs, custom) to make the contract explicit
-      // and avoid reliance on JSON round-trip.
-      const schemaMap = new Map(
-        collections.map((col) => [col.slug, JSON.parse(JSON.stringify(col.fields))])
+      // Snapshot each collection's schema as an independent FieldLike tree BEFORE Payload's sanitizer
+      // mutates the originals (it deletes `localized` from fields nested under a localized ancestor).
+      // `projectFieldsToFieldLike` deep-copies only the properties the pipeline reads — an explicit,
+      // typed contract, replacing the old JSON round-trip (which "worked" only by silently dropping the
+      // Lexical editor's async functions that structuredClone chokes on). Payload's `Field[]` is
+      // structurally assignable to `FieldLike[]`, so the projection happens right here at the boundary.
+      const schemaMap: CollectionSchemaMap = new Map(
+        collections.map((col) => [col.slug, projectFieldsToFieldLike(col.fields)])
       );
       const collectionSlugs = new Set(schemaMap.keys());
       const basePath = normalizePath(rawBasePath);

--- a/packages/payload-plugin-translator/src/server/features/translate-field/resolveFieldSubtree.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-field/resolveFieldSubtree.ts
@@ -1,7 +1,6 @@
-import type { Field } from "payload";
-
 import { isTranslatableField } from "../../shared";
 import { findFieldByPath } from "../../../core/kernel/field-traversal";
+import type { FieldLike } from "../../../core/kernel/field-traversal";
 
 /**
  * Outcome of mapping a declared field path to a translatable subtree.
@@ -17,7 +16,12 @@ import { findFieldByPath } from "../../../core/kernel/field-traversal";
  *   locales → caller no-ops (translate the whole document instead).
  */
 export type FieldSubtreeResolution =
-  | { status: "resolved"; schema: Field[]; sourceData: Record<string, unknown>; fieldName: string }
+  | {
+      status: "resolved";
+      schema: FieldLike[];
+      sourceData: Record<string, unknown>;
+      fieldName: string;
+    }
   | { status: "not-found" }
   | { status: "not-translatable" }
   | { status: "inside-blocks" }
@@ -34,7 +38,7 @@ export type FieldSubtreeResolution =
  * `blocks` field returns `inside-blocks`.
  */
 export function resolveFieldSubtree(
-  rootFields: Field[],
+  rootFields: FieldLike[],
   fieldPath: string,
   value: unknown,
   doc?: unknown

--- a/packages/payload-plugin-translator/src/server/modules/provenance/Provenance.service.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/Provenance.service.ts
@@ -1,6 +1,7 @@
-import type { CollectionSlug, Field, Payload } from "payload";
+import type { CollectionSlug, Payload } from "payload";
 
 import { computeSourceFingerprint } from "../../../core/domain/content-projection/computeSourceFingerprint";
+import type { FieldLike } from "../../../core/kernel/field-traversal";
 import { isRecordStale } from "../../../core/domain/provenance";
 import type { ProvenanceKey, ProvenanceStore } from "../../../core/domain/provenance";
 import type { CollectionSchemaMap } from "../../../types/CollectionSchemaMap";
@@ -150,7 +151,11 @@ export class ProvenanceService {
    * hash). Cached per source locale so a document translated from one source into N locales fetches
    * the source once.
    */
-  private makeCurrentFingerprint(collection: CollectionSlug, documentId: string, schema: Field[]) {
+  private makeCurrentFingerprint(
+    collection: CollectionSlug,
+    documentId: string,
+    schema: FieldLike[]
+  ) {
     const cache = new Map<string, string>();
     return async (sourceLocale: string): Promise<string> => {
       const cached = cache.get(sourceLocale);

--- a/packages/payload-plugin-translator/src/types/CollectionSchemaMap.ts
+++ b/packages/payload-plugin-translator/src/types/CollectionSchemaMap.ts
@@ -1,7 +1,11 @@
-import type { CollectionSlug, Field } from "payload";
+import type { CollectionSlug } from "payload";
+
+import type { FieldLike } from "../core/kernel/field-traversal";
 
 /**
- * Map of collection slug to original field schema.
- * Used to access original schemas before Payload sanitization.
+ * Map of collection slug to its projected field schema — an independent {@link FieldLike} snapshot
+ * taken (via `projectFieldsToFieldLike`) before Payload's sanitizer mutates the originals, so nested
+ * `localized` flags survive. Typed as `FieldLike[]` (not Payload's `Field[]`) because every consumer
+ * reads it structurally as `FieldLike`; the projection is the boundary that makes that explicit.
  */
-export type CollectionSchemaMap = Map<CollectionSlug, Field[]>;
+export type CollectionSchemaMap = Map<CollectionSlug, FieldLike[]>;


### PR DESCRIPTION
## Summary

Internal refactor, **no public API change**. Replaces the lossy `schemaMap` clone in `plugin.ts` with an explicit, typed schema projection — closing a long-standing data-correctness trap.

## Problem

`plugin.ts` snapshotted each collection's field schema with:

```ts
new Map(collections.map((col) => [col.slug, JSON.parse(JSON.stringify(col.fields))]))
```

The clone exists because Payload's sanitizer mutates the original field objects in place (it `delete`s `localized` from fields nested under a localized ancestor), and the pipeline needs the pre-sanitize schema to know what to translate. `structuredClone` can't be used — Lexical editor configs hold async functions it throws on. The JSON round-trip "worked" only by silently dropping every function, and typed the boundary as `any` — nothing declared which properties the pipeline actually depends on, so a future read of a dropped property would fail silently.

## Change

A typed recursive `projectFieldsToFieldLike` in `core/kernel/field-traversal` deep-copies **only** the properties the pipeline reads: `type`, `name`, `localized`, `custom`, `fields`, `blocks` (incl. the load-bearing `block.slug`), and `tabs` (named + unnamed). Every field/container is a new object and `localized` is copied by value **before** Payload sanitizes, so nested localization survives.

- The projector is pure `FieldLike[] → FieldLike[]` and never imports Payload — it stays in payload-free core. Payload's `Field[]` assigns structurally to `FieldLike[]` at the `plugin.ts` call site.
- `CollectionSchemaMap` retyped `Field[]` → `FieldLike[]`; the two internal consumers that annotated `Field[]` (`resolveFieldSubtree`, `Provenance.service`) follow — the boundary is now typed, not `any`.
- `custom` is copied by reference (a passthrough bag Payload never mutates; deep-copying it would re-hit the function problem).

## Why it was worth de-risking first

A short read-only investigation preceded the code and corrected the original plan: `block.slug` and the tab sub-shapes are load-bearing (a flat property copy would silently break block/tab translation), and the sanitize premise was confirmed in Payload's own `sanitizeFields` (`delete field.localized`, propagated to nested fields).

## Verification

- `check-types` ✓
- `test` ✓ — full suite; new regression test simulates Payload's in-place `delete field.localized` on the source and asserts the projection is unaffected (plus block.slug / tabs / presentational-container / whitelist coverage)
- `lint` ✓ — repo baseline, no new warnings

Design doc: `docs/plans/2026-07-15-schemamap-fieldlike-projection.md` (with the investigation findings folded in).