### PR TITLE
Client content sandbox A (do not merge)

### DIFF
--- a/apps/cms/SANDBOX.md
+++ b/apps/cms/SANDBOX.md
@@ -1,0 +1,31 @@
+# Client content sandbox A
+
+This branch exists only to hold open a preview deployment of `apps/cms` that a
+prospect can log into and edit freely while they evaluate the CMS.
+
+**Do not merge this PR, and do not push code changes here.** It carries no code
+diff from `main` on purpose: what they see has to be stock Ideal CMS, not a work in
+progress.
+
+This repo is public, so the branch does not say which prospect it belongs to. The
+mapping, along with the login we hand out, lives in the deal record.
+
+## How it works
+
+- the open PR keeps a Vercel preview deployment alive on this branch
+- the Neon integration gives that deployment its own database branch, copied from
+  the parent at the moment the branch was cut, so anything they change stays off
+  the shared demo database
+- live preview resolves against the deployment's own origin (`generatePreviewPath`
+  returns a relative path), so the editing experience works on the preview domain
+  with no extra configuration
+
+Vercel crons only run on production deployments, so the hourly
+`/api/scheduled-publish/run` job does not fire here. Scheduling a publish in this
+sandbox stores the schedule and shows the UI, but nothing will execute it until
+someone calls that endpoint.
+
+## Retiring it
+
+Close the PR and delete the branch. That drops the preview deployment and the Neon
+branch with it. Nothing on `main` is affected.


### PR DESCRIPTION
Holds open a preview deployment of `apps/cms` so a prospect can log in and edit content while they evaluate the CMS against another platform. They asked for a login they could actually try, not a walkthrough.

**Do not merge, and do not push code here.** There is no code diff from `main` on purpose - they should see stock Ideal CMS, not a work in progress. The single file in the diff is [`apps/cms/SANDBOX.md`](https://github.com/focusreactive/payload-plugins/blob/sandbox-a/apps/cms/SANDBOX.md), which exists so the branch explains itself and so Vercel cannot skip the build for having no changes under the project root.

This repo is public, so neither the branch nor this description says which prospect it is for. The mapping and the login live in the deal record.

## Why a PR at all

The open PR is what keeps the preview deployment alive, and the Neon integration gives that deployment its own database branch copied from the parent. They can create, publish and delete as much as they like without touching the shared demo data.

## Known limits of the sandbox

Vercel crons run on production deployments only, so the hourly `/api/scheduled-publish/run` job does not fire here. A scheduled publish can be set up and inspected, but nothing executes it until that endpoint is called.

## Retiring it

Close the PR and delete the branch - the preview deployment and the Neon branch go with it.
