### PR TITLE
fix(dev): repair the sandbox frontend and add a locale switcher

### DIFF
--- a/apps/dev/.env.example
+++ b/apps/dev/.env.example
@@ -20,3 +20,4 @@ GA4_CLIENT_EMAIL=service-account@your-gcp-project.iam.gserviceaccount.com
 GA4_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
 
 NEXT_PUBLIC_GA4_MEASUREMENT_ID=G-XXXXXXX
+NEXT_PUBLIC_SERVER_URL=http://localhost:4040

--- a/apps/dev/src/app/(frontend)/[slug]/LocaleSwitcher.tsx
+++ b/apps/dev/src/app/(frontend)/[slug]/LocaleSwitcher.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import React, { useId } from "react";
+
+import { LOCALES } from "./locales";
+import type { LocaleCode } from "./locales";
+
+// A native <select> keeps the OS picker on touch devices; `appearance: none` only removes the
+// chrome, so the arrow has to be drawn back in as a background image. Its colour is baked into the
+// SVG because a data URI cannot read a CSS variable — `--theme-elevation-250` as of writing.
+const CHEVRON =
+  "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6'%3E%3Cpath fill='rgb(87,87,87)' d='M0 0h10L5 6z'/%3E%3C/svg%3E\")";
+
+export function LocaleSwitcher({ current }: { current: LocaleCode }) {
+  const router = useRouter();
+  const id = useId();
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const [pending, startTransition] = React.useTransition();
+
+  const select = (code: string) => {
+    const next = new URLSearchParams(params.toString());
+    next.set("locale", code);
+    // Client navigation: the server re-renders with the new locale, so the published-only filter
+    // and the locale fallbacks stay exactly as they are for a real visitor.
+    startTransition(() => router.replace(`${pathname}?${next.toString()}`, { scroll: false }));
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "calc(var(--base) * 0.5)",
+        padding: "calc(var(--base) * 0.6) calc(var(--base) * 1.7)",
+      }}
+    >
+      <label
+        htmlFor={id}
+        style={{ fontSize: 13, letterSpacing: "0.04em", color: "var(--theme-elevation-250)" }}
+      >
+        Language
+      </label>
+      <select
+        id={id}
+        value={current}
+        onChange={(event) => select(event.target.value)}
+        disabled={pending}
+        style={{
+          appearance: "none",
+          padding:
+            "calc(var(--base) * 0.3) calc(var(--base) * 1.5) calc(var(--base) * 0.3) calc(var(--base) * 0.6)",
+          borderRadius: "var(--style-radius-m)",
+          border: "1px solid var(--theme-border-color)",
+          background: `${CHEVRON} no-repeat right calc(var(--base) * 0.6) center, var(--theme-elevation-0)`,
+          backgroundSize: "10px 6px",
+          color: "var(--theme-elevation-800)",
+          font: "inherit",
+          fontSize: 14,
+          lineHeight: 1.2,
+          cursor: pending ? "progress" : "pointer",
+          opacity: pending ? 0.6 : 1,
+        }}
+      >
+        {LOCALES.map(({ code, label }) => (
+          <option
+            key={code}
+            value={code}
+            style={{
+              background: "var(--theme-elevation-100)",
+              color: "var(--theme-elevation-800)",
+            }}
+          >
+            {label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/apps/dev/src/app/(frontend)/[slug]/locales.ts
+++ b/apps/dev/src/app/(frontend)/[slug]/locales.ts
@@ -1,0 +1,11 @@
+export const LOCALES = [
+  { code: "en", label: "English" },
+  { code: "de", label: "Deutsch" },
+  { code: "fr", label: "Français" },
+  { code: "es", label: "Español" },
+] as const;
+
+export type LocaleCode = (typeof LOCALES)[number]["code"];
+
+export const isLocale = (value: string | undefined): value is LocaleCode =>
+  LOCALES.some((l) => l.code === value);

--- a/apps/dev/src/app/(frontend)/[slug]/page.tsx
+++ b/apps/dev/src/app/(frontend)/[slug]/page.tsx
@@ -5,21 +5,29 @@ import React from "react";
 
 import config from "@/payload.config";
 
+import { LocaleSwitcher } from "./LocaleSwitcher";
+import { isLocale } from "./locales";
 import { PageClient } from "./PageClient";
 
 interface Props {
   params: Promise<{ slug: string }>;
+  searchParams: Promise<{ locale?: string }>;
 }
 
-export default async function Page({ params }: Props) {
+export default async function Page({ params, searchParams }: Props) {
   const { slug } = await params;
+  const { locale: requested } = await searchParams;
+  const locale = isLocale(requested) ? requested : "en";
   const payload = await getPayload({ config });
 
   const { docs } = await payload.find({
     collection: "pages",
     depth: 1,
     limit: 1,
-    where: { slug: { equals: slug } },
+    locale,
+    where: {
+      and: [{ slug: { equals: slug } }, { _status: { equals: "published" } }],
+    },
   });
 
   const page = docs[0];
@@ -29,8 +37,15 @@ export default async function Page({ params }: Props) {
 
   return (
     <>
-      <TrackPage collection="pages" id={page.id} locale="en" />
-      <PageClient initialData={page as any} serverURL={process.env.NEXT_PUBLIC_SERVER_URL ?? ""} />
+      <LocaleSwitcher current={locale} />
+      <TrackPage collection="pages" id={page.id} locale={locale} />
+      {/* Keyed by locale: `useLivePreview` snapshots `initialData` on mount, so without a remount
+          the previous locale's content would survive the switch. */}
+      <PageClient
+        key={locale}
+        initialData={page as any}
+        serverURL={process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:4040"}
+      />
     </>
   );
 }

--- a/apps/dev/src/app/(frontend)/styles.css
+++ b/apps/dev/src/app/(frontend)/styles.css
@@ -1,5 +1,30 @@
 :root {
   --font-mono: "Roboto Mono", monospace;
+
+  /* Payload's own design tokens, copied by value from
+     node_modules/@payloadcms/ui/dist/scss/{colors,app,vars}.scss. Importing
+     @payloadcms/ui/dist/styles.css instead would pull 253 KB of admin theme that restyles
+     html/body and overrides this site. These are the DARK-theme resolutions, which is what this
+     sandbox uses; the light ones live in the same file if the site ever gains a light mode. */
+  --base-px: 20;
+  --base-body-size: 13;
+  --base: calc((var(--base-px) / var(--base-body-size)) * 1rem);
+
+  --color-base-100: rgb(235, 235, 235);
+  --color-base-650: rgb(87, 87, 87);
+  --color-base-750: rgb(60, 60, 60);
+  --color-base-800: rgb(47, 47, 47);
+  --color-base-900: rgb(20, 20, 20);
+
+  --theme-elevation-0: var(--color-base-900);
+  --theme-elevation-100: var(--color-base-800);
+  --theme-elevation-150: var(--color-base-750);
+  --theme-elevation-250: var(--color-base-650);
+  --theme-elevation-800: var(--color-base-100);
+  --theme-border-color: var(--theme-elevation-150);
+
+  --style-radius-s: 3px;
+  --style-radius-m: 4px;
 }
 
 * {

--- a/apps/dev/src/lib/ab-testing/dbAdapter.ts
+++ b/apps/dev/src/lib/ab-testing/dbAdapter.ts
@@ -3,5 +3,5 @@ import { payloadGlobalAdapter } from "@focus-reactive/payload-plugin-ab/adapters
 import type { VariantData } from "./types";
 
 export const abAdapter = payloadGlobalAdapter<VariantData>({
-  serverURL: process.env.NEXT_PUBLIC_SERVER_URL ?? "",
+  serverURL: process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:4040",
 });

--- a/apps/dev/src/payload.config.ts
+++ b/apps/dev/src/payload.config.ts
@@ -164,12 +164,13 @@ export default buildConfig({
       ],
       site: {
         name: "Dev Site",
-        baseUrl: process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:3000",
+        baseUrl: process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:4040",
       },
       supportedLocales: ["en", "de", "fr", "es"],
     }),
   ],
   secret: process.env.PAYLOAD_SECRET || "",
+  serverURL: process.env.NEXT_PUBLIC_SERVER_URL ?? "http://localhost:4040",
   sharp,
   typescript: {
     outputFile: path.resolve(baseDir, "payload-types.ts"),


### PR DESCRIPTION
Sandbox-only. No plugin package is touched — every file is under `apps/dev`, which is private and not released. Split out of #119 so the plugin change stays reviewable on its own.

## Three defects

**Live preview threw on every page that rendered it.** `admin.livePreview` was configured but `serverURL` was not set at all. Payload posts to the preview frame using `serverURL` as the target origin, and an empty string is not a valid one:

```
SyntaxError: Failed to execute 'postMessage' on 'Window': Invalid target origin ''
    at useLivePreview.useEffect
```

The frontend had the same hole from the other side — `serverURL={process.env.NEXT_PUBLIC_SERVER_URL ?? ""}` with the variable never set. Both fallbacks now name the port the `dev` script binds, so the sandbox runs with no `.env`, and the variable is documented in `.env.example`.

**The public page rendered unpublished documents.** Unpublishing in Payload flips `_status` and leaves the row and its content in the main table, so a find with no status filter returns it unchanged:

```
id=1  slug=home   _status=published
id=2  slug=about  _status=draft      ← still served
```

The query now asks for published documents.

**A stale port.** The site's `baseUrl` defaulted to `:3000` while the app binds `:4040`.

## The locale switcher

The thing this sandbox exists to exercise — seeing a translation without going through the admin.

A native `<select>`: touch devices get the OS picker, and the keyboard works (arrows, type-to-select, `Esc`) with no code. `appearance: none` strips only the chrome, so the arrow is drawn back as an inline SVG background — a data URI cannot read a CSS variable, so its colour is a literal, noted at the definition.

Switching writes `?locale=` and does a **client navigation**; the server re-renders. That was deliberate over fetching from the client:

- the published-only filter and the locale fallbacks keep behaving exactly as they do for a real visitor;
- no read access has to be opened on the REST API — it is currently closed, and a client fetch would have needed it (`403` today).

The client component is keyed by locale: `useLivePreview` snapshots `initialData` on mount, so without a remount the previous locale's content survives the switch.

## About the styling

It uses Payload's own token names — `--theme-elevation-*`, `--theme-border-color`, `--style-radius-m`, `--base` — declared in the frontend stylesheet with the values they resolve to in Payload's **dark** theme, which is what this site is.

They are a **copy**, and that is written next to them along with the source files. Importing `@payloadcms/ui/dist/styles.css` instead would pull 253 KB of admin theme that restyles `html`/`body` and would take the site with it. The cost of the copy is that it drifts if Payload changes its palette; the alternative was worse.

## Verification

Type-check clean; lint clean on the changed files. Checked in a browser rather than by reading:

- `/about` — the `postMessage` exception is gone from the console, the page renders;
- unpublished `/about` returns **404**, published `/home` returns **200**;
- the switcher renders, `?locale=de` selects "Deutsch", switching updates the URL and re-renders without a full reload.

## Not included

`src/app/(payload)/admin/importMap.js` keeps showing as modified while a dev server runs, because Payload regenerates it on config change and the analytics plugin does not register without GA4 credentials — `adminRegistry: "@/lead-actions-admin#default"` is declared inside it, so all three entries drop together. The committed map is the superset and is left alone: a surplus entry is inert, a missing one breaks the admin for anyone who does have GA4 configured.
