### PR TITLE
test(dev): run the translator integration suite on Postgres and MongoDB

### DIFF
--- a/apps/dev/docs/multi-db-verification.md
+++ b/apps/dev/docs/multi-db-verification.md
@@ -39,6 +39,76 @@ Two adapter-specific notes surfaced by the harness (neither is a provenance defe
   provenance — so the harness tests the `deleteByDocument` query directly instead. The full hook path is
   covered by the plugin's unit tests and the SQLite/Postgres runs.
 
+## Run the translator integration suite on all three
+
+```bash
+docker compose up -d              # from apps/dev
+bun run test:integration:all      # sqlite → postgres → mongo, in turn
+# or one at a time:
+bun run test:integration:postgres
+```
+
+The three run one after another regardless of failures — separated by `;`, not `&&`, because Postgres
+is knowingly red (see below) and `&&` would stop the chain before Mongo ever ran.
+
+`bootTestPayload` picks its adapter from `DB_ADAPTER` through `resolveTestDbAdapter()`, the test-side
+sibling of `resolveDbAdapter()` in `src/lib/database/resolveAdapter.ts`.
+
+**Isolation.** Each boot needs a database of its own: the twelve spec files run serially but share
+one server, so without it they would read each other's rows. SQLite gets this for free — a throwaway
+file per boot. Postgres and MongoDB do not, so each boot is given a namespace named by a random run
+id — a Postgres **schema**, a Mongo **database** — which `cleanup()` drops before closing the
+connection. A failure to drop is logged rather than swallowed: one leaked namespace per boot is
+invisible until the server is full of them.
+
+**Tests get their own database, not just their own schema.** `POSTGRES_TEST_URL` defaults to
+`…/payload_test` and `MONGO_TEST_SERVER` (default `mongodb://localhost:27017`) is a **server** url with
+no database name — unlike `MONGO_URL`, which carries the app's own. Postgres needs this rather than
+just a schema: Payload documents `schemaName` as experimental and working *"only when there are not
+other tables or enums of the same name in the database under a different schema"*, and the test
+collections collide with the dev app's by construction. Postgres creates the database on first
+connect, so there is no setup step.
+
+**Type generation is off in the harness** (`typescript: { autoGenerate: false }`). Without it a Mongo
+run rewrites the committed `src/payload-types.ts` with Mongo's string ids — `defaultIDType` flips from
+`number` to `string`, and every id type with it — leaving the working tree dirty after a test run.
+
+**Cost.** Measured over the full 12-file suite: sqlite 26 s, postgres 30 s, mongo 28 s. Per-boot
+schema creation on Postgres does not measurably change the total.
+
+**Leftovers.** A namespace leaks if a boot throws before `cleanup()` exists, or if the process is
+killed mid-run. Both land in the dedicated test database, away from the app's data.
+
+**One database survives a full Mongo run.** `auto-translate-unknown-locale.int.test.ts` leaves a
+`t…`-prefixed database holding a single `_docs_versions` collection: the namespace is dropped, and a
+late write from the auto-translate path recreates it after teardown. It is ~12 KB and one per full
+run, not per boot. Suspected to be the same "the hook's work outlives the operation that triggered
+it" family as [#124](https://github.com/focusreactive/payload-plugins/issues/124); left alone here
+because this work changes no plugin source. To clear leftovers:
+
+```bash
+docker exec dev-mongo-1 mongosh --quiet --eval \
+  'db.adminCommand("listDatabases").databases.filter(d=>/^t[0-9a-f]{32}$/.test(d.name)).forEach(d=>db.getSiblingDB(d.name).dropDatabase())'
+```
+
+The pattern is exact on purpose: `startsWith("t")` would also drop a `test` or `todo` database of your
+own on the same server. The Postgres equivalent, against `payload_test`:
+
+```sql
+SELECT 'DROP SCHEMA "'||nspname||'" CASCADE;' FROM pg_namespace WHERE nspname ~ '^t[0-9a-f]{32}$';
+```
+
+### Known failures on Postgres
+
+Three of the five cases in `auto-translate.int.test.ts` and `auto-translate-unknown-locale.int.test.ts`
+fail on Postgres and pass on SQLite and MongoDB. This is a real plugin defect, not a harness artefact: the
+auto-translate hook hands the runner `req.payload` instead of `req`, so the work it starts runs
+outside the transaction the hook is executing in and cannot see the still-uncommitted source
+document. Setting `transactionOptions: false` on the adapter makes all five pass, which isolates the
+cause — all five then pass. Tracked in
+[#124](https://github.com/focusreactive/payload-plugins/issues/124); the suite reports it rather than
+working around it.
+
 ## Running the full app on a non-default DB
 
 ```bash

--- a/apps/dev/package.json
+++ b/apps/dev/package.json
@@ -25,6 +25,10 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:integration": "vitest run -c vitest.integration.config.ts",
+    "test:integration:sqlite": "cross-env DB_ADAPTER=sqlite bun run test:integration",
+    "test:integration:postgres": "cross-env DB_ADAPTER=postgres bun run test:integration",
+    "test:integration:mongo": "cross-env DB_ADAPTER=mongo bun run test:integration",
+    "test:integration:all": "bun run test:integration:sqlite; bun run test:integration:postgres; bun run test:integration:mongo",
     "check-types": "tsgo --noEmit -p tsconfig.check.json"
   },
   "dependencies": {

--- a/apps/dev/src/integration/translator/bootTestPayload.ts
+++ b/apps/dev/src/integration/translator/bootTestPayload.ts
@@ -2,7 +2,6 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { sqliteAdapter } from "@payloadcms/db-sqlite";
 import { lexicalEditor } from "@payloadcms/richtext-lexical";
 import {
   createTranslationProvider,
@@ -16,6 +15,7 @@ import { buildConfig } from "payload";
 import type { CollectionConfig, Payload } from "payload";
 import { getPayload } from "payload";
 
+import { createTestDatabase } from "../../lib/database/resolveAdapter";
 import { reverseComplete } from "../../lib/translator/fakeComplete";
 import { buildTestCollections } from "./testCollections";
 
@@ -38,13 +38,14 @@ export type TestPayload = {
 };
 
 /**
- * Boot a real Payload for integration tests — translator-scoped (one caller today; the sqlite-headless
- * boot mechanics are structured to lift into a shared helper if a second plugin ever needs them).
+ * Boot a real Payload for integration tests — translator-scoped (one caller today; the headless boot
+ * mechanics are structured to lift into a shared helper if a second plugin ever needs them).
  *
  * Design decisions that make the boot deterministic and headless (the load-bearing part):
- * - **Fresh unique sqlite file** under the OS temp dir per boot, so schema `push` is a clean CREATE with
- *   no data-loss branch — Payload never drops to the interactive "accept data loss?" prompt that would
- *   hang an unattended/headless run. `cleanup()` removes the temp dir even on failure.
+ * - **Fresh namespace per boot** — a temp SQLite file, a Postgres schema or a Mongo database keyed by
+ *   `runId` (see `resolveTestDbAdapter`), so schema `push` is a clean CREATE with no data-loss branch
+ *   — Payload never drops to the interactive "accept data loss?" prompt that would hang an
+ *   unattended/headless run. `cleanup()` drops the namespace and removes the temp dir even on failure.
  * - **Sync runner:** a translation runs INLINE inside the triggering `afterChange`, so it is complete
  *   when the awaited `payload.update`/`create` resolves — no job autorun, no polling, no async race
  *   in the specs.
@@ -65,7 +66,7 @@ export async function bootTestPayload(opts?: {
   fallback?: boolean;
 }): Promise<TestPayload> {
   const dir = mkdtempSync(join(tmpdir(), "translator-int-"));
-  const dbPath = join(dir, "test.db");
+  const { db, drop } = createTestDatabase(join(dir, "test.db"));
 
   const collections = opts?.collections ?? buildTestCollections();
   const autoTranslate = opts?.autoTranslate;
@@ -87,10 +88,12 @@ export async function bootTestPayload(opts?: {
 
   const config = await buildConfig({
     secret: "integration-test-secret",
-    db: sqliteAdapter({ client: { url: `file:${dbPath}` } }),
+    db,
     editor: lexicalEditor(),
     // Quiet the boot: no telemetry, no admin bundle needed for local-API tests.
     telemetry: false,
+    // A Mongo boot regenerates the committed `src/payload-types.ts` with string ids, dirtying the tree.
+    typescript: { autoGenerate: false },
     localization: {
       defaultLocale: "en",
       fallback: opts?.fallback ?? false,
@@ -115,6 +118,16 @@ export async function bootTestPayload(opts?: {
   const payload = await getPayload({ config });
 
   const cleanup = async () => {
+    // Before `payload.db.destroy()` below: dropping the namespace needs the connection destroy closes.
+    try {
+      await drop(payload);
+    } catch (error) {
+      // Loud on purpose. A silent failure here leaks a schema or database per boot, and with one
+      // boot per spec file that is invisible until the server is full of them.
+      console.warn(
+        `[bootTestPayload] could not drop the test namespace: ${(error as Error).message}`
+      );
+    }
     try {
       await payload.db.destroy?.();
     } catch {

--- a/apps/dev/src/lib/database/resolveAdapter.ts
+++ b/apps/dev/src/lib/database/resolveAdapter.ts
@@ -1,6 +1,17 @@
+import { randomUUID } from "node:crypto";
+
 import { mongooseAdapter } from "@payloadcms/db-mongodb";
 import { postgresAdapter } from "@payloadcms/db-postgres";
 import { sqliteAdapter } from "@payloadcms/db-sqlite";
+import type { Payload } from "payload";
+
+const DEFAULT_POSTGRES_URL = "postgres://payload:payload@localhost:5434/payload";
+// A database of its own, not a schema inside the app's. Payload documents `schemaName` as
+// experimental and working "only when there are not other tables or enums of the same name in the
+// database under a different schema" — and the test collections collide with the dev app's by
+// construction. Anyone who has run `DB_ADAPTER=postgres bun run dev` would otherwise start seeing
+// unexplained failures. Postgres creates it on first connect (`disableCreateDatabase` defaults off).
+const DEFAULT_POSTGRES_TEST_URL = "postgres://payload:payload@localhost:5434/payload_test";
 
 /**
  * Pick the Payload DB adapter from `DB_ADAPTER` so the dev app can be verified against SQLite,
@@ -18,8 +29,7 @@ export function resolveDbAdapter() {
     case "postgres":
       return postgresAdapter({
         pool: {
-          connectionString:
-            process.env.POSTGRES_URL ?? "postgres://payload:payload@localhost:5434/payload",
+          connectionString: process.env.POSTGRES_URL ?? DEFAULT_POSTGRES_URL,
         },
         push,
       });
@@ -33,5 +43,64 @@ export function resolveDbAdapter() {
         client: { url: process.env.DATABASE_URL || "file:./dev.db" },
         push,
       });
+  }
+}
+
+/**
+ * The database an integration-test boot runs against, plus the teardown that removes it.
+ *
+ * Postgres and Mongo keep data between runs and every spec file boots against the same server, so
+ * each boot gets a namespace of its own — a Postgres schema, a Mongo database. `drop` closes over
+ * that name, which is why the two arrive together: a branch here that creates a namespace without a
+ * matching teardown would leak it silently. SQLite needs none of it; `sqliteFile` is a throwaway per
+ * boot and the caller deletes it.
+ *
+ * An unrecognised `DB_ADAPTER` throws rather than falling back: a typo that silently ran SQLite would
+ * report a green run for a database it never touched.
+ */
+export function createTestDatabase(sqliteFile: string) {
+  switch (process.env.DB_ADAPTER) {
+    case "postgres": {
+      // The leading "t" makes it a valid unquoted Postgres identifier — those cannot start with a digit.
+      const schema = `t${randomUUID().replaceAll("-", "")}`;
+      return {
+        db: postgresAdapter({
+          pool: { connectionString: process.env.POSTGRES_TEST_URL ?? DEFAULT_POSTGRES_TEST_URL },
+          schemaName: schema,
+        }),
+        drop: async (payload: Payload) => {
+          // Not Payload's own `dropDatabase()`: that one drops the schema and immediately recreates
+          // it, which would leave an empty schema behind per boot. A schema name cannot be a bound
+          // parameter, so it is interpolated — `schema` is built from `randomUUID()` above, never
+          // from input.
+          const { pool } = payload.db as { pool: { query: (q: string) => Promise<unknown> } };
+          await pool.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+        },
+      };
+    }
+    case "mongo":
+    case "mongodb": {
+      // Not `MONGO_URL`: that one already names a database, so a run id appended to it is a collection.
+      const server = process.env.MONGO_TEST_SERVER ?? "mongodb://localhost:27017";
+      return {
+        db: mongooseAdapter({ url: `${server}/t${randomUUID().replaceAll("-", "")}` }),
+        drop: async (payload: Payload) => {
+          const { connection } = payload.db as {
+            connection: { dropDatabase: () => Promise<unknown> };
+          };
+          await connection.dropDatabase();
+        },
+      };
+    }
+    case undefined:
+    case "sqlite":
+      return {
+        db: sqliteAdapter({ client: { url: `file:${sqliteFile}` } }),
+        drop: () => Promise.resolve(),
+      };
+    default:
+      throw new Error(
+        `Unknown DB_ADAPTER "${process.env.DB_ADAPTER}" — expected sqlite, postgres or mongo`
+      );
   }
 }

--- a/packages/payload-plugin-translator/docs/plans/2026-09-04-integration-multi-adapter.task.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-09-04-integration-multi-adapter.task.md
@@ -1,0 +1,102 @@
+# Task contract — run the translator integration suite on all three DB adapters
+
+Prerequisite for [#108](https://github.com/focusreactive/payload-plugins/issues/108), shipped separately so that fix's diff stays about the fix.
+
+**Risk: LOW.** Test harness only; no plugin source is touched, and the default adapter's behaviour is unchanged.
+
+## Design decisions
+
+**D1 — the adapter resolver lives beside the app's, not in the harness.**
+`resolveTestDbAdapter()` is added to `src/lib/database/resolveAdapter.ts`, next to the existing
+`resolveDbAdapter()`. Rejected: resolving inline in `bootTestPayload`. The connection defaults and the
+`DB_ADAPTER` vocabulary are already stated once in that file and documented in
+`docs/multi-db-verification.md`; a second copy in the test tree would drift from it.
+
+**D1b — tests get their own Postgres database, not a schema inside the app's.**
+Payload documents `schemaName` as experimental and working *"only when there are not other tables or
+enums of the same name in the database under a different schema"* — and the test collections collide
+with the dev app's by construction. A schema inside `payload` is green only while `public` is empty;
+it would start failing for anyone who had run `DB_ADAPTER=postgres bun run dev`. `POSTGRES_TEST_URL`
+defaults to `…/payload_test`, which Postgres creates on first connect. Symmetric with `MONGO_TEST_SERVER`.
+
+**D2 — isolation is a namespace per boot, not a shared database with a wipe.**
+Each boot gets a Postgres **schema** / Mongo **database** named by a random run id, dropped by
+`cleanup()`. Rejected: one shared database wiped between files — a wipe has to enumerate collections
+to be correct, and gets it wrong the moment a spec adds a fixture collection. A namespace needs no
+such knowledge. SQLite keeps its throwaway file: it already has this property for free.
+
+**D3 — the drop runs before the connection closes, and logs on failure.**
+Rejected: silent best-effort, matching the existing `destroy()` call below it. One leaked namespace
+per boot is invisible until the server is full of them, and the twelve spec files each boot once.
+
+**D4 — `MONGO_TEST_SERVER`, not `MONGO_URL`.**
+The app's `MONGO_URL` carries a database name; appending a run id to it addresses a collection, not a
+database. A separate server-only variable makes that unambiguous.
+
+**D5 — one function returning the adapter paired with its teardown, not two that switch separately.**
+`createTestDatabase(sqliteFile)` returns `{ db, drop }`, `drop` closing over the namespace name.
+Rejected: a `resolve` / `drop` pair taking the id as a parameter — it switched on `DB_ADAPTER` twice,
+so a branch could create a namespace with no matching teardown and leak silently, and its
+`(runId, sqliteFile)` signature took two strings positionally, which a caller can swap without the
+compiler noticing.
+
+**New surface:** `createTestDatabase`. One caller, `bootTestPayload` — which uses both halves of what
+it returns, so the pairing is what earns it rather than the count.
+
+**Written contract owed:** none. Both functions are named for what they do and take no ambiguous
+same-typed parameters.
+
+**Escalate:** no.
+
+## Acceptance criteria
+
+1. **SQLite is unchanged.** `bun run test:integration` with no `DB_ADAPTER` set passes 70/70, as before.
+2. **MongoDB passes.** `bun run test:integration:mongo` passes 70/70.
+3. **Postgres passes except the known defect.** `bun run test:integration:postgres` fails exactly the three auto-translate cases of #124 and passes the other 67.
+4. **No namespace is leaked on Postgres**, and on Mongo at most the one documented below: a full run leaves exactly one ~12 KB database, recreated after teardown by a late write from `auto-translate-unknown-locale.int.test.ts`. Bisected spec by spec; every other spec leaves nothing.
+5. **`src/payload-types.ts` is untouched** after a run on every adapter.
+6. **Per-adapter scripts exist**, named after the established `verify:provenance:*` pair.
+7. **`docs/multi-db-verification.md` documents** the run, the isolation scheme, the measured cost, and the known Postgres failures.
+8. **Checks clean:** `check-types` for both packages, plugin unit tests, lint at no worse than the repo baseline.
+
+## Measured
+
+| adapter | suite | wall time |
+|---|---|---|
+| sqlite | 70/70 | 26 s |
+| postgres | 67/70 (#124) | 30 s |
+| mongo | 70/70 | 28 s |
+
+Per-boot schema creation on Postgres costs nothing measurable against the fixed fork-and-boot overhead — the concern that motivated measuring it did not materialise.
+
+## Human choices
+
+- **Run this before #108, as its own PR.** The user's call: mixing harness work into the fix would make the fix's diff mostly infrastructure.
+- **Do not paper over the Postgres failures.** They are a real plugin defect (#124), found by this harness on its first run. Setting `transactionOptions: false` would turn the suite green and hide it; the suite reports it instead.
+
+## Risks
+
+- The harness now depends on Docker services for two of three adapters. SQLite — the default, and what everyone runs by habit — needs nothing, so the default path is unaffected.
+- A namespace is leaked if the process is killed between boot and `cleanup()`. Run ids are random, so leaks accumulate rather than collide; the doc says where to look.
+
+## Review log
+
+**2026-09-04 — comment audit.** 23 comment lines over 51 of code (4.5 per 10) judged too dense.
+Deleted or shortened 7, kept 2 with reasons (the `dropTestNamespace` contract; the loud `console.warn`
+that deliberately differs from the silent `destroy()` below it). Three MISSING entries closed: a bare
+`.slice(0, 20)`, an unexplained structural cast, and a connection default written twice. The stranded
+pre-existing docblock on `bootTestPayload` — which still claimed isolation came from a SQLite file —
+was rewritten; the diff had made it false.
+
+**2026-09-04 — reuse and simplification.** No prior art to reuse: this is the repo's only multi-adapter
+resolver and the first namespace drop. Three outright defects found and fixed — `test:integration:all`
+chained with `&&` so Postgres, knowingly red, stopped the run before Mongo ever executed; `drizzle-orm`
+was imported but declared in no `package.json`, resolving only through the hoisted linker; and the doc
+pointed `docker compose up -d` at the repo root when the compose file lives in `apps/dev`.
+
+**2026-09-04 — altitude.** Confirmed per-boot teardown is the right depth and `globalSetup` would be
+wrong. Two findings taken: the `schemaName` experimental caveat (D1b above) and Payload's own
+`dropDatabase()` recreating the schema, now noted in code so nobody "simplifies" to it. One deferred
+with reasoning: a sweep of stale namespaces at run *start*, which would also cover a boot that throws
+before `cleanup()` exists and a killed process. Deferred because D1b moves the leftovers into a
+dedicated database where they are inert, and because it is new machinery the user has not seen.


### PR DESCRIPTION
Test harness only. No plugin source is touched, and nothing here can cut a release: `apps/dev` is private and excluded from publishing.

Prerequisite for #108, shipped first and separately so that fix's diff stays about the fix.

## What changes

`bootTestPayload` hardcoded SQLite, so the twelve integration specs only ever exercised one of the three adapters the plugin claims to support. It now takes its adapter from `DB_ADAPTER`, through `createTestDatabase()` placed beside the app's existing `resolveDbAdapter()`.

```bash
docker compose up -d              # from apps/dev
bun run test:integration:all      # sqlite → postgres → mongo
bun run test:integration:postgres # or one at a time
```

## Results

| adapter | suite | wall time |
|---|---|---|
| sqlite | **70 / 70** | 26 s |
| postgres | **67 / 70** — see below | 30 s |
| mongo | **70 / 70** | 28 s |

Per-boot schema creation on Postgres costs nothing measurable against the fixed fork-and-boot overhead. The concern that motivated measuring it did not materialise.

## The harness found a real defect on its first run

The three Postgres failures are **not** a harness artefact. `AutoTranslateEnqueue.hook.ts:83` hands the runner `req.payload` rather than `req`, so the work it starts runs outside the transaction the `afterChange` hook is executing in and cannot see the still-uncommitted source document. With the sync runner — which translates inline — the source reads empty and nothing is written. No error is raised.

Isolated by a single change with nothing else touched:

```
postgresAdapter({ …, transactionOptions: false })  →  5 passed
postgresAdapter({ … })                            →  3 failed | 2 passed
```

`createSyncRunner` is public API, so this is reachable by users and not only by the suite. Filed as **#124**.

Setting `transactionOptions: false` in the test adapter would have turned the suite green. It is deliberately not set: a suite that hides a real defect to stay green is worse than one that reports it.

## Design notes worth a reviewer's attention

**Isolation is a namespace per boot.** SQLite had this for free. Postgres and Mongo share one server and the specs boot serially against it, so without namespacing they would read each other's rows. Rejected: one shared database wiped between files — a wipe must enumerate collections to be correct, and gets it wrong the moment a spec adds a fixture collection.

**The teardown is returned with the adapter, not written as a second switch.** `createTestDatabase()` returns `{ db, drop }` with `drop` closing over the namespace name. An earlier shape had a `resolve` / `drop` pair switching on `DB_ADAPTER` separately: a branch could then create a namespace with no matching teardown and leak it silently, and its `(runId, sqliteFile)` signature took two strings positionally, which a caller can swap without the compiler noticing.

**Tests get a Postgres database of their own, not a schema inside the app's.** Payload documents `schemaName` as experimental and working *"only when there are not other tables or enums of the same name in the database under a different schema"* — and the test collections collide with the dev app's by construction. A schema inside `payload` is green only while its `public` schema is empty, so the suite would start failing, unexplained, for anyone who had run `DB_ADAPTER=postgres bun run dev`. `POSTGRES_TEST_URL` defaults to `payload_test`, which Postgres creates on first connect.

**An unrecognised `DB_ADAPTER` throws.** A typo like `postgress` would otherwise fall through to SQLite and report a green run for a database it never touched — the one outcome a verification harness must not produce.

**Type generation is off in the harness.** Without `typescript: { autoGenerate: false }`, a Mongo boot rewrites the committed `src/payload-types.ts` with string ids (`defaultIDType` flips number → string) and leaves the tree dirty after a test run.

## Known leftovers

A full Mongo run leaves exactly one ~12 KB database. Bisected spec by spec: `auto-translate-unknown-locale.int.test.ts` has its namespace dropped and then recreated by a late write from the auto-translate path — the same "the hook's work outlives the operation that triggered it" family as #124. Not fixed here, since this change touches no plugin source; the doc carries an exact-pattern command to clear leftovers.

Considered and deferred: sweeping stale namespaces at run *start*, which would also cover a boot that throws before `cleanup()` exists, and a killed process. Deferred because test namespaces now live in a dedicated database where they are inert, and because it is new machinery worth deciding on separately.

## Verification

```
integration    sqlite 70/70 · postgres 67/70 (#124) · mongo 70/70
unit           1315 passed
check-types    clean, both packages
lint           0 warnings, 0 errors on the changed files
leftovers      0 schemas in payload and payload_test, 1 mongo database (documented)
```

The reasoning, the rejected alternatives and the three review passes are recorded in `packages/payload-plugin-translator/docs/plans/2026-09-04-integration-multi-adapter.task.md`.
