### PR TITLE
chore(cms): translate PKCE doc comment to English

### DIFF
--- a/apps/cms/src/lib/auth/oidc/pkce.ts
+++ b/apps/cms/src/lib/auth/oidc/pkce.ts
@@ -1,5 +1,5 @@
 /**
- * PKCE: code_verifier и code_challenge для Authorization Code flow
+ * PKCE: code_verifier and code_challenge for the Authorization Code flow
  */
 function base64UrlEncode(bytes: Uint8Array): string {
   const b64 = Buffer.from(bytes).toString("base64");


### PR DESCRIPTION
The last Russian comment left in the codebase.

```diff
 /**
- * PKCE: code_verifier и code_challenge для Authorization Code flow
+ * PKCE: code_verifier and code_challenge for the Authorization Code flow
  */
```

Comment only — no behaviour change. `apps/cms` is private and skipped by `--ignore-private-packages`, so this carries no release.

## Context

Found while sweeping the repository for non-English content. Everything else that turned up is intentional and was left alone: Russian strings in `TranslationMutator.test.ts` and the `TranslationProvider` JSDoc example are translation *results* used as fixtures, and `"статья-1"` in `jobId.test.ts` is a deliberate Unicode identifier case.

## Known unrelated warning

`ultracite` reports a pre-existing `require-unicode-regexp` warning on line 6 of this file (`/=+$/` missing the `u` flag). Untouched here — it predates this change and deserves its own fix.