### PR TITLE
chore(ci): delete Neon preview branch when PR closes

### DIFF
--- a/.github/workflows/cleanup-neon-preview-branch.yml
+++ b/.github/workflows/cleanup-neon-preview-branch.yml
@@ -1,0 +1,23 @@
+name: Cleanup Neon preview branch
+
+# The Neon<->Vercel integration creates a `preview/<git-branch>` database branch
+# for each apps/cms preview deployment but never removes it. Delete it as soon as
+# the PR is closed (merged or not) so stale branches don't accumulate storage costs.
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  delete-branch:
+    name: Delete preview/${{ github.head_ref }}
+    runs-on: ubuntu-latest
+    # Fork PRs get no Neon preview branch and cannot read repository secrets.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          branch: preview/${{ github.head_ref }}
+          api_key: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
## What

Adds `.github/workflows/cleanup-neon-preview-branch.yml`. On `pull_request: closed` (merged or not), deletes the Neon branch `preview/<git-branch>` via `neondatabase/delete-branch-action@v3`.

## Why

The Neon<->Vercel integration creates a `preview/<git-branch>` DB branch for every `apps/cms` preview deployment but never removes it. Stale branches accumulate storage cost. Plugin-only PRs also get a preview deploy, so this applies repo-wide — no path filter needed.

## Notes

- `permissions: {}` — the action only talks to the Neon API, `GITHUB_TOKEN` needs no scopes.
- Skips fork PRs: secrets aren't exposed to `pull_request` runs from forks, so the step would fail on every external PR. It also avoids passing an untrusted branch name into the action, which interpolates it straight into a `run:` block.
- Reads `secrets.NEON_PROJECT_ID` + `secrets.NEON_API_KEY` (both already set on this repo).

## Verification

`preview/<git-branch>` naming is not yet confirmed against the console. Because `pull_request` workflows run from the PR head, closing this PR exercises the workflow itself — that run is the test. If the prefix is wrong the job fails visibly and it's a one-line change.