### PR TITLE
fix(translator): replace Russian status labels with English

### DIFF
--- a/packages/payload-plugin-translator/src/client/shared/ui/StatusCounter/StatusCounter.tsx
+++ b/packages/payload-plugin-translator/src/client/shared/ui/StatusCounter/StatusCounter.tsx
@@ -21,10 +21,10 @@ const statusColorMap = {
 };
 
 const statusLabelMap = {
-  pending: "В очереди",
-  running: "В процессе",
-  completed: "Завершено",
-  failed: "Ошибки",
+  pending: "Queued",
+  running: "Translating",
+  completed: "Translated",
+  failed: "Failed",
 };
 
 export default function StatusCounter({


### PR DESCRIPTION
`StatusCounter` shipped its default labels in Russian inside an otherwise English plugin.

```diff
 const statusLabelMap = {
-  pending: "В очереди",
-  running: "В процессе",
-  completed: "Завершено",
-  failed: "Ошибки",
+  pending: "Queued",
+  running: "Translating",
+  completed: "Translated",
+  failed: "Failed",
 };
```

## Why this wording

Reuses the vocabulary already established elsewhere in the plugin, so the three status label sets stay identical rather than introducing a third phrasing:

- `client/features/collection-translation-progress/ui/CollectionTranslationProgress.tsx`
- `client/entities/translation/ui/TranslationStatusList/StatusBadge.tsx`

Both already use Queued / Translating / Translated / Failed.

## Scope note

The component has no call sites inside the plugin today — only its own barrel re-exports it. So these defaults do not currently render anywhere. They are still reachable by consumers through the `./client/*` export path, which is why this is typed `fix:` rather than `chore:`.

Worth a follow-up decision on whether `StatusCounter` should be deleted as dead code; out of scope here.

## Verification

`check-types` clean, `ultracite` clean on the changed file, full plugin suite green (1188/1188). Behaviour is unchanged beyond the four strings.