### PR TITLE
fix(translator): tier-C config guards (localization enqueue, field exclude, duplicate level)

### DIFF
--- a/packages/payload-plugin-translator/src/plugin.test.ts
+++ b/packages/payload-plugin-translator/src/plugin.test.ts
@@ -425,7 +425,10 @@ describe("translatorPlugin — lifecycle callbacks", () => {
         collection_slug: "posts",
         collection_id: ["1", "2"],
       }),
-      payload: { logger: { error: vi.fn() } },
+      payload: {
+        config: { localization: { locales: ["en", "de", "fr"] } },
+        logger: { error: vi.fn() },
+      },
     };
     await enqueue?.handler?.(req as never);
 
@@ -459,7 +462,10 @@ describe("translatorPlugin — lifecycle callbacks", () => {
         collection_slug: "posts",
         collection_id: ["1", "2"],
       }),
-      payload: { logger: { error: vi.fn() } },
+      payload: {
+        config: { localization: { locales: ["en", "de", "fr"] } },
+        logger: { error: vi.fn() },
+      },
     };
     await enqueue?.handler?.(req as never);
 

--- a/packages/payload-plugin-translator/src/server/features/enqueue-translation/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/enqueue-translation/handler.test.ts
@@ -17,15 +17,32 @@ describe("EnqueueTranslationHandler", () => {
   let mockTaskRunner: TaskRunner;
   let mockTaskRunnerFactory: TaskRunnerFactory;
   let config: EnqueueConfig;
+  const warn = vi.fn();
 
+  // Bare request: no localization configured. Used for the validation, collection-availability, and
+  // localization-guard paths — all of which reject before any locale resolution.
   const createMockRequest = (body: unknown): PayloadRequest =>
     ({
       payload: {} as Payload,
       json: vi.fn().mockResolvedValue(body),
     }) as unknown as PayloadRequest;
 
+  // Request whose payload carries a configured locale set + logger. Translation is meaningless without
+  // localization, so every success-path test runs against this.
+  const createLocalizedRequest = (body: unknown): PayloadRequest =>
+    ({
+      payload: {
+        config: { localization: { locales: ["en", "de", "fr", "es"] } },
+        logger: { warn },
+      },
+      json: vi.fn().mockResolvedValue(body),
+    }) as unknown as PayloadRequest;
+
+  const enqueuedTasks = () => (mockTaskRunner.enqueue as any).mock.calls[0][0];
+
   beforeEach(() => {
     vi.clearAllMocks();
+    warn.mockClear();
 
     mockTaskRunner = {
       enqueue: vi.fn().mockResolvedValue(undefined),
@@ -85,9 +102,30 @@ describe("EnqueueTranslationHandler", () => {
     });
   });
 
+  describe("localization guard (D2)", () => {
+    // Without localization there is no valid target locale: a phantom locale would either orphan rows
+    // or, with no localization at all, overwrite the single unlocalized field — wiping the source.
+    it("returns 400 and enqueues nothing when localization is not enabled", async () => {
+      const req = createMockRequest({
+        source_lng: "en",
+        target_lng: "de",
+        collection_slug: "posts",
+        collection_id: ["doc-1"],
+        strategy: "overwrite",
+      });
+
+      const response = await handler.handle(req);
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.message).toContain("Localization is not enabled");
+      expect(mockTaskRunner.enqueue).not.toHaveBeenCalled();
+    });
+  });
+
   describe("success responses", () => {
     it("enqueues tasks for specific documents", async () => {
-      const req = createMockRequest({
+      const req = createLocalizedRequest({
         source_lng: "en",
         target_lng: "de",
         collection_slug: "posts",
@@ -103,7 +141,7 @@ describe("EnqueueTranslationHandler", () => {
     });
 
     it("calls runner.enqueue with correct tasks", async () => {
-      const req = createMockRequest({
+      const req = createLocalizedRequest({
         source_lng: "en",
         target_lng: "fr",
         collection_slug: "posts",
@@ -129,8 +167,12 @@ describe("EnqueueTranslationHandler", () => {
     // This is a schema design decision that should be tested at integration level
 
     it("creates task runner with request payload", async () => {
-      const mockPayload = { collections: {} } as Payload;
-      const req = createMockRequest({
+      const mockPayload = {
+        collections: {},
+        config: { localization: { locales: ["en", "de", "fr", "es"] } },
+        logger: { warn },
+      } as unknown as Payload;
+      const req = createLocalizedRequest({
         source_lng: "en",
         target_lng: "de",
         collection_slug: "posts",
@@ -146,21 +188,6 @@ describe("EnqueueTranslationHandler", () => {
   });
 
   describe("multi-target fan-out", () => {
-    const warn = vi.fn();
-    // A request whose payload carries a configured locale set + logger, so locale validation is active.
-    const createLocalizedRequest = (body: unknown): PayloadRequest =>
-      ({
-        payload: {
-          config: { localization: { locales: ["en", "de", "fr", "es"] } },
-          logger: { warn },
-        },
-        json: vi.fn().mockResolvedValue(body),
-      }) as unknown as PayloadRequest;
-
-    const enqueuedTasks = () => (mockTaskRunner.enqueue as any).mock.calls[0][0];
-
-    beforeEach(() => warn.mockClear());
-
     it("fans out one task per (document x target) — 2 docs x 2 targets = 4 (AC3)", async () => {
       const req = createLocalizedRequest({
         source_lng: "en",

--- a/packages/payload-plugin-translator/src/server/features/enqueue-translation/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/enqueue-translation/handler.ts
@@ -40,13 +40,20 @@ export class EnqueueTranslationHandler {
         "Content of this collection is not available for translation"
       );
 
-    // Normalize the scalar-or-array target into the concrete locales to fan out to: de-dup, exclude the
-    // source, and drop locales that are not configured (unknown locales would burn a provider call and
-    // corrupt data — Postgres locale enum / orphaned Mongo rows). `config` is optional-chained because a
-    // localization-less (or minimally-mocked) payload has none, which correctly disables the filter.
+    // A localization-less config has no valid target locale: a phantom locale would burn a provider
+    // call and corrupt data — orphaned rows on Mongo/SQLite, a locale-enum error on Postgres, or (with
+    // no localization at all) overwrite the single unlocalized field and wipe the source. Reject before
+    // anything is enqueued.
     const knownLocales = extractLocaleCodes(
       req.payload.config?.localization as LocalizationLike | undefined
     );
+    if (!knownLocales)
+      return ServerResponse.badRequest(
+        "Localization is not enabled in this Payload config; there are no target locales to translate into"
+      );
+
+    // Normalize the scalar-or-array target into the concrete locales to fan out to: de-dup, exclude the
+    // source, and drop locales that are not configured.
     const { targets, droppedUnknown } = resolveTargetLocales({
       target_lng,
       source_lng,
@@ -56,7 +63,7 @@ export class EnqueueTranslationHandler {
       req.payload.logger?.warn(
         `[payload-plugin-translator] enqueue on "${collectionSlug}": ignoring unknown target locale(s) ${droppedUnknown.join(
           ", "
-        )} (configured locales: ${knownLocales ? [...knownLocales].join(", ") : "n/a"}).`
+        )} (configured locales: ${[...knownLocales].join(", ")}).`
       );
     }
     if (targets.length === 0)

--- a/packages/payload-plugin-translator/src/server/features/enqueue-translation/resolveTargetLocales.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/enqueue-translation/resolveTargetLocales.test.ts
@@ -50,16 +50,6 @@ describe("resolveTargetLocales", () => {
     expect(r.droppedUnknown).toEqual(["xx"]);
   });
 
-  it("keeps every non-source target unfiltered when localization is unknown/disabled", () => {
-    const r = resolveTargetLocales({
-      target_lng: ["de", "xx"],
-      source_lng: "en",
-      knownLocales: null,
-    });
-    expect(r.targets).toEqual(["de", "xx"]);
-    expect(r.droppedUnknown).toEqual([]);
-  });
-
   it("returns no targets when every requested locale is the source or unknown", () => {
     const r = resolveTargetLocales({
       target_lng: ["en", "xx"],

--- a/packages/payload-plugin-translator/src/server/features/enqueue-translation/resolveTargetLocales.ts
+++ b/packages/payload-plugin-translator/src/server/features/enqueue-translation/resolveTargetLocales.ts
@@ -4,7 +4,7 @@
 export type ResolvedTargetLocales = {
   /** The concrete locales to fan out to — de-duplicated, source excluded, unknown removed. */
   targets: string[];
-  /** Requested locales that are not configured (dropped) — empty when localization is unknown/disabled. */
+  /** Requested locales that are not configured (dropped). */
   droppedUnknown: string[];
   /** Whether the source locale was requested as a target and excluded. */
   droppedSource: boolean;
@@ -13,30 +13,27 @@ export type ResolvedTargetLocales = {
 /**
  * Normalize the enqueue `target_lng` input (scalar or array) into the concrete list of target locales
  * to translate into. Applies, in order: array-coercion, de-duplication (first-seen order preserved),
- * source-locale exclusion, and — when the configured locale set is known — dropping unknown locales.
+ * source-locale exclusion, and dropping unknown (unconfigured) locales.
  *
  * De-dup and unknown-dropping are the manual-enqueue counterparts of the auto-translate policy filter:
  * the runner only supersedes against already-stored jobs, so duplicates within one enqueue must be
  * collapsed here; and an unknown locale must never reach the pipeline — it burns a provider call and
  * either errors on a Postgres locale enum or writes orphaned, invisible data on Mongo/SQLite.
  *
- * @param knownLocales - the configured locale codes, or `null` when localization is disabled/absent
- *   (then no unknown-dropping is applied — every requested locale except the source is kept).
+ * @param knownLocales - the configured locale codes. Never null: the caller must reject a
+ *   localization-less config before reaching here (translating without localization has no valid
+ *   target and would corrupt data), so "no localization" is not representable as an input.
  */
 export function resolveTargetLocales(args: {
   target_lng: string | string[];
   source_lng: string;
-  knownLocales: Set<string> | null;
+  knownLocales: Set<string>;
 }): ResolvedTargetLocales {
   const { target_lng, source_lng, knownLocales } = args;
   const requested = Array.isArray(target_lng) ? target_lng : [target_lng];
   const deduped = [...new Set(requested)];
   const droppedSource = deduped.includes(source_lng);
   const withoutSource = deduped.filter((target) => target !== source_lng);
-
-  if (!knownLocales) {
-    return { targets: withoutSource, droppedUnknown: [], droppedSource };
-  }
   const droppedUnknown = withoutSource.filter((target) => !knownLocales.has(target));
   const targets = withoutSource.filter((target) => knownLocales.has(target));
   return { targets, droppedUnknown, droppedSource };

--- a/packages/payload-plugin-translator/src/server/features/translate-field/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-field/handler.test.ts
@@ -54,6 +54,12 @@ beforeEach(() => {
         f({ name: "title", type: "text", localized: true }),
         f({ name: "count", type: "number" }),
         f({
+          name: "secret",
+          type: "text",
+          localized: true,
+          custom: { translateKit: { exclude: true } },
+        }),
+        f({
           name: "layout",
           type: "blocks",
           blocks: [
@@ -203,6 +209,20 @@ describe("TranslateFieldHandler", () => {
     const res = await handler.handle(reqWithDoc({ id: "p1", count: 5 }, { field_path: "count" }));
     expect(res.status).toBe(200);
     expect((await res.json()).data.notice.level).toBe("info");
+    expect(translateContent).not.toHaveBeenCalled();
+  });
+
+  it("no-ops a field excluded via withFieldTranslation({ exclude }) — provider never called (D1)", async () => {
+    const translateContent = await importTranslateContent();
+
+    const res = await handler.handle(
+      reqWithDoc({ id: "p1", secret: "Hello" }, { field_path: "secret" })
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()).data;
+    expect(body.status).toBe("noop");
+    expect(body.notice.level).toBe("info");
+    expect(body.notice.message).toContain("excluded from translation");
     expect(translateContent).not.toHaveBeenCalled();
   });
 

--- a/packages/payload-plugin-translator/src/server/features/translate-field/handler.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-field/handler.ts
@@ -106,6 +106,11 @@ export class TranslateFieldHandler {
         noop(sourceValue, "info", "Nothing to translate in this field")
       );
     }
+    if (resolution.status === "excluded") {
+      return ServerResponse.success(
+        noop(sourceValue, "info", "This field is excluded from translation")
+      );
+    }
 
     // No `strategy`/`targetData`: a per-field translate is an explicit "translate this field now",
     // so `translateContent` always overwrites (its default). skip_existing has no meaning here.

--- a/packages/payload-plugin-translator/src/server/features/translate-field/resolveFieldSubtree.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-field/resolveFieldSubtree.test.ts
@@ -92,6 +92,40 @@ describe("resolveFieldSubtree", () => {
     expect(resolveFieldSubtree(schema, "meta", {}).status).toBe("not-translatable");
   });
 
+  it("returns excluded for a translatable leaf opted out via withFieldTranslation({ exclude }) (D1)", () => {
+    const excludedSchema: Field[] = [
+      f({
+        name: "secret",
+        type: "text",
+        localized: true,
+        custom: { translateKit: { exclude: true } },
+      }),
+      f({
+        name: "block",
+        type: "blocks",
+        blocks: [
+          {
+            slug: "hero",
+            fields: [
+              f({
+                name: "hidden",
+                type: "text",
+                localized: true,
+                custom: { translateKit: { exclude: true } },
+              }),
+            ],
+          },
+        ],
+      }),
+    ];
+
+    // top-level excluded leaf
+    expect(resolveFieldSubtree(excludedSchema, "secret", "x").status).toBe("excluded");
+    // excluded leaf resolved inside a block (exclude honored uniformly, not only at the top level)
+    const doc = { block: [{ blockType: "hero", hidden: "x" }] };
+    expect(resolveFieldSubtree(excludedSchema, "block.0.hidden", "x", doc).status).toBe("excluded");
+  });
+
   it("returns inside-blocks when the path descends through a blocks field with no document data", () => {
     expect(resolveFieldSubtree(schema, "layout.0.headline", "x").status).toBe("inside-blocks");
   });

--- a/packages/payload-plugin-translator/src/server/features/translate-field/resolveFieldSubtree.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-field/resolveFieldSubtree.ts
@@ -1,4 +1,4 @@
-import { isTranslatableField } from "../../shared";
+import { isFieldExcludedFromTranslation, isTranslatableField } from "../../shared";
 import { findFieldByPath } from "../../../core/kernel/field-traversal";
 import type { FieldLike } from "../../../core/kernel/field-traversal";
 
@@ -9,6 +9,10 @@ import type { FieldLike } from "../../../core/kernel/field-traversal";
  *   are ready for `translateContent`, and `fieldName` is the key to unwrap the result.
  * - `not-found` — the path resolves to no field at all (a typo) → caller returns 400.
  * - `not-translatable` — resolves to a field that isn't a text-like leaf → caller no-ops.
+ * - `excluded` — resolves to a translatable leaf that opted out via `withFieldTranslation({ exclude })`
+ *   → caller no-ops. Kept distinct from `not-translatable` so the notice can say *why* (a deliberate
+ *   opt-out, not a wrong type), and because this route must honor the same exclude the whole-document
+ *   path honors via `isTranslatableLeaf` — otherwise naming the path directly bypasses the opt-out.
  * - `inside-blocks` — the path descends through a polymorphic `blocks` field that couldn't be
  *   resolved: no `doc` was supplied to read the element's `blockType` from → caller no-ops.
  * - `localized-list-ancestor` — the path descends through a `localized` `blocks`/`array` field,
@@ -24,6 +28,7 @@ export type FieldSubtreeResolution =
     }
   | { status: "not-found" }
   | { status: "not-translatable" }
+  | { status: "excluded" }
   | { status: "inside-blocks" }
   | { status: "localized-list-ancestor" };
 
@@ -52,14 +57,14 @@ export function resolveFieldSubtree(
   const result = findFieldByPath(rootFields, segments, doc);
   switch (result.status) {
     case "leaf":
-      return isTranslatableField(result.field)
-        ? {
-            status: "resolved",
-            schema: [result.field],
-            sourceData: { [result.field.name]: value },
-            fieldName: result.field.name,
-          }
-        : { status: "not-translatable" };
+      if (!isTranslatableField(result.field)) return { status: "not-translatable" };
+      if (isFieldExcludedFromTranslation(result.field)) return { status: "excluded" };
+      return {
+        status: "resolved",
+        schema: [result.field],
+        sourceData: { [result.field.name]: value },
+        fieldName: result.field.name,
+      };
     case "container":
       return { status: "not-translatable" };
     case "inside-blocks":

--- a/packages/payload-plugin-translator/src/server/modules/translation-levels/PluginConfigBuilder.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-levels/PluginConfigBuilder.test.ts
@@ -63,6 +63,44 @@ describe("PluginConfigBuilder", () => {
     expect(other.admin).toBeUndefined(); // unmanaged collection untouched
   });
 
+  it("deduplicates a collection component declared twice for the same slot + path (duplicate level)", () => {
+    const builder = new PluginConfigBuilder(deps([{ slug: "posts" }]));
+    // Two documentLevel()-style registrations: distinct `make` closures, same slot + component path.
+    builder.addCollectionComponent("beforeDocumentControls", () => component("doc"));
+    builder.addCollectionComponent("beforeDocumentControls", () => component("doc"));
+
+    const config = { collections: [{ slug: "posts" }] } as unknown as Config;
+    builder.applyTo(config);
+
+    const posts = config.collections![0] as Record<string, any>;
+    expect(posts.admin.components.edit.beforeDocumentControls).toHaveLength(1); // one control, not two
+  });
+
+  it("keeps distinct components on the same slot when their paths differ", () => {
+    const builder = new PluginConfigBuilder(deps([{ slug: "posts" }]));
+    builder.addCollectionComponent("beforeDocumentControls", () => component("a"));
+    builder.addCollectionComponent("beforeDocumentControls", () => component("b"));
+
+    const config = { collections: [{ slug: "posts" }] } as unknown as Config;
+    builder.applyTo(config);
+
+    const posts = config.collections![0] as Record<string, any>;
+    expect(posts.admin.components.edit.beforeDocumentControls).toHaveLength(2);
+  });
+
+  it("dedups per (slot + path): the same path on different slots is not collapsed", () => {
+    const builder = new PluginConfigBuilder(deps([{ slug: "posts" }]));
+    builder.addCollectionComponent("beforeDocumentControls", () => component("x"));
+    builder.addCollectionComponent("beforeListTable", () => component("x"));
+
+    const config = { collections: [{ slug: "posts" }] } as unknown as Config;
+    builder.applyTo(config);
+
+    const posts = config.collections![0] as Record<string, any>;
+    expect(posts.admin.components.edit.beforeDocumentControls).toHaveLength(1);
+    expect(posts.admin.components.beforeListTable).toHaveLength(1);
+  });
+
   it("registers admin providers into config.admin.components.providers", () => {
     const builder = new PluginConfigBuilder(deps());
     const provider = component("cache");

--- a/packages/payload-plugin-translator/src/server/modules/translation-levels/PluginConfigBuilder.ts
+++ b/packages/payload-plugin-translator/src/server/modules/translation-levels/PluginConfigBuilder.ts
@@ -21,6 +21,14 @@ export type PluginConfigBuilderDeps = TranslationContext;
 
 const endpointKey = (endpoint: Endpoint): string => `${endpoint.method} ${endpoint.path}`;
 
+/**
+ * Identity of a collection admin component for dedup: its slot plus its module path (+ export name).
+ * `serverProps` (per-collection data) are excluded, so the same control registered by a level declared
+ * twice collapses to one — while genuinely different controls (distinct path or slot) do not.
+ */
+const componentKey = (slot: CollectionAdminSlot, component: RawPayloadComponentExport): string =>
+  `${slot} ${component.path}#${component.exportName ?? ""}`;
+
 function attachToSlot(
   collection: CollectionConfig,
   slot: CollectionAdminSlot,
@@ -136,8 +144,13 @@ export class PluginConfigBuilder implements LevelContext {
     const managed = new Set(this.collections.map((collection) => collection.slug));
     config.collections?.forEach((collection) => {
       if (!managed.has(collection.slug)) return;
+      const seen = new Set<string>();
       for (const { slot, make } of this.collectionComponents) {
-        attachToSlot(collection, slot, make(collection));
+        const component = make(collection);
+        const key = componentKey(slot, component);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        attachToSlot(collection, slot, component);
       }
     });
   }


### PR DESCRIPTION
Three independent correctness fixes for the translator plugin, all from the
config-combination-rules plan (`docs/plans/2026-07-29-config-combination-rules.md`,
tier "real defects" + duplicated-control). Each is a separate commit → three
distinct changelog entries under one patch release.

## Fixes

### 1. Reject manual enqueue when localization is disabled (D2)
A manual `POST /translate/enqueue` with localization disabled or absent kept
every requested target locale and passed it to `payload.update({ locale })` —
orphaning rows (Mongo/SQLite), erroring on a Postgres locale enum, or, with no
localization at all, overwriting the single unlocalized field and **wiping the
source**. The handler now returns `400` before enqueuing anything, and
`resolveTargetLocales` no longer accepts a `null` locale set, so a
localization-less config is unrepresentable.

### 2. Honor field-level exclude on the single-field translation route (D1)
The `/field` route resolved a path by field **type** only, so a field opted out
via `withFieldTranslation({ exclude })` could still be translated by naming its
path directly — bypassing the opt-out the whole-document path honors via
`isTranslatableLeaf`. `resolveFieldSubtree` now returns a distinct `excluded`
status for such a leaf (uniformly, including inside blocks) and the handler
no-ops it with a clear notice.

### 3. De-duplicate translation controls when a level is declared twice (X1)
A level listed twice (e.g. `levels: [documentLevel(), documentLevel()]`)
attached its admin control to each managed collection twice, rendering a
duplicated button. Endpoints already dedup by `(method, path)`;
`attachCollectionComponents` now mirrors that, deduping by `(slot + component
path)` so a duplicate level renders one control silently.

## Verification
- Unit: 1175 tests pass (+8 new across the three fixes).
- Integration: 9 files / 32 tests pass against the built `dist`.
- Type-check (turbo) and lint clean; full `tsc` declaration build succeeds.

## Notes / out of scope
- The `/field` route also does not check `localized` (a non-localized field
  could be translated by naming its path). Same class as #2 but a separate
  concern — left as a follow-up, not folded in.
- Unifying the three copies of the locale invariants (source-exclusion /
  unknown-drop / de-dup) into one shared unit shared by the auto-translate and
  manual paths is the planned next slice; kept out here to keep the diff tight.
