### PR TITLE
docs(translator): feature dependency graph

### DIFF
--- a/packages/payload-plugin-translator/docs/plans/2026-07-24-feature-dependency-graph.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-07-24-feature-dependency-graph.md
@@ -1,0 +1,204 @@
+# Translator plugin — feature dependency graph
+
+**Status:** Reference map (Phase 1 — capture only) · **Date:** 2026-07-24 · **Scope:** `@focus-reactive/payload-plugin-translator`
+**Provenance:** built + reconciled by an independent architecture-mapping pass (3 read-only agents over config-time wiring, the server feature surface, and the client), cross-checked against a first-pass draft. Edges below carry `file:line` evidence in the code.
+
+Purpose: make the growing web of inter-feature dependencies + cross-feature rules **explicit**, so a
+contributor can see — before adding a feature — what depends on what, what each capability produces and
+consumes, and which invariants hold across features. Phase 1 is the map; whether to codify any of it into
+an init-time mechanism is **deferred** (see §6).
+
+Three layers, kept separate on purpose:
+1. **Product / capability graph** — roadmap-level "X unblocks Y" (§1).
+2. **Config-time (code) graph** — what `plugin.ts` `init()` actually wires, produces→consumes (§2).
+3. **Cross-feature invariants** — rules that span features (§3). Plus the **client graph** (§4) that the
+   first draft under-covered.
+
+---
+
+## 1. Product / capability graph (roadmap)
+
+The correction the mapping surfaced: the shared coupling is a **pure fingerprint primitive**
+(`computeSourceFingerprint`), NOT the provenance *feature*. #50 and #51 both reuse that primitive;
+only #50 additionally needs provenance *enabled*.
+
+```mermaid
+flowchart LR
+  FP["computeSourceFingerprint<br/>(pure core primitive)"]:::core
+  P47["#47 provenance sidecar — DONE"]:::done
+  LC["lifecycle callbacks<br/>(always-on) — DONE"]:::done
+  P50["#50 stale detection — DONE"]:::done
+  P51["#51 auto-translate — DONE"]:::done
+  P46["#46 single/multi target — DONE"]:::done
+  P75["#75 per-locale status — DONE"]:::done
+  FL["fieldLevel per-field translate<br/>(sync, no provenance) — DONE"]:::done
+  P48["#48 per-field WITH provenance — OPEN"]:::open
+  P49["#49 global dashboard — OPEN"]:::open
+  FF["field-level fingerprint<br/>(deferred primitive)"]:::future
+
+  FP --> P47
+  FP --> P50
+  FP --> P51
+  P47 -->|requires| P50
+  P75 ==>|requires| P46
+  FP -.-> FF
+  FF -.->|needed by| P48
+  P49 -.->|needs NEW aggregate endpoint| AGG["server status/staleness rollup<br/>(does not exist yet)"]:::future
+
+  classDef core fill:#ede9fe,stroke:#7c3aed,stroke-width:2px
+  classDef done fill:#dcfce7,stroke:#16a34a,stroke-width:2px
+  classDef open fill:#fef9c3,stroke:#ca8a04,stroke-width:2px
+  classDef future fill:#e5e7eb,stroke:#6b7280,stroke-dasharray:4 2
+```
+
+`==>` = hard; `-->` solid = hard; `-.->` = soft/shared. Note: `#51` connects to the **primitive**, not
+to `#47`.
+
+| Feature | Requires (hard) | Benefits / shares (soft) | Notes |
+|---|---|---|---|
+| #47 provenance sidecar | — | `computeSourceFingerprint` | Opt-in; SQL needs a consumer migration. |
+| lifecycle callbacks | — | — | **Independent, always-on**, ungated (`plugin.ts:141`); not part of #47. |
+| #50 stale detection | **#47 enabled** | `computeSourceFingerprint` | Provenance off ⇒ staleness returns `[]`. |
+| #51 auto-translate | — (**not** #47) | shares `computeSourceFingerprint` drift-gate | Works with provenance disabled; needs a runner to execute. |
+| #46 single/multi target | **#75** (per-locale supersession) | — | Multi fan-out corrupts other locales without per-`(doc,locale)` keying. |
+| fieldLevel per-field (shipped) | schemaMap, provider | — | Synchronous `POST {basePath}/field`; **no runner, no persistence, no provenance**. |
+| #48 per-field WITH provenance (OPEN) | field-level fingerprint (extends #47) | fieldLevel plumbing | Distinct from shipped fieldLevel: #48 integrates provenance/staleness (see I10). |
+| #49 dashboard (OPEN) | **a new server aggregate endpoint** | #47 status, #51 coverage | Cannot reuse per-collection hooks as-is — see §4. |
+
+---
+
+## 2. Config-time (code) graph — what `init()` wires
+
+`plugin.ts` `init()` composes in a **fixed order dictated by produces→consumes edges**.
+
+```mermaid
+flowchart TD
+  collections["collections (config)"] -->|projectFieldsToFieldLike<br/>BEFORE Payload sanitizer| schemaMap["schemaMap (FieldLike/slug)"]
+  schemaMap --> slugs["collectionSlugs<br/>(= managedSlugs gate)"]
+  provCfg["provenance (config)"] --> provMod["configureProvenance()"]
+  schemaMap --> provMod
+  provMod -->|serviceFactory| runnerWiring
+  provMod -->|serviceFactory| builder
+  schemaMap --> runnerWiring["wireTranslateRunner()"]
+  provider["translationProvider"] --> runnerWiring
+  runner["runner (config)"] --> runnerWiring
+  lifecycle["lifecycle (config)"] --> runnerWiring
+  runnerWiring -->|taskRunnerFactory| autoMod["configureAutoTranslate()"]
+  runnerWiring -->|taskRunnerFactory| builder
+  schemaMap --> autoMod
+  collections -->|withAutoTranslate custom| autoMod
+  localization["config.localization"] -.->|validate/drop targets| autoMod
+  builder["PluginConfigBuilder<br/>access · targetSelection · provider · schemaMap"] --> levels["levels[].extend()"]
+  levels --> routes["route bundle<br/>(enqueue/run/cancel/status/staleness)"]
+  levels --> fieldRoute["fieldLevel → POST /field<br/>(consumes schemaMap + provider)"]
+  levels --> comps["admin components (widgets)"]
+  provMod -->|serviceFactory| routes
+  runnerWiring -->|taskRunnerFactory| routes
+  basePath["basePath (config)"] --> cache["CacheProviderExport (client)"]
+  targetSel["targetSelection (config)"] --> builder --> sprops["level serverProps → client widgets"]
+
+  classDef derived fill:#dbeafe,stroke:#2563eb
+  class schemaMap,slugs,provMod,runnerWiring,autoMod,builder,cache derived
+```
+
+### Produces / consumes (corrected)
+
+| Producer | Produces | Consumed by | Coupling |
+|---|---|---|---|
+| `init()` from `collections` (`plugin.ts:128`) | **`schemaMap`** | `ProvenanceService`, the pipeline handler, auto-translate hook, **`fieldLevel` route** (`fieldLevel.ts:33`) | Hard. NOT consumed by the staleness/job routes. |
+| `configureProvenance` (`Provenance.wiring.ts:57`) | **`serviceFactory`** (absent when off) | pipeline handler (record), staleness route config (2 handlers share one config) | Soft: absent ⇒ no write, staleness `[]`. **2 consumer sites** (not 3). |
+| `wireTranslateRunner` (`wireTranslateRunner.ts:80`) | **`taskRunnerFactory`** + a `configModifier` | auto-translate hook, the 6 job routes | Hard. |
+| `configureAutoTranslate` (`plugin.ts:146`) | a `configModifier` (afterChange hook) | `applyTo` | Reads `withAutoTranslate` custom; validates vs `config.localization`. |
+| `PluginConfigBuilder` | the config sink | `levels[].extend` | Carries access, `taskRunnerFactory`, `schemaMap`, **`translationProvider`** (→ fieldLevel), `serviceFactory`, `targetSelection`, basePath. |
+| `CacheProviderExport(basePath)` | client `basePath` context | all 9 client API hooks | The only always-added admin provider (not deduped). |
+
+### Composition order (and why)
+1. **`schemaMap` first** — two reasons: (a) **temporal** — it must snapshot `col.fields` *before* Payload's sanitizer strips `localized` from nested fields (`plugin.ts:122-127`); (b) it's the shared input everything downstream reads.
+2. `configureProvenance` before `wireTranslateRunner` (its `serviceFactory` is a runner-wiring input).
+3. `wireTranslateRunner` before `configureAutoTranslate` + builder (its `taskRunnerFactory` is their input).
+4. builder + `levels[].extend` consume the factories above.
+5. `addConfigModifier(runner, provenance, auto)` + `CacheProvider` → `applyTo` (the one mutation sink).
+
+**The three config modifiers are order-independent among themselves** — only "modifiers run before component/endpoint registration" matters (a runner modifier may return a fresh config object). The `runner→provenance→auto` sequence is not load-bearing.
+
+---
+
+## 3. Cross-feature invariants (the "rules")
+
+| # | Invariant | Enforced where |
+|---|---|---|
+| I1 | Stale detection is meaningless without provenance | **Code** — `getDocumentStaleness.handler` returns `[]` when `serviceFactory` absent. |
+| I2 | The **pure `computeSourceFingerprint`** is the single fingerprint source — used by the provenance write path, the staleness read path, AND the auto-translate drift-gate (3 consumers) | **Code** — `ProvenanceService` (write+read) + `hasSourceContentChanged` (drift) call the same core fn. |
+| I3 | Fingerprint must be captured from the **pristine source, before the pipeline mutates it in place** | **Code** — `translate-document/handler.ts:47-52`; else fresh translations read instantly stale. |
+| I4 | Auto-translate must not translate its own writes (loop guard) | **Code, 2 barriers** — writer stamps `AUTO_TRANSLATE_SKIP` context (`handler.ts:131`) + hook skips non-source-locale writes / the flag (`AutoTranslateEnqueue.hook.ts:46,63`). |
+| I5 | Source locale excluded from targets | **Code, 3 sites** — auto-translate task builder, auto-translate hook locale-guard, **manual enqueue `resolveTargetLocales`**. |
+| I6 | Unknown target locales never reach the pipeline (Postgres enum / orphan data) | **Code, 2 sites** — auto-translate `filterPolicyToKnownLocales` (config-time) + `resolveTargetLocales` (runtime), both via `extractLocaleCodes`. |
+| I7 | Duplicate targets de-duped in one enqueue (runner only supersedes vs stored jobs) | **Code, 2 sites** — auto-translate policy + `resolveTargetLocales`. |
+| I8 | Concurrent translations into different locales of one doc must not evict each other | **Code** — supersession keyed `(documentId, targetLng)` (jobs runner); sync runner's 3-part status key. Hard prerequisite of #46. |
+| I9 | Reconciler keeps `id` on shared (non-localized-container) rows or it wipes other locales | **Code** — `DataReconciler` `sharedRow` guard (c0a49d1b). |
+| I10 | Provenance sidecar slug must not collide with a consumer collection | **Code** — `assertProvenanceSlugFree` throws at config-time (exact-slug only; does not model SQL `dbName`). |
+| I11 | The route bundle registers once even though 2 levels contribute it | **Code** — `PluginConfigBuilder` endpoint dedup by `method+path`. |
+| I12 | Enabling provenance on SQL needs a consumer-created migration | **Convention/docs only** — README + collection JSDoc; runtime *tolerates* a missing table (returns `[]`), does not enforce. |
+| I13 | Each level should appear at most once | **Convention only — NOT enforced.** Endpoints dedup, but **admin components do not**, so a duplicated level renders a duplicated control. |
+| I14 (future) | A partial per-field translation must not record a **whole-doc** fingerprint (would falsely read "fully translated") | **Not built.** Note: the *shipped* fieldLevel records **no** fingerprint at all, so the risk is specific to **#48** integrating provenance. |
+
+Also noted: `get-collection-status` returns a flat, **non-per-locale** job list; only `get-document-status` reduces to latest job per target locale (the #75 per-locale feed).
+
+---
+
+## 4. Client dependency graph (was under-covered)
+
+### Config → client — three channels
+1. **`basePath`** → `CacheProviderExport` → `TranslateKitConfigContext` → `useTranslateKitConfig()` → **all 9 API hooks** build `/api${basePath}/…`.
+2. **`serverProps`** on the level export classes → `.server.tsx` → client widget: `targetSelection` (selects the target-field shape: `[]` vs `""`), plus server-derived `hasDrafts` (`collectionHasDrafts`) and `autoTranslate` (`resolveAutoTranslateSummary`). `access` rides the same serverProps but is consumed **only server-side** (the gate) — it never enters the client bundle.
+3. **Locales** — NOT via plugin serverProps: `useLocaleOptions` wraps `useConfig()` (`@payloadcms/ui`) + `useLocale()`. Consumed by both forms + `TranslateFieldControl`.
+
+### Hooks → endpoints
+| Hook | HTTP · route |
+|---|---|
+| `useCollectionTranslationStatus` | GET `/collection/:slug` |
+| `useDocumentTranslation` | GET `/document/:slug/:id` |
+| `useDocumentStaleness` | GET `/stale/:slug/:id` |
+| `useQueueDocumentTranslation` | POST `/enqueue` |
+| `useRunDocumentTranslation` | POST `/run/:id` |
+| `useCancelDocumentTranslation` | DELETE `/cancel` |
+| `useCancelCollectionTranslations` | DELETE `/cancel-by-collection/:slug` |
+| `useDismissStaleness` | POST `/stale/dismiss` |
+| `useTranslateField` | POST `/field` (opt-in `fieldLevel()` only) |
+
+### Client query-cache invalidation graph (the client analogue of I1)
+- `useQueueDocumentTranslation` success → invalidates document-status + collection-status + staleness.
+- `useRun…` → document-status + staleness; `useCancel…` → the respective status; `useDismissStaleness` → staleness.
+- **Completion-driven:** `useDocumentTranslation` fires a staleness invalidation when any locale newly reaches `completed`.
+- **Document status = a client-side JOIN** of two endpoints (`buildTranslationStatusRows({ staleness, runs })`).
+- Polling: collection/document status poll ~20s while jobs pending/running; **staleness never polls** (lazy). `fieldLevel` writes straight to form state with **no cache invalidation**.
+
+### UI portability
+- **Payload-agnostic** (react / rhf / radix only): `Select`, `MultiSelect`, `InfoPopover`, `Popup`, `FormSelect`, `FormMultiSelect`, `FormSelectStrategy` — locale options are injected as props, keeping them decoupled.
+- **Payload/Next-coupled** (one layer up): `useLocaleOptions`, the URL-param hooks, the widgets, `TranslateFieldControl`.
+
+---
+
+## 5. Known implicit coupling & risks
+- **`schemaMap` is a god-input** — every subsystem reads it (one clear producer at the boundary, but the largest coupling point).
+- **`provenance.serviceFactory`** fans to the pipeline handler + the staleness route config — the most-threaded produced value.
+- **Rules I5/I6/I7 are duplicated** across the auto-translate path and the manual-enqueue `resolveTargetLocales` — same rule, two implementations (drift risk; a shared locale-resolution unit is the natural home if a third caller appears).
+- **`init()` order-dependence is implicit** — encoded only by the `const` sequence, not by any declared dependency. The main thing a code mechanism (§6) could make explicit.
+- **I13 (level uniqueness) is unenforced** for admin components — the clearest "safe-by-convention, not by code" gap.
+
+## 6. #49 dashboard — concrete data dependencies (not a reuse)
+The mapping established that #49 **cannot** be built by aggregating the current per-collection hooks:
+- The managed-collection set is **server-only**; there is no client channel exposing it.
+- Status/staleness routes are **single-collection / single-doc and URL-param-gated** — a global admin page has no collection in the URL.
+- There is **no staleness rollup** endpoint; auto-translate coverage is resolved per-collection in the `.server.tsx` wrapper (reads each collection's `custom`).
+- The 20s polling model doesn't scale to an N-collection fan-out.
+
+⇒ #49 introduces a **new server aggregate capability** (status + staleness + auto-translate rollup over the managed set) + its client hook — a genuinely new edge, not a reuse.
+
+## 7. Phase 2 — codifying this (DEFERRED, decide from this map)
+- **(a) Docs only** — keep this graph current; discipline-based.
+- **(b) Declared `requires` + init-time validation** — each module's `configure(ctx)` declares what it needs; `init()` validates combinations + emits precise warnings (extends the existing auto-translate locale-warning). Targets the real failure modes: I1, I6, I13, I14, and the implicit init order-dependence.
+- **(c) Capability registry + topological wiring** — mini-DI ordering modules from declared deps; likely over-engineered for the current ~8 features.
+
+Recommendation to evaluate later: **(b)**, not (c). Decide once #48/#49 land and the edge count is known.
+```

--- a/packages/payload-plugin-translator/docs/plans/2026-07-29-config-combination-rules.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-07-29-config-combination-rules.md
@@ -1,0 +1,109 @@
+# Translator plugin — config combination rules & enforcement plan
+
+**Status:** Spec + implementation plan (Phase 2 design) · **Date:** 2026-07-29 · **Scope:** `@focus-reactive/payload-plugin-translator`
+**Companion:** builds on `2026-07-24-feature-dependency-graph.md` (the dependency edges); this doc is about **combination behavior** and **how to anchor each rule in code**. Every row is evidence-backed by a read-only combination sweep (config×config, config×per-collection, feature×runner/drafts/localization).
+
+Goal: turn the plugin's implicit combination behavior into **explicit, mostly-enforced contracts**, so an invalid or silently-degrading configuration is caught (or at least surfaced) instead of "working weirdly." The root problem the sweep found: enforcement is **asymmetric** — the auto-translate config path is well-guarded (config-time warns), while the manual-enqueue path, the runner choice, and cross-route consistency are guarded only by prose/JSDoc.
+
+## How to read this
+
+**Tiers** (where a rule can be anchored):
+- **A — type** (compile-time): make the invalid combination *unrepresentable* in the plugin's own config types. Strongest, but only reaches the plugin's own config shape — NOT Payload's `localization`, per-collection `custom`, or the runner instance.
+- **B — init validation** (boot-time): each capability declares `requires`/`conflictsWith`/`warnsWhen`; a central `validateComposition()` throws/warns at `init()` and logs the resolved "effective config". The workhorse — most rules land here.
+- **C — runtime contract** (per-op): a shared code unit every path must call (locale resolution, exclude check), or a per-operation policy (cap). Fixes drift + the real bugs.
+- **advisory** — a behavioral/perf property that is not an error and cannot be a hard contract; surfaced via warn + doc + (where useful) the admin UI.
+
+**Enforcement kinds:** `type` · `throw` · `warn` · `guard` (shared runtime unit) · `cap` · `doc/observe`.
+
+**Default throw-vs-warn stance:** warn by default; `throw` only for unambiguously-broken configs; every `throw` gets a documented escape hatch. (Open thresholds flagged in §4.)
+
+---
+
+## 1. Real defects — fix regardless of the rest (Tier C)
+
+| # | Rule | Current behavior (evidence) | Contract | Tier | Enforce | Anchor |
+|---|---|---|---|---|---|---|
+| D1 | `withFieldTranslation({ exclude:true })` must be honored by **every** translation path, including the `/field` route | Whole-doc/auto/collection honor it via `FieldChunkCollector`→`isTranslatableLeaf`; the fieldLevel `/field` route gates only by type (`field-guards.ts:11-13`) and never checks exclude (`resolveFieldSubtree.ts:54-62`, `translate-field/handler.ts:104-124`) → an excluded field **can be translated** by naming its path | C | guard (honor exclude in `resolveFieldSubtree`/handler) | `translate-field/resolveFieldSubtree.ts`, `translate-field/handler.ts` |
+| D2 | A target locale not in `config.localization` must never reach the pipeline — on **all** enqueue paths | Auto-translate path guarded; **manual `/enqueue` is not**: `resolveTargetLocales` with `knownLocales=null` (localization off/absent) keeps all targets → `payload.update({locale})` writes a phantom locale (orphan rows on Mongo/SQLite; enum error on Postgres) (`resolveTargetLocales.ts:37-38`, `enqueue/handler.ts:47-49`) | C | guard (shared locale-resolution unit both paths call; when localization absent → drop+warn or 400) | new shared `resolveTargetLocales` used by auto-translate + enqueue |
+
+D1/D2 also collapse the duplicated invariants I5/I6/I7 (source-exclusion / unknown-drop / dedup live in 2–3 copies today) into one shared unit — one fix, three benefits.
+
+## 2. Silent degradation — feature looks enabled, no-ops with no signal
+
+| # | Rule | Current | Contract | Tier | Enforce | Anchor |
+|---|---|---|---|---|---|---|
+| S1 | Stale detection requires provenance enabled | `/stale/*` always registers; returns `[]` when `serviceFactory` absent, no signal (`getDocumentStaleness.handler.ts:30-31`) | **Preferred A:** model stale as an explicit sub-option of `provenance` so "stale without provenance" can't be expressed. **Fallback B:** warn at init if a stale surface is active without provenance | A→B | type (preferred) / warn | `plugin.ts` config type; `Provenance.wiring.ts` |
+| S2 | Empty `levels: []` = no UI **and** no HTTP surface | `??` keeps `[]`; modifiers/provenance/auto-translate still wire, but nothing to translate through, no signal (`plugin.ts:148`) | warn: "no levels → no translation UI or endpoints registered" | B | warn | `plugin.ts` levels resolution |
+| S3 | `withAutoTranslate` on a collection not in `collections` is ignored | `slugs = enabled ∩ managed` → hook never injected, silent (`AutoTranslate.wiring.ts:76`). Inconsistent with manual enqueue, which 400s for unmanaged | warn: "auto-translate configured on <slug> but it is not in the plugin's `collections`" | B | warn | `AutoTranslate.wiring.ts` |
+| S4 | Auto-translate with no *effective* targets (`[]`, or only the source locale) | 0 tasks, silent (only the unknown-locale drop warns) (`policy.ts:136-137`, `hook.ts:80`) | warn: "auto-translate on <slug> has no effective target locales" | B | warn | `AutoTranslate.wiring.ts` |
+| S5 | Provenance on a SQL adapter requires the migrated table to exist | Runtime **swallows** a missing table (returns `[]`, writes no-op) → history silently never recorded; no signal (`plugin.ts:59-67`) | **RESOLVED — probe + throw:** at init, when adapter is SQL + provenance enabled, do a lightweight existence probe on the provenance table; if absent, stop init with a controlled error naming the fix ("generate + run a migration for `<slug>`"). Also **stop swallowing** the missing-table error at runtime (defense-in-depth). Probe = one init query; fires **only when the table is genuinely absent** (silent once migrated) | B | **throw** (probe-gated) | provenance wiring / `init()` |
+| S6 | `targetSelection:'multi'` has no effect without a document/collection level | With only `fieldLevel`/`[]`, multi is inert, silent (`fieldLevel` never reads it) | warn: "targetSelection has no effect without documentLevel/collectionLevel" | B | warn | `plugin.ts` / builder |
+| S7 | Duplicate slug in `collections` silently collapses (Map last-wins) | `schemaMap` keyed by slug (`plugin.ts:128-130`) | **RESOLVED — throw:** a duplicate slug stops init with a clear error (silently collapsing hides a real config mistake, and there's no non-arbitrary winner to pick for the user) | B | **throw** | `plugin.ts` schemaMap build |
+
+## 3. Contradictory / undefined — no defined rule
+
+| # | Rule | Current | Contract | Tier | Enforce | Anchor |
+|---|---|---|---|---|---|---|
+| X1 | A level may appear at most once | Endpoints dedup by `method+path`; **admin components do NOT** → duplicated control (`PluginConfigBuilder.ts:139-141`; I13) | **RESOLVED — silent dedup:** dedup admin components by (slot + component identity) in the builder → a doubled level renders one control; no warn (single obviously-correct resolution) | C | guard (dedup) | `PluginConfigBuilder.ts` |
+| X2 | Provenance sidecar slug must not collide even via SQL `dbName`/snake_case | Exact-slug throws; `dbName`/case/separator variants unguarded (`slugGuard.ts:5-13`) | **RESOLVED — throw:** normalize (snake_case + `dbName`) and compare; a probable table collision stops init with a clear error (extends the existing exact-slug throw; best-effort — a normalized match is treated as a collision) | B | **throw** | `slugGuard.ts` |
+| X3 | Translation endpoints default to **authenticated** (`req.user` present), not open | Today all routes are open when `access` is unset (`withAccessCheck.ts:14`) — a spend/DoS footgun with no signal | **RESOLVED — safe default + warn-on-open:** default `access` = require an authenticated user; override stricter (roles/tenants) or looser (allow-all) via `access`. Print the resolved policy in the effective-config log. **Warn only when `access` is explicitly allow-all.** Behavior change → release note + `@since`; keep an explicit allow-all escape hatch for local dev / externally-authed callers | A+B | **default guard** + warn-on-explicit-open | `init()` / routes wiring; `access` config default |
+
+## 4. Implicit behavior — same config, different runtime
+
+| # | Rule | Current | Contract | Tier | Enforce | Anchor |
+|---|---|---|---|---|---|---|
+| M1 | `multi × select_all` fan-out is bounded | Unbounded `docs × targets` cross-product, no cap/confirm (`enqueue/handler.ts:67-83`, `collection-utils.ts:20-25`) | **RESOLVED:** new plugin config `maxBulkTasks?: number` (default **500**); a bulk run over the limit is rejected (400) with a clear message (`docs×targets` count + limit + "raise `maxBulkTasks` to allow more") | C | cap (+ config prop) | `enqueue/handler.ts`; config type |
+| M2 | Features that need durable cross-request status must be unavailable on a runner that can't provide it | Sync runner runs inline in afterChange; status in-memory, lost on restart; only JSDoc says "development" (`SyncRunnerProvider.ts:48-62`). Status/progress/cancel endpoints silently return stale/empty in-memory data | **RESOLVED — capability contract, NOT env-gating:** extend the runner port with a declared capability set (e.g. `durableStatus`, `async`); the core decides by **declared capability, never by concrete runner type** (no `instanceof`). Endpoints/UI that require `durableStatus` either don't register or return a clear "unsupported by the configured runner" response instead of degrading silently. Print `runner=sync: inline, non-durable, status endpoints off` in the effective-config log. No `NODE_ENV` check. **Pre-req:** enumerate (from code) exactly which surfaces require durable status | A+C | **capability guard** on the runner port | runner port `interface` + status/progress/cancel wiring |
+| M3 | Auto-translate trigger semantics (drafts on = publish-gated; off = every save) | Correct but only a README parenthetical; not surfaced (`policy.ts:100-103`) | advisory: state in effective-config log + the admin auto-translate indicator; doc | advisory | doc/observe | effective-config log + `AutoTranslateMarker` |
+| M4 | Auto-translate source = `defaultLocale` unless overridden | Changing `defaultLocale` silently re-points the source (`hook.ts:52-53`); manual path uses request `source_lng` | advisory: show resolved source per collection in effective-config log; doc | advisory | doc/observe | effective-config log |
+| M5 | Source fingerprint read omits `fallbackLocale:false` (target read has it) | Edge: only when `sourceLocale ≠ defaultLocale` fallback-filled values enter the baseline (`sourceDocument.ts:15` vs `handler.ts:57`) | small code fix (add `fallbackLocale:false` to the source read) OR document the constraint | C | guard (or doc) | `shared/payload/sourceDocument.ts` |
+
+## 5. The mechanism (Tier B core) — capability contracts + one validator
+
+Each capability module exports a lightweight contract descriptor (no DI container):
+
+```ts
+type CapabilityContract = {
+  id: string;                               // "provenance" | "auto-translate" | "levels" | ...
+  enabledBy: (cfg) => boolean;              // is this capability active for this config?
+  requires?: string[];                      // hard prerequisites (other capability ids / conditions)
+  conflictsWith?: string[];                 // hard conflicts
+  warnsWhen?: (resolved) => Diagnostic[];   // soft/degradation checks → warnings
+  effective?: (resolved) => string[];       // lines for the "effective config" log
+};
+```
+
+`init()` gathers the contracts and runs one pass:
+```ts
+const { errors, warnings, effective } = validateComposition(contracts, resolvedConfig, { adapter, env });
+if (errors.length) throw new TranslatorConfigError(errors);   // hard (Tier B throw)
+for (const w of warnings) payload.logger.warn(w);             // soft (Tier B warn)
+payload.logger.info(renderEffectiveConfig(effective));        // observability (answers "implicit config")
+```
+
+- **`errors`** = the `throw` rows (unambiguously broken).
+- **`warnings`** = the silent-degradation + implicit rows.
+- **`effective`** = the resolved-behavior log — the single biggest win for "implicit configuration": every active capability prints what it actually does (auto-translate: publish-gated on `posts` into `de,fr`; runner=sync→inline; provenance=on slug `translator-provenance`; …).
+
+Type-level (Tier A) items (S1 stale-as-subflag, and any config-shape tightening) are done in the config types directly; runtime (Tier C) items (D1, D2, X1, M1, M5) are shared units / builder changes, independent of the validator.
+
+## 6. Sequencing (each row already tags where it goes)
+1. **Tier C bug fixes first** — D1, D2 (+ fold I5/I6/I7 into the shared locale unit), X1 (component dedup). Highest value, independent, shippable now; each is a real correctness fix.
+2. **Tier A** — S1 stale-as-subflag (unrepresentable-invalid) + any config-shape tightening.
+3. **Tier B core** — the `CapabilityContract` + `validateComposition` + effective-config log, then wire the warn/throw rows (S2–S7, X2, X3). S5 adds the init-time provenance-table probe; S7/X2 are throws.
+4. **Runner capability contract (M2)** — extend the runner port with declared capabilities; gate durable-status-dependent surfaces on them. Independent of the validator; needs the affected-surface enumeration first.
+5. **Tier C policy** — M1 `maxBulkTasks` cap.
+6. **advisory** — M3, M4 surfacing + docs.
+
+## 7. Threshold decisions
+
+All threshold decisions are resolved (2026-07-29):
+- **X3 access:** safe default — require an authenticated user; override both ways via `access`; warn only on explicit allow-all. (Not "warn on open by default" — the default is now safe.)
+- **M1 bulk cap:** configurable `maxBulkTasks`, default **500**; over the limit → reject (400) with the count.
+- **X1 duplicate level:** silent dedup of admin components (single obviously-correct resolution).
+- **S7 duplicate slug / X2 slug collision:** throw at init — a name collision has no non-arbitrary winner, so the developer must resolve it.
+- **S5 SQL migration:** probe the provenance table at init; **throw** a controlled error if absent (silent once migrated) — not a recurring warn. A missing table is a broken config, not a nag.
+- **M2 sync runner:** **not** env-gated. Model runner **capabilities** on the port; make durable-status-dependent features unavailable by declared capability (never by runner type). Enumerate the affected surfaces from code before implementing.
+
+Everything above is design; no code in this doc. Tier C bug fixes (D1/D2/X1) are the natural first implementation slice.
+```


### PR DESCRIPTION
## Summary

Adds a reference map of the translator plugin's **inter-feature dependencies** — so the growing web of "feature X needs feature Y" and cross-feature rules is explicit before we add the next capabilities (#48/#49). Docs-only; no code changes.

`packages/payload-plugin-translator/docs/plans/2026-07-24-feature-dependency-graph.md`

The map is evidence-backed (every edge cites `file:line`) and was built by an independent mapping pass over the config-time wiring, the server feature surface, and the client — which corrected several assumptions from a first draft.

## What's in it

Three layers, kept separate on purpose, plus a cross-cutting one:

1. **Product / capability graph** — roadmap-level "X unblocks Y". Key facts the mapping established:
   - the shared coupling is a **pure `computeSourceFingerprint` primitive**, not the provenance *feature*;
   - **#51 auto-translate does NOT require #47** (works with provenance disabled);
   - **#46 multi-target ↔ #75 per-locale status is a hard dependency** (fan-out corrupts other locales without per-`(doc,locale)` supersession);
   - the shipped synchronous **`fieldLevel`** per-field translate is distinct from the OPEN **#48** (per-field *with* provenance);
   - **lifecycle callbacks** are an independent, always-on capability (not part of #47).
2. **Config-time (`init()`) graph** — the actual produces→consumes edges (`schemaMap`, `provenance.serviceFactory`, `taskRunnerFactory`) and the composition order, with the reason each step must follow the prior.
3. **Cross-feature invariants (I1–I14)** — the rules that span features, including which are code-enforced vs **convention-only** (e.g. level-uniqueness is *not* enforced for admin components; SQL provenance migration is docs-only).
4. **Client dependency graph** — the three config→client channels, the 9 hooks→endpoints edges, the query-cache invalidation graph, and the concrete finding that **#49 (global dashboard) needs a new server aggregate endpoint** — it can't reuse the URL-gated, single-scope per-collection hooks.

## Scope

- **Phase 1 (this PR): capture only.** No behavior change, no code.
- **Phase 2 (deferred):** whether to codify any of this into init-time checks (declared `requires` + validation vs a capability registry) — to be decided from this map after #48/#49.
