### PR TITLE
test(translator): make the data-integrity suite bite, and pin #115

### DIFF
--- a/apps/dev/src/integration/translator/data-integrity.int.test.ts
+++ b/apps/dev/src/integration/translator/data-integrity.int.test.ts
@@ -39,7 +39,7 @@ const EN = {
   ],
 };
 
-const enqueue = (ctx: TestPayload, id: string, target: string) =>
+const enqueue = (ctx: TestPayload, id: string, target: string, publish = true) =>
   callEndpoint(ctx.payload, "post", "/translate/enqueue", {
     body: {
       source_lng: "en",
@@ -47,12 +47,40 @@ const enqueue = (ctx: TestPayload, id: string, target: string) =>
       collection_slug: "docs",
       collection_id: [id],
       strategy: "overwrite",
-      publish_on_translation: true,
+      publish_on_translation: publish,
     },
   });
 
+// `docs` is this spec's own fixture collection, so it is absent from the dev app's generated
+// `payload-types`. Every cast that gap needs lives in these four helpers; nothing below casts.
+type Doc = Record<string, unknown>;
+
 const read = (ctx: TestPayload, id: string, locale: string) =>
-  ctx.payload.findByID({ collection: "docs", id, locale });
+  ctx.payload.findByID({
+    collection: "docs" as "pages",
+    id,
+    locale: locale as "en",
+  }) as unknown as Promise<Doc>;
+
+const readDraft = (ctx: TestPayload, id: string, locale: string) =>
+  ctx.payload.findByID({
+    collection: "docs" as "pages",
+    id,
+    locale: locale as "en",
+    draft: true,
+  }) as unknown as Promise<Doc>;
+
+const createDoc = async (ctx: TestPayload, data: Record<string, unknown>): Promise<string> => {
+  const doc = await ctx.payload.create({
+    collection: "docs" as "pages",
+    locale: "en",
+    data: data as never,
+  });
+  return String(doc.id);
+};
+
+const updateDraft = (ctx: TestPayload, id: string, data: Record<string, unknown>) =>
+  ctx.payload.update({ collection: "docs" as "pages", id, locale: "en", draft: true, data });
 
 describe("data integrity — translation never destroys content", () => {
   let ctx: TestPayload;
@@ -65,8 +93,7 @@ describe("data integrity — translation never destroys content", () => {
   });
 
   it("translating a SECOND locale does NOT wipe the FIRST (the c0a49d1b repro)", async () => {
-    const created = await ctx.payload.create({ collection: "docs", locale: "en", data: EN });
-    const id = String(created.id);
+    const id = await createDoc(ctx, EN);
 
     await enqueue(ctx, id, "de");
     // DE is fully populated before the FR pass.
@@ -105,8 +132,7 @@ describe("data integrity — translation never destroys content", () => {
   });
 
   it("keeps block/array ids stable across translation (in-place update, no recreate)", async () => {
-    const created = await ctx.payload.create({ collection: "docs", locale: "en", data: EN });
-    const id = String(created.id);
+    const id = await createDoc(ctx, EN);
 
     const before = await read(ctx, id, "en");
     const blockIds = (before.sections as Block[]).map((b) => b.id);
@@ -124,11 +150,17 @@ describe("data integrity — translation never destroys content", () => {
     // And the target locale exposes the same shared-row ids.
     const de = await read(ctx, id, "de");
     expect((de.sections as Block[]).map((b) => b.id)).toEqual(blockIds);
+    // Everything above is an ABSENCE of change, which a run that translated nothing satisfies just
+    // as well. The claim is "translated in place", so the run has to be shown doing the translating.
+    expect((de.sections as Block[]).map((b) => b.heading ?? b.caption)).toEqual([
+      rev("Hero one"),
+      rev("Cta two"),
+      rev("Hero three"),
+    ]);
   });
 
   it("preserves NON-localized data inside a shared row, in every locale", async () => {
-    const created = await ctx.payload.create({ collection: "docs", locale: "en", data: EN });
-    const id = String(created.id);
+    const id = await createDoc(ctx, EN);
 
     await enqueue(ctx, id, "de");
 
@@ -140,14 +172,144 @@ describe("data integrity — translation never destroys content", () => {
       expect(anchors).toEqual(["top", null, "bottom"]);
       expect((doc.items as Item[]).map((i) => i.code)).toEqual(["C1", "C2"]);
     }
+
+    // The other half of the claim: the LOCALIZED siblings in those same rows were translated. Without
+    // it the case says only "nothing changed", which is true of a run that did nothing.
+    const de = await read(ctx, id, "de");
+    expect((de.sections as Block[]).map((b) => b.heading ?? b.caption)).toEqual([
+      rev("Hero one"),
+      rev("Cta two"),
+      rev("Hero three"),
+    ]);
+  });
+
+  // #115. The reconciler is source-driven — it iterates the SOURCE list — so whatever the source read
+  // misses is absent from the reconciled result, and the write then rewrites the draft from that
+  // truncated shape. Reading the published row was therefore destructive in a way the issue
+  // understates: the draft's own rows are replaced by the published ones, so the draft-only element
+  // is deleted AND the source-locale text of the survivors goes with it — the editor reopens the
+  // page and the list is blank. Cured by the source read taking the current version (`draft: true`).
+  describe("the source draft differs structurally from the published row (#115)", () => {
+    // Publish EN as the fixture, then give the draft a different shape. Returns the document id and
+    // the draft's own row ids, which must survive: new ids mean delete+recreate, which is what
+    // wiped the leaf values.
+    const withDraftShape = async (sections: unknown[], items?: unknown[]) => {
+      const id = await createDoc(ctx, EN);
+      await updateDraft(ctx, id, items ? { sections, items } : { sections });
+      const draft = await readDraft(ctx, id, "en");
+      return { id, blockIds: (draft.sections as Block[]).map((b) => b.id) };
+    };
+
+    const headings = (doc: Record<string, unknown>) =>
+      (doc.sections as Block[]).map((b) => b.heading ?? b.caption);
+
+    it("keeps an element that exists only in the draft, and the survivors' source text", async () => {
+      const { id, blockIds } = await withDraftShape(
+        [...EN.sections, { blockType: "hero", heading: "Draft-only hero" }],
+        [...EN.items, { label: "Draft-only item", code: "C3" }]
+      );
+
+      await enqueue(ctx, id, "de", false);
+
+      const draft = await readDraft(ctx, id, "en");
+      expect(headings(draft), "the draft-only block was deleted").toEqual([
+        "Hero one",
+        "Cta two",
+        "Hero three",
+        "Draft-only hero",
+      ]);
+      expect(
+        (draft.items as Item[]).map((i) => i.label),
+        "the draft-only item was deleted"
+      ).toEqual(["Item one", "Item two", "Draft-only item"]);
+      // The heart of it: the rows are the DRAFT's own, not the published ones swapped in. Asserting
+      // the headings alone is not enough — under the defect they came back `undefined`, which is
+      // how the source text was lost.
+      expect(
+        (draft.sections as Block[]).map((b) => b.id),
+        "draft rows were replaced"
+      ).toEqual(blockIds);
+
+      // Positive control: "nothing was deleted" is also what a pipeline that did nothing produces.
+      const de = await readDraft(ctx, id, "de");
+      expect(headings(de)).toEqual([
+        rev("Hero one"),
+        rev("Cta two"),
+        rev("Hero three"),
+        rev("Draft-only hero"),
+      ]);
+    });
+
+    it("does not resurrect an element the editor deleted in the draft", async () => {
+      const { id } = await withDraftShape([EN.sections[0], EN.sections[2]]);
+
+      await enqueue(ctx, id, "de", false);
+
+      expect(headings(await readDraft(ctx, id, "en")), "a deleted block came back").toEqual([
+        "Hero one",
+        "Hero three",
+      ]);
+      expect(headings(await readDraft(ctx, id, "de"))).toEqual([
+        rev("Hero one"),
+        rev("Hero three"),
+      ]);
+    });
+
+    it("keeps the draft's order, not the published one", async () => {
+      const { id } = await withDraftShape([EN.sections[2], EN.sections[1], EN.sections[0]]);
+
+      await enqueue(ctx, id, "de", false);
+
+      expect(headings(await readDraft(ctx, id, "en")), "published order was restored").toEqual([
+        "Hero three",
+        "Cta two",
+        "Hero one",
+      ]);
+      expect(headings(await readDraft(ctx, id, "de"))).toEqual([
+        rev("Hero three"),
+        rev("Cta two"),
+        rev("Hero one"),
+      ]);
+    });
+
+    // Publish mode reaches the draft through a second write, so it needs its own case. The
+    // draft-only element going live is the documented trade-off, not an accident.
+    it("in publish mode the draft-only element survives and goes live", async () => {
+      const { id } = await withDraftShape([
+        ...EN.sections,
+        { blockType: "hero", heading: "Draft-only hero" },
+      ]);
+
+      await enqueue(ctx, id, "de", true);
+
+      expect(headings(await readDraft(ctx, id, "en"))).toEqual([
+        "Hero one",
+        "Cta two",
+        "Hero three",
+        "Draft-only hero",
+      ]);
+      expect(headings(await read(ctx, id, "de")), "the locale did not go live").toEqual([
+        rev("Hero one"),
+        rev("Cta two"),
+        rev("Hero three"),
+        rev("Draft-only hero"),
+      ]);
+    });
   });
 
   it("re-translating the SAME locale is non-destructive and idempotent", async () => {
-    const created = await ctx.payload.create({ collection: "docs", locale: "en", data: EN });
-    const id = String(created.id);
+    const id = await createDoc(ctx, EN);
 
     await enqueue(ctx, id, "de");
     const first = await read(ctx, id, "de");
+    // Pin what the first run PRODUCED before comparing the second to it: "both runs agree" is
+    // satisfied by "both runs produced nothing".
+    expect((first.sections as Block[]).map((b) => b.heading ?? b.caption)).toEqual([
+      rev("Hero one"),
+      rev("Cta two"),
+      rev("Hero three"),
+    ]);
+
     await enqueue(ctx, id, "de"); // run it again
     const second = await read(ctx, id, "de");
 


### PR DESCRIPTION
Tests only, in one file. No production code changes, and nothing here can cut a release: `apps/dev` is private and excluded from publishing.

Three things, kept together because they are one job — this suite claims to hold the contract *"translation never destroys content"*, and until now it largely did not.

## 1. #115 is already fixed, and was guarded by nothing

`fetchSourceDocument` reading the **published row** deleted list elements that existed only in the source locale's **draft**. The reconciler is source-driven, so an element the source read misses is absent from the reconciled result, and the write then rewrites the draft from that truncated shape.

Taking the source read to the current version (`draft: true`) shipped in **0.11.1** — for two other reasons, not this one. #115 was cured as a side effect, which is why it was verified rather than assumed:

| source read | result |
|---|---|
| current (0.11.1) | the draft-only element survives |
| `draft: true` removed | `expected 1 to be 2` — deleted, exactly as the issue describes |

Nothing guarded it. Removing that one argument would have restored silent data loss with the whole suite still green.

Four cases now cover the shapes a draft can differ by: an element **added**, an element **deleted**, the **order** changed, and the same in **publish mode**. Every one was proven by mutation.

## 2. The defect was wider than the issue records

The issue says the draft-only element is deleted. Measured on a deliberately broken build, the draft's own rows are **replaced** by the published ones:

```
published en:   [af6 "One", af7 "Two"]
draft en before: [af8 "One", af9 "Two", afa "Three"]
draft en AFTER:  [af6, af7]                 <- own rows gone, and no text at all
```

So the source-locale text of the *surviving* elements went with it: the editor reopened the page in English and the list read blank. Asserting headings alone does not catch this — under the defect they came back `undefined` rather than wrong — so the added case asserts the **draft's row ids survive**, which is what discriminates.

## 3. Three existing cases guarded nothing

Run with the source read replaced by a stub that throws, these stayed **green**:

- `keeps block/array ids stable across translation`
- `preserves NON-localized data inside a shared row, in every locale`
- `re-translating the SAME locale is non-destructive and idempotent`

Each asserted only that something had **not changed** — equally true of a run that did nothing. The idempotency case compared two runs to each other, which "both produced nothing" satisfies.

Each now also asserts, in the same run, that the translation actually landed. Result: **8 of 8** cases fail against the stub, where 5 did before.

The same hole was present in the four new cases as written — all five stub failures landed on the positive control, none on the preservation assertions — so the controls are what make any of this discriminate, and that is now measured rather than assumed.

## 4. Type errors: 24 → 0

`docs` is this spec's own fixture collection and so is absent from the dev app's generated `payload-types`. The reads did not type their result, so every access to a fixture field was an error. Every Payload call now goes through four helpers that hold the casts, as `strategy-publish-matrix.int.test.ts` already does.

Worth knowing: these are **invisible to `bun run check-types`**, whose tsconfig omits `payload-types.ts`. The real check is `tsgo --noEmit -p tsconfig.json`. Repo-wide that count went 160 → 117; the remainder is pre-existing in other specs and out of scope here.

## Verification

```
integration tests    70 passed (12 files)
unit tests           1315 passed
check-types          clean, both packages
tsgo -p tsconfig.json  0 errors in this file (was 24)
lint                 0 warnings, 0 errors
```

Mutations run and reverted:

| Mutation | Reddens |
|---|---|
| remove `draft: true` from the source read | all four new cases, each with its own message |
| the same, earlier assertions temporarily removed | the array assertion, then the draft-row-id assertion |
| pipeline translates nothing | every positive control, in all four cases |
| source read stubbed to throw | 8 of 8 — the check that found finding 3 |

The stub and its runner config were built for the audit and deliberately **not** committed: the substitution keys on a module path, so it rots into a false green if the file ever moves, and integration tests do not run in CI, so nobody would be running it. The mutations above reproduce the same findings against whatever the code is at the time.

Closes #115
