### PR TITLE
fix(translator): bound the job scan on enqueue, and stop it deleting finished jobs

### DIFF
--- a/apps/dev/docs/multi-db-verification.md
+++ b/apps/dev/docs/multi-db-verification.md
@@ -79,10 +79,11 @@ schema creation on Postgres does not measurably change the total.
 **Leftovers.** A namespace leaks if a boot throws before `cleanup()` exists, or if the process is
 killed mid-run. Both land in the dedicated test database, away from the app's data.
 
-**One database survives a full Mongo run.** `auto-translate-unknown-locale.int.test.ts` leaves a
-`t…`-prefixed database holding a single `_docs_versions` collection: the namespace is dropped, and a
-late write from the auto-translate path recreates it after teardown. It is ~12 KB and one per full
-run, not per boot. Suspected to be the same "the hook's work outlives the operation that triggered
+**A database or two survives a full Mongo run.** Usually one, from
+`auto-translate-unknown-locale.int.test.ts`: the namespace is dropped, and a late write from the
+auto-translate path recreates it after teardown. Because it is a race, a busy machine can leave
+another — a spec that runs alone without leaking has been seen to leak inside a full run. Each is
+~12 KB. Suspected to be the same "the hook's work outlives the operation that triggered
 it" family as [#124](https://github.com/focusreactive/payload-plugins/issues/124); left alone here
 because this work changes no plugin source. To clear leftovers:
 

--- a/apps/dev/src/integration/translator/bootTestPayload.ts
+++ b/apps/dev/src/integration/translator/bootTestPayload.ts
@@ -10,7 +10,10 @@ import {
   translatorPlugin,
   withAutoTranslate,
 } from "@focus-reactive/payload-plugin-translator";
-import type { TranslationProvider } from "@focus-reactive/payload-plugin-translator";
+import type {
+  TaskRunnerProvider,
+  TranslationProvider,
+} from "@focus-reactive/payload-plugin-translator";
 import { buildConfig } from "payload";
 import type { CollectionConfig, Payload } from "payload";
 import { getPayload } from "payload";
@@ -57,6 +60,8 @@ export type TestPayload = {
  *   publish; the enqueue route still works.
  * @param opts.collections - replaces the shared fixture set entirely (not merged). The set must
  *   still contain a `docs` collection when `autoTranslate` is passed.
+ * @param opts.runner - defaults to the sync runner. `createPayloadJobsRunner({ autoRun: false })`
+ *   leaves queued jobs unprocessed in `payload-jobs`, so a spec can read the rows.
  * @param opts.fallback - localization fallback, off by default: an unwritten locale reads as
  *   empty, not as the default locale's text. Localization-level, so it applies to the whole boot.
  */
@@ -64,6 +69,7 @@ export async function bootTestPayload(opts?: {
   autoTranslate?: { targets: string[]; strategy?: "overwrite" | "skip_existing" };
   collections?: CollectionConfig[];
   fallback?: boolean;
+  runner?: TaskRunnerProvider;
 }): Promise<TestPayload> {
   const dir = mkdtempSync(join(tmpdir(), "translator-int-"));
   const { db, drop } = createTestDatabase(join(dir, "test.db"));
@@ -108,7 +114,7 @@ export async function bootTestPayload(opts?: {
       translatorPlugin({
         collections: managed,
         translationProvider: countingProvider,
-        runner: createSyncRunner(),
+        runner: opts?.runner ?? createSyncRunner(),
         levels: [documentLevel()],
         provenance: true,
       }),

--- a/apps/dev/src/integration/translator/job-supersede.int.test.ts
+++ b/apps/dev/src/integration/translator/job-supersede.int.test.ts
@@ -1,0 +1,108 @@
+import { createPayloadJobsRunner } from "@focus-reactive/payload-plugin-translator";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { bootTestPayload } from "./bootTestPayload";
+import type { TestPayload } from "./bootTestPayload";
+import { callEndpoint } from "./callEndpoint";
+
+// Rows are counted, never identified by id: SQLite reuses the rowid of a deleted row (integer primary
+// key, no AUTOINCREMENT), so a replacement job can arrive carrying the deleted job's id and an
+// id-based assertion would pass for the wrong reason.
+
+type Job = {
+  id: string | number;
+  completedAt?: string | null;
+  input?: { target_lng?: string; collection_id?: string };
+};
+
+let ctx: TestPayload;
+
+const enqueue = async (id: string, target = "de") => {
+  const res = await callEndpoint(ctx.payload, "post", "/translate/enqueue", {
+    body: {
+      source_lng: "en",
+      target_lng: target,
+      collection_slug: "docs",
+      collection_id: [id],
+      strategy: "overwrite",
+      publish_on_translation: false,
+    },
+  });
+  expect(res.status, "the enqueue endpoint rejected the request").toBe(200);
+  return (res.data as { data: { queued: number } }).data.queued;
+};
+
+// The cases share one boot, so the table also holds every earlier case's jobs.
+const jobs = async (documentId: string): Promise<Job[]> => {
+  const { docs } = await ctx.payload.find({
+    collection: "payload-jobs" as "pages",
+    pagination: false,
+    where: { taskSlug: { equals: "translate_document" } } as never,
+  });
+  return (docs as Job[]).filter((j) => j.input?.collection_id === documentId);
+};
+
+const markFinished = (jobId: string | number) =>
+  ctx.payload.update({
+    collection: "payload-jobs" as "pages",
+    id: jobId,
+    data: { completedAt: new Date().toISOString(), processing: false } as never,
+  });
+
+const createDoc = async () => {
+  const doc = await ctx.payload.create({
+    collection: "docs" as "pages",
+    locale: "en",
+    data: { title: "Src", _status: "published" } as never,
+  });
+  return String(doc.id);
+};
+
+beforeAll(async () => {
+  ctx = await bootTestPayload({ runner: createPayloadJobsRunner({ autoRun: false }) });
+});
+afterAll(async () => {
+  await ctx?.cleanup();
+});
+
+describe("re-enqueue supersedes unfinished work, not finished work", () => {
+  it("keeps a finished job when the same locale is translated again", async () => {
+    const id = await createDoc();
+    expect(await enqueue(id), "fixture: the first enqueue queued a job").toBe(1);
+
+    const [first] = await jobs(id);
+    await markFinished(first.id);
+
+    expect(await enqueue(id), "the re-enqueue queued nothing").toBe(1);
+
+    const after = await jobs(id);
+    expect(after.filter((j) => j.completedAt).length, "the finished job was deleted").toBe(1);
+    expect(after.length, "finished job plus the new one").toBe(2);
+  });
+
+  it("still supersedes an unfinished job for the same locale", async () => {
+    const id = await createDoc();
+    await enqueue(id);
+    expect((await jobs(id)).length, "fixture").toBe(1);
+
+    expect(await enqueue(id), "the re-enqueue queued nothing").toBe(1);
+
+    expect((await jobs(id)).length, "the unfinished job was not superseded").toBe(1);
+  });
+
+  it("leaves another locale's unfinished job alone", async () => {
+    const id = await createDoc();
+    await enqueue(id, "de");
+    await enqueue(id, "fr");
+    expect((await jobs(id)).length, "fixture: one job per locale").toBe(2);
+
+    expect(await enqueue(id, "de"), "the re-enqueue queued nothing").toBe(1);
+
+    const after = await jobs(id);
+    expect(after.length, "the fr job was collateral damage").toBe(2);
+    expect(after.map((j) => j.input?.target_lng).sort(), "one job per locale, still").toEqual([
+      "de",
+      "fr",
+    ]);
+  });
+});

--- a/packages/payload-plugin-translator/docs/DEPRECATIONS.md
+++ b/packages/payload-plugin-translator/docs/DEPRECATIONS.md
@@ -55,7 +55,7 @@ the single source of truth — code annotations link here by anchor instead of d
 - **What:** passing a bare `Array<string | number>` of document ids as the second argument to
   `TaskRunner.findByCollection`.
 - **Status:** live
-- **Deprecated:** 2026-09-04 / PR #TBD
+- **Deprecated:** 2026-09-04 / PR #126
 - **Replacement:** `TaskFilter` — `findByCollection(slug, { documentIds })`.
 - **Remove in:** next major
 - **Why:** a positional argument cannot grow. The second filter this method needed —

--- a/packages/payload-plugin-translator/docs/DEPRECATIONS.md
+++ b/packages/payload-plugin-translator/docs/DEPRECATIONS.md
@@ -50,6 +50,28 @@ the single source of truth — code annotations link here by anchor instead of d
   - `src/server/modules/task-runner/payload-jobs-runner/normalizeJob.ts` (read fallback)
   - `src/server/modules/task-runner/payload-jobs-runner/types.ts` (`PayloadJob.input` shape)
 
+### find-by-collection-document-ids-array
+
+- **What:** passing a bare `Array<string | number>` of document ids as the second argument to
+  `TaskRunner.findByCollection`.
+- **Status:** live
+- **Deprecated:** 2026-09-04 / PR #TBD
+- **Replacement:** `TaskFilter` — `findByCollection(slug, { documentIds })`.
+- **Remove in:** next major
+- **Why:** a positional argument cannot grow. The second filter this method needed —
+  `excludeCompleted`, which bounds the read on the enqueue path (#108) — had nowhere to go without
+  either a third positional parameter or an object. The object also lets the type say which fields
+  reach the database and which are matched in memory, a distinction that is invisible at the call
+  site and was previously carried only by a comment.
+- **Migration:** the parameter is a union, so both forms compile and behave identically;
+  `toTaskFilter` normalizes them at the top of each implementation. Removing the array form is a
+  one-line change to that helper plus the two runner signatures.
+- **Code refs:**
+  - `src/server/modules/task-runner/TaskRunner.interface.ts` (the union, `TaskFilter`, `toTaskFilter`)
+  - `src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.ts`
+  - `src/server/modules/task-runner/sync-runner/SyncTaskRunner.ts`
+  - `src/server/features/get-document-status/handler.ts` (a remaining array-form caller)
+
 ### cancel-by-collection-route
 
 - **What:** `POST {basePath}/cancel-by-collection` endpoint.

--- a/packages/payload-plugin-translator/docs/plans/2026-09-04-job-scan-bounds.task.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-09-04-job-scan-bounds.task.md
@@ -103,6 +103,32 @@ settles the question, and #108 holds the detail. A dangling reference to it in `
 repointed. Verified and kept: `excludeCompleted` really is wider than the `pending` status, because a
 job that exhausts its retries keeps `completedAt` null.
 
+**2026-09-04 — whole-file comment audit of `PayloadJobsTaskRunner.ts`.** 88 comment lines over 147 of
+code — 6.0 per ten. Deleted 6, rewrote 8, rewrote code twice, kept 1, added 1; the file is now at 49.
+The diagnosis was not unreadable code but design-doc prose migrated into it: three of the four largest
+blocks duplicated something with a canonical home (the deprecation ledger, issue #108, this file).
+
+Two code changes came out of it. `cancelInternal` is renamed `cancelAndDeleteJobs` — it calls
+`payload.jobs.cancel` **and** `payload.delete`, and the old name is what forced a comment defending
+`excludeCompleted`. And the `jobs.cancel` + `delete` pair now says why both and why in that order:
+`jobs.cancel` only writes `{ error: { cancelled: true }, hasError: true, processing: false }`, which is
+the abort signal to a running handler, so a reader who sees the delete would otherwise conclude the
+cancel is dead code.
+
+**A second stale claim, found in the same file on the same day.** The eleven-line comment justifying
+`jobs.run({ where })` over `payload.jobs.runByID({ id })` said the id path "writes `processing: true`
+but returns no rows … leaving the job stuck forever". Checked against the installed payload 3.84.1:
+`@payloadcms/drizzle/dist/updateJobs.js` takes the optimized upsert branch for `{ processing: true }`
+and returns `[result]`, and the non-optimized branch findMany's by id and returns rows — neither
+returns zero. **The deviation is still correct, for a different reason:** in
+`payload/dist/queues/operations/runJobs/index.js` the guard block (`processing: false`, `hasError` not
+true, `waitUntil` due) is built only for the non-id branch, so `runByID` would re-run a job that had
+exhausted its retries. The comment now says that instead.
+
+Worth recording as a pattern rather than two incidents: both stale claims described Payload's
+internals, and both aged silently within a single minor version. A comment that transcribes another
+package's implementation is a maintenance liability even when it is right on the day it is written.
+
 **2026-09-04 — reuse, simplification, altitude.** Nothing re-implemented; no existing normalizer fits.
 Five findings taken. `toTaskFilter` moved out of `TaskRunner.interface.ts` — five of the package's six
 `*.interface.ts` files are types-only, and it was the one carrying runtime code — and is now exported

--- a/packages/payload-plugin-translator/docs/plans/2026-09-04-job-scan-bounds.task.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-09-04-job-scan-bounds.task.md
@@ -1,0 +1,116 @@
+# Task contract — bound the job scan on enqueue (#108)
+
+Investigation and measurements: [#108 comment](https://github.com/focusreactive/payload-plugins/issues/108#issuecomment-5533106260).
+Stacked on [#125](https://github.com/focusreactive/payload-plugins/pull/125) so the result can be verified on all three adapters.
+
+**Risk: HIGH.** Touches a semi-public interface with four callers, and changes what `enqueue` deletes.
+
+## Design decisions
+
+**D1 — exclude completed jobs from the query; do not narrow by collection.**
+Measured: excluding completed jobs takes the rows loaded per enqueue from 2000 to 0 at a 2000-job
+history, and adding a collection filter on top changes nothing. Rejected: narrowing by
+`input.collection_slug`, which buys nothing measurable and would silently drop every job written
+before the ID-agnostic migration — `readCollectionRef` reads the slug from that field OR from the
+legacy `input.collection.relationTo`, and a where clause sees only the first.
+
+**D2 — `excludeCompleted`, not `pendingOnly`.**
+`completedAt: { exists: false }` also returns running and failed jobs. A flag named for the `pending`
+status would promise a narrower set than it delivers, and `enqueue` genuinely wants the wider one: a
+failed job for the same (document, locale) is still superseded by a re-run.
+
+**D3 — `documentIds` keeps being matched in memory, `excludeCompleted` goes into the query.**
+The asymmetry is stated in the type. Without it the next person adds a third field and assumes all
+three are equally cheap.
+
+**D4 — the second parameter becomes a union, and the array form is deprecated rather than removed.**
+`Array<string | number> | TaskFilter`, branching on `Array.isArray`. Rejected: replacing the array
+outright — `TaskRunner` is reachable through the exported `TaskRunnerProvider.create()`, whose own
+docblock anticipates third-party runners, and a removal would have to wait for the next major anyway.
+The user's reason for the object is flexibility independent of this fix: a positional argument cannot
+grow, an options object can.
+
+**D5 — `cancel-by-collection` is deliberately not changed.**
+It loads everything and filters `status === "pending"` itself. Passing the new flag would speed it up
+by one line, but its route is already in DEPRECATIONS.md for replacement by a unified `/cancel`, and
+it runs once per human click rather than once per document in a batch. Left alone to keep this diff
+about the path where the cost actually lands.
+
+**Placement:** `TaskFilter` beside `TaskRunner` in `TaskRunner.interface.ts` — it is part of that
+contract and has no life without it. Both runners implement it; `withQueuedNotification` forwards it.
+
+**New surface:** `TaskFilter`. Callers: `PayloadJobsTaskRunner.enqueue` and — through the union —
+every existing caller of `findByCollection`. It is a type, not an abstraction over behaviour.
+
+**`@since`:** `TaskFilter` carries `@since 0.12.0` — 0.11.1 plus the minor this ships as, per
+DEPRECATIONS.md's policy that deprecations ship as `feat`. It is not re-exported from `src/index.ts`,
+but `TaskRunnerProvider.create(): TaskRunner` is, so a third-party runner must satisfy this type.
+
+**Written contract owed:** yes — which fields reach the database and which are applied in memory, and
+what `excludeCompleted` includes (running and failed, not only pending). Stated in the type's docblock.
+
+**Escalate:** no. One module, no new dependency, no data-model change.
+
+## Acceptance criteria
+
+1. **The enqueue scan no longer grows with history.** An integration test seeds completed jobs and
+   asserts the rows the enqueue path loads do not grow with them. *Check: integration test on SQLite.*
+2. **Completed jobs survive a re-translation.** Translate a locale twice; the first job's row is still
+   present afterwards. *Check: integration test.* Currently fails — today's `enqueue` deletes it.
+3. **Unfinished jobs are still superseded.** A pending job for the same (document, locale) is still
+   cancelled by a re-enqueue. *Check: existing unit tests must stay green.*
+4. **The query still narrows by `taskSlug` and `completedAt` only** — never by collection slug or
+   document id, so neither the SQLite coercion defect nor the legacy-shape loss returns.
+   *Check: the existing `narrows the SQL where clause` unit test, extended.*
+5. **The positional array form still compiles and behaves as before.** *Check: existing unit tests for
+   both runners, unchanged, stay green.*
+6. **`SyncTaskRunner` honours the same filter.** *Check: unit test.*
+7. **The array form carries a real `@deprecated` tag** plus a DEPRECATIONS.md entry in that file's
+   established format, so the next major's removal sweep can find it by grep.
+8. **The rewritten comment states only what is true**, verified today: `in` versus `equals` on SQLite,
+   Postgres and MongoDB handling everything, and accumulation under `deleteJobOnComplete: false`.
+9. **All three adapters pass.** *Check: `test:integration:all`; Postgres still fails only the three
+   auto-translate cases of #124.*
+10. **Checks clean:** check-types both packages, unit tests, lint at the repo baseline.
+
+## Human choices
+
+- **Stop deleting completed jobs on re-enqueue.** The user's call, made knowing the consequence: the
+  job table no longer self-prunes per (document, locale), which promotes #122 (retention) from low
+  priority to needed. Rejected alternative: preserving today's behaviour by deleting duplicates with a
+  where clause instead of loading them — which cannot express a numeric document id on SQLite.
+- **Introduce `TaskFilter` regardless of whether this fix needs it**, and deprecate the positional
+  array now. The user's reason is interface flexibility, not this optimisation.
+
+## Risks
+
+- **The table grows, and two polled endpoints read it.** `enqueue`'s delete used to prune per
+  (document, locale), so the steady state was roughly one job per pair ever translated; it becomes one
+  per translation *run*. `get-collection-status` and `get-document-status` both still read the table
+  unpaginated on every poll, and the first serialises a row per job to the browser. Neither can adopt
+  `excludeCompleted` — their content is the finished jobs. This is what turns #122 from tidiness into
+  a bounded-read requirement, and #123 records the endpoints' own unbounded read.
+- The union parameter lives until the next major. It is three lines and one `Array.isArray`.
+
+## Review log
+
+**2026-09-04 — comment audit.** 67 comment lines over 155 of code (4.3 per 10) judged too dense.
+Deleted 6, rewrote 7. Caught a factual error: the rewritten rationale asserted a mechanism for the
+SQLite drizzle defect ("the value is inlined without quotes") that a read of `parseParams.js`
+contradicts for string values. Rather than adjudicate a mechanism that had already drifted within one
+Payload version, the whole drizzle paragraph was dropped — the docblock's own two-stored-shapes reason
+settles the question, and #108 holds the detail. A dangling reference to it in `reclaimStaleJobs` was
+repointed. Verified and kept: `excludeCompleted` really is wider than the `pending` status, because a
+job that exhausts its retries keeps `completedAt` null.
+
+**2026-09-04 — reuse, simplification, altitude.** Nothing re-implemented; no existing normalizer fits.
+Five findings taken. `toTaskFilter` moved out of `TaskRunner.interface.ts` — five of the package's six
+`*.interface.ts` files are types-only, and it was the one carrying runtime code — and is now exported
+from `src/index.ts` beside `TaskRunnerProvider`, because the union puts the normalization obligation on
+every third-party runner and half-exporting the tool that discharges it is the worst of both. AC7 was
+reopened and met: a `@deprecated` tag *is* expressible as an overload pair, which my first pass wrongly
+recorded as impossible. `SyncTaskRunner` now keys `excludeCompleted` on `completedAt` rather than
+`status`: the two runners previously agreed only because `getJobStatus` happens to check `completedAt`
+before `error`. The new spec lost a dead union branch, a redundant `collections` option and a missing
+status assertion. The risk about table growth was sharpened to name the two polled endpoints that read
+it.

--- a/packages/payload-plugin-translator/src/index.ts
+++ b/packages/payload-plugin-translator/src/index.ts
@@ -45,8 +45,16 @@ export {
 export type { TranslationFailureCode } from "./translation-providers";
 
 // Task runners
-export { createPayloadJobsRunner, createSyncRunner } from "./server/modules/task-runner";
-export type { TaskRunnerProvider, PayloadJobsRunnerOptions } from "./server/modules/task-runner";
+export {
+  createPayloadJobsRunner,
+  createSyncRunner,
+  toTaskFilter,
+} from "./server/modules/task-runner";
+export type {
+  TaskRunnerProvider,
+  PayloadJobsRunnerOptions,
+  TaskFilter,
+} from "./server/modules/task-runner";
 
 // Translation levels
 export { documentLevel, collectionLevel, fieldLevel } from "./composition/levels";

--- a/packages/payload-plugin-translator/src/server/modules/lifecycle/withQueuedNotification.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/lifecycle/withQueuedNotification.test.ts
@@ -58,16 +58,25 @@ describe("withQueuedNotification", () => {
     expect(calls).toEqual(["queued", "enqueue"]);
   });
 
-  it("delegates cancel / run / findByCollection unchanged", async () => {
+  it("delegates cancel and run unchanged", async () => {
     const runner = makeRunner();
     const wrapped = withQueuedNotification(runner, new LifecycleNotifier({}, { error: vi.fn() }));
 
     await wrapped.cancel(["a"]);
     await wrapped.run("b");
-    await wrapped.findByCollection("posts" as CollectionSlug, ["c"]);
 
     expect(runner.cancel).toHaveBeenCalledWith(["a"]);
     expect(runner.run).toHaveBeenCalledWith("b");
-    expect(runner.findByCollection).toHaveBeenCalledWith("posts", ["c"]);
+  });
+
+  it("hands findByCollection's filter on, normalizing the deprecated array form", async () => {
+    const runner = makeRunner();
+    const wrapped = withQueuedNotification(runner, new LifecycleNotifier({}, { error: vi.fn() }));
+
+    await wrapped.findByCollection("posts" as CollectionSlug, ["c"]);
+    expect(runner.findByCollection).toHaveBeenCalledWith("posts", { documentIds: ["c"] });
+
+    await wrapped.findByCollection("posts" as CollectionSlug, { excludeCompleted: true });
+    expect(runner.findByCollection).toHaveBeenLastCalledWith("posts", { excludeCompleted: true });
   });
 });

--- a/packages/payload-plugin-translator/src/server/modules/lifecycle/withQueuedNotification.ts
+++ b/packages/payload-plugin-translator/src/server/modules/lifecycle/withQueuedNotification.ts
@@ -1,4 +1,5 @@
 import type { TaskRunner } from "../task-runner/TaskRunner.interface";
+import { toTaskFilter } from "../task-runner/toTaskFilter";
 import type { LifecycleNotifier } from "./LifecycleNotifier";
 import { taskFromInput } from "./taskMapping";
 
@@ -19,7 +20,9 @@ export function withQueuedNotification(
     },
     cancel: (taskIds) => runner.cancel(taskIds),
     run: (taskId) => runner.run(taskId),
-    findByCollection: (collectionSlug, documentIds) =>
-      runner.findByCollection(collectionSlug, documentIds),
+    // Normalized rather than forwarded as-is: the wrapper's own signature comes from the overload
+    // pair, so it cannot pass the deprecated array form straight through.
+    findByCollection: (collectionSlug, filter) =>
+      runner.findByCollection(collectionSlug, toTaskFilter(filter)),
   };
 }

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/TaskRunner.interface.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/TaskRunner.interface.ts
@@ -29,10 +29,29 @@ export interface TaskRunner {
   run(taskId: string): Promise<RunResult>;
 
   /**
-   * Find tasks by collection and optionally filter by document IDs.
+   * @deprecated Pass `{ documentIds }` instead. Removed in the next major.
+   * See docs/DEPRECATIONS.md#find-by-collection-document-ids-array
    */
   findByCollection(
     collectionSlug: CollectionSlug,
-    documentIds?: Array<string | number>
+    documentIds: Array<string | number>
   ): Promise<Task[]>;
+  /** Find tasks for a collection, optionally narrowed by a {@link TaskFilter}. */
+  findByCollection(collectionSlug: CollectionSlug, filter?: TaskFilter): Promise<Task[]>;
 }
+
+/**
+ * How a {@link TaskRunner.findByCollection} call is narrowed. Each field says whether it reaches the
+ * database or is applied in memory over everything the database returned.
+ *
+ * @since 0.12.0
+ */
+export type TaskFilter = {
+  /** Keep only tasks for these documents. Applied in memory — see `PayloadJobsTaskRunner.findByCollection`. */
+  documentIds?: Array<string | number>;
+  /**
+   * Drop tasks that have finished. Keeps running and failed ones — everything a re-enqueue can still
+   * supersede — so it is wider than the `pending` status.
+   */
+  excludeCompleted?: boolean;
+};

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/index.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/index.ts
@@ -7,4 +7,5 @@ export type { Task, TaskStatus } from "./types";
 export { createPayloadJobsRunner } from "./payload-jobs-runner";
 export type { PayloadJobsRunnerOptions } from "./payload-jobs-runner";
 export { createSyncRunner } from "./sync-runner";
-export type { TaskRunner } from "./TaskRunner.interface";
+export type { TaskFilter, TaskRunner } from "./TaskRunner.interface";
+export { toTaskFilter } from "./toTaskFilter";

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.test.ts
@@ -70,6 +70,15 @@ describe("PayloadJobsTaskRunner", () => {
   });
 
   describe("enqueue", () => {
+    it("looks for superseded jobs among unfinished ones only", async () => {
+      await runner.enqueue([createInput()]);
+
+      const whereArg = mockPayload.find.mock.calls[0][0].where;
+      expect(whereArg).toEqual({
+        and: [{ taskSlug: { equals: "translate_document" } }, { completedAt: { exists: false } }],
+      });
+    });
+
     it("queues tasks with correct input", async () => {
       const input = createInput();
       await runner.enqueue([input]);
@@ -529,6 +538,32 @@ describe("PayloadJobsTaskRunner", () => {
       });
       expect(JSON.stringify(whereArg)).not.toContain("collection_id");
       expect(JSON.stringify(whereArg)).not.toContain("collection.value");
+    });
+
+    it("adds completedAt to the where clause when asked to exclude finished jobs", async () => {
+      await runner.findByCollection("posts" as CollectionSlug, { excludeCompleted: true });
+
+      const whereArg = mockPayload.find.mock.calls[0][0].where;
+      expect(whereArg).toEqual({
+        and: [{ taskSlug: { equals: "translate_document" } }, { completedAt: { exists: false } }],
+      });
+      expect(JSON.stringify(whereArg)).not.toContain("collection_id");
+    });
+
+    it("reads the deprecated array form as documentIds", async () => {
+      const jobs = [
+        createJob({ id: "job-1", input: { collection_slug: "posts", collection_id: "doc-1" } }),
+        createJob({ id: "job-2", input: { collection_slug: "posts", collection_id: "doc-2" } }),
+      ];
+      mockPayload.find.mockResolvedValue({ docs: jobs });
+
+      const positional = await runner.findByCollection("posts" as CollectionSlug, ["doc-1"]);
+      const object = await runner.findByCollection("posts" as CollectionSlug, {
+        documentIds: ["doc-1"],
+      });
+
+      expect(positional.map((t) => t.id)).toEqual(["job-1"]);
+      expect(object.map((t) => t.id)).toEqual(positional.map((t) => t.id));
     });
 
     it("matches jobs stored in both the legacy and the new shape", async () => {

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.ts
@@ -28,7 +28,7 @@ export class PayloadJobsTaskRunner implements TaskRunner {
 
     for (const [collectionSlug, items] of byCollection) {
       const documentIds = items.map((t) => t.collectionId);
-      // Finished jobs must stay out of this set: superseding deletes (`cancelInternal` reaches
+      // Finished jobs must stay out of this set: superseding deletes (`cancelAndDeleteJobs` reaches
       // `payload.delete`), so a completed job for the same (document, locale) would be erased along
       // with the pending one.
       const existing = await this.findByCollection(collectionSlug, {
@@ -45,7 +45,7 @@ export class PayloadJobsTaskRunner implements TaskRunner {
         supersededKeys.has(documentLocaleKey(t.input.collectionId, t.input.targetLng))
       );
       if (toCancel.length > 0) {
-        await this.cancelInternal(toCancel.map((t) => t.id));
+        await this.cancelAndDeleteJobs(toCancel.map((t) => t.id));
       }
     }
 
@@ -78,7 +78,7 @@ export class PayloadJobsTaskRunner implements TaskRunner {
 
   async cancel(taskIds: string[]): Promise<void> {
     if (taskIds.length === 0) return;
-    await this.cancelInternal(taskIds);
+    await this.cancelAndDeleteJobs(taskIds);
   }
 
   async run(taskId: string): Promise<RunResult> {
@@ -92,26 +92,17 @@ export class PayloadJobsTaskRunner implements TaskRunner {
       return { success: false, error: "already_completed" };
     }
     if (task.status === "running") {
-      // A genuinely in-flight job is refused. A stale processing lock (left by
-      // a process killed mid-run) is reclaimable: clear it first so the queue
-      // picker below — which only selects `processing: false` — can re-run it.
+      // The picker below selects only `processing: false`, so a stale lock must be cleared first.
       if (!this.isStale(task.updatedAt)) {
         return { success: false, error: "already_running" };
       }
       await this.resetProcessing({ id: { equals: taskId } });
     }
 
-    // Execute synchronously via the queue + `where` picker so the job runs to
-    // completion within this request (nothing is abandoned after the HTTP
-    // response — reliable on serverless too).
-    //
-    // NOT `payload.jobs.runByID({ id })`: on the drizzle adapter the id-path
-    // (`db.updateJobs({ id })`) writes `processing: true` but returns no rows,
-    // so `runJobs` reports `noJobsRemaining` and the handler never runs —
-    // leaving the job stuck at `processing: true` forever. The `where`-based
-    // picker selects, runs, and finalizes the job correctly (verified against
-    // sqlite). The picker also enforces processing:false / no-error / no
-    // pending waitUntil, so a failed (max-retries) job is not re-run here.
+    // `where` picker, not `payload.jobs.runByID({ id })`: in `runJobs` the guard block
+    // (processing:false, hasError not true, waitUntil due) is built only for the non-id branch, so
+    // the id path would re-run a job that already exhausted its retries. Checked against payload
+    // 3.84.1.
     await this.payload.jobs.run({
       queue: this.config.queueName,
       where: { id: { equals: taskId } },
@@ -121,20 +112,11 @@ export class PayloadJobsTaskRunner implements TaskRunner {
   }
 
   /**
-   * Reset stale processing locks so abandoned jobs become eligible for the
-   * autorun picker again. The picker requires processing:false, no error, and
-   * no pending waitUntil; a job abandoned mid-run (no error, no waitUntil)
-   * satisfies the rest, so clearing processing is sufficient for that case.
-   * A job that already exhausted retries (hasError:true) stays excluded from
-   * autorun and is only recoverable via a manual run().
-   *
-   * A job is stale when it is still `processing: true`, not yet completed, and
-   * its `updatedAt` is older than `staleJobTimeoutMs` — i.e. a process was
-   * killed mid-run (deploy/crash/timeout). Threshold-based, so a job genuinely
-   * in flight on another live instance (fresh `updatedAt`) is left alone.
-   * Filters on real `payload-jobs` columns only (no JSON-path traversal), so
-   * the in-memory filtering in `findByCollection` (issue #108) does not apply here.
-   * @returns the number of jobs reclaimed.
+   * Clear stale `processing` locks — still processing, not completed, `updatedAt` older than
+   * `staleJobTimeoutMs` — so abandoned jobs are eligible for the autorun picker again. A job that
+   * exhausted its retries carries `hasError: true` and stays excluded from autorun even after its
+   * lock is cleared; only a manual `run()` recovers it.
+   * @returns how many locks were cleared.
    */
   async reclaimStaleJobs(): Promise<number> {
     const cutoff = new Date(Date.now() - this.config.staleJobTimeoutMs).toISOString();
@@ -148,12 +130,7 @@ export class PayloadJobsTaskRunner implements TaskRunner {
     });
   }
 
-  /**
-   * Clear the `processing` lock on every job matching `where`, returning how
-   * many were reset. Shared by the per-job reset in `run()` (a stale lock) and
-   * the bulk boot/recovery reset in `reclaimStaleJobs()`. `depth: 0` because
-   * only the count is needed — no relationships to populate.
-   */
+  /** Clears the `processing` lock on every job matching `where`. `depth: 0` — only the count is read. */
   private async resetProcessing(where: Where): Promise<number> {
     const result = await this.payload.update({
       collection: this.config.jobsCollection,
@@ -164,10 +141,6 @@ export class PayloadJobsTaskRunner implements TaskRunner {
     return result.docs.length;
   }
 
-  /**
-   * A processing lock is stale once `updatedAt` is older than the configured
-   * timeout — the owning run is presumed dead.
-   */
   private isStale(updatedAt: string): boolean {
     const parsed = Date.parse(updatedAt);
     // Unknown/corrupt timestamp → treat as stale so the job can be recovered
@@ -179,17 +152,10 @@ export class PayloadJobsTaskRunner implements TaskRunner {
   /**
    * Find translation jobs for a collection.
    *
-   * Only `taskSlug` and — when asked — `completedAt` reach the database; both are real columns. The
-   * collection slug and the document ids are matched in memory, because `readCollectionRef` reads a
-   * job's collection reference from the current flat-text fields OR from the relationship shape that
-   * predates the ID-agnostic migration (docs/DEPRECATIONS.md#jobs-input-collection-field) — a `where`
-   * on `input.collection_slug` sees only the first and would silently drop every job queued before
-   * that migration.
-   *
-   * `excludeCompleted` is what bounds the read for the callers that pass it: under
-   * `jobs.deleteJobOnComplete: false` completed jobs are never removed, so an unfiltered scan grows
-   * with the whole translation history. Narrowing by collection on top of it measured no better —
-   * see issue #108.
+   * Only `taskSlug` and `completedAt` reach the database; slug and document ids are matched in memory
+   * because a job's collection reference may sit in either the flat-text fields or the legacy
+   * relationship shape (`readCollectionRef`), so a `where` on `input.collection_slug` would silently
+   * drop every pre-migration job. `excludeCompleted` is what bounds the read — see issue #108.
    */
   async findByCollection(
     collectionSlug: CollectionSlug,
@@ -204,9 +170,6 @@ export class PayloadJobsTaskRunner implements TaskRunner {
     return bySlug.filter((t) => wanted.has(t.input.collectionId));
   }
 
-  /**
-   * Group tasks by collection slug
-   */
   private groupByCollection(tasks: TaskInput[]): Map<CollectionSlug, TaskInput[]> {
     const map = new Map<CollectionSlug, TaskInput[]>();
     for (const task of tasks) {
@@ -217,12 +180,13 @@ export class PayloadJobsTaskRunner implements TaskRunner {
     return map;
   }
 
-  /**
-   * Internal cancel implementation
-   */
-  private async cancelInternal(taskIds: string[]): Promise<void> {
+  private async cancelAndDeleteJobs(taskIds: string[]): Promise<void> {
     if (taskIds.length === 0) return;
 
+    // Both, in this order: `jobs.cancel` only writes `{ error: { cancelled: true }, hasError: true,
+    // processing: false }`, which is what signals a running handler to abort. The delete then removes
+    // the row — under `deleteJobOnComplete: false` a cancelled job would otherwise sit in the status
+    // feed forever.
     await this.payload.jobs.cancel({
       where: { id: { in: taskIds } },
       queue: this.config.queueName,
@@ -234,9 +198,6 @@ export class PayloadJobsTaskRunner implements TaskRunner {
     });
   }
 
-  /**
-   * Internal method to find jobs with where clause
-   */
   private async findJobsInternal(
     where?: Where,
     params?: { limit?: number; pagination?: boolean }

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/payload-jobs-runner/PayloadJobsTaskRunner.ts
@@ -1,6 +1,7 @@
 import type { Payload, Where, CollectionSlug } from "payload";
 
-import type { TaskRunner } from "../TaskRunner.interface";
+import type { TaskFilter, TaskRunner } from "../TaskRunner.interface";
+import { toTaskFilter } from "../toTaskFilter";
 import type { Task, TaskInput, RunResult, ID } from "../types";
 import type { PayloadJobsRunnerConfig, PayloadJob } from "./types";
 import { normalizeJob } from "./normalizeJob";
@@ -27,7 +28,13 @@ export class PayloadJobsTaskRunner implements TaskRunner {
 
     for (const [collectionSlug, items] of byCollection) {
       const documentIds = items.map((t) => t.collectionId);
-      const existing = await this.findByCollection(collectionSlug, documentIds);
+      // Finished jobs must stay out of this set: superseding deletes (`cancelInternal` reaches
+      // `payload.delete`), so a completed job for the same (document, locale) would be erased along
+      // with the pending one.
+      const existing = await this.findByCollection(collectionSlug, {
+        documentIds,
+        excludeCompleted: true,
+      });
       // Supersede only jobs for the SAME (document, target locale) being re-enqueued — never a
       // concurrent job for a *different* locale of the same document. Cancelling per-document would
       // kill an in-flight translation of another locale (the concurrent re-translate bug).
@@ -126,7 +133,7 @@ export class PayloadJobsTaskRunner implements TaskRunner {
    * killed mid-run (deploy/crash/timeout). Threshold-based, so a job genuinely
    * in flight on another live instance (fresh `updatedAt`) is left alone.
    * Filters on real `payload-jobs` columns only (no JSON-path traversal), so
-   * the drizzle SQLite issue in `findByCollection` does not apply here.
+   * the in-memory filtering in `findByCollection` (issue #108) does not apply here.
    * @returns the number of jobs reclaimed.
    */
   async reclaimStaleJobs(): Promise<number> {
@@ -170,56 +177,29 @@ export class PayloadJobsTaskRunner implements TaskRunner {
   }
 
   /**
-   * Find translation jobs for a collection, optionally narrowed by document IDs.
+   * Find translation jobs for a collection.
    *
-   * Narrowing is by `taskSlug` only in SQL; the collection slug and document
-   * IDs are matched in memory (via the normalized `Task`, which reads both the
-   * current flat-text shape and the legacy relationship shape). This is the
-   * one path that must transparently span both stored shapes during the
-   * ID-agnostic migration — see docs/DEPRECATIONS.md#jobs-input-collection-field.
+   * Only `taskSlug` and — when asked — `completedAt` reach the database; both are real columns. The
+   * collection slug and the document ids are matched in memory, because `readCollectionRef` reads a
+   * job's collection reference from the current flat-text fields OR from the relationship shape that
+   * predates the ID-agnostic migration (docs/DEPRECATIONS.md#jobs-input-collection-field) — a `where`
+   * on `input.collection_slug` sees only the first and would silently drop every job queued before
+   * that migration.
    *
-   * IMPORTANT — why slug/id are matched in memory, not in the SQL WHERE
-   * ------------------------------------------------------------------------
-   * The "natural" implementation would push `input.collection_id` into the
-   * where clause. This DOES NOT work on SQLite (and is unreliable on any
-   * adapter) because of two compounding bugs in Payload's drizzle layer.
-   *
-   * 1. The `input` field on `payload-jobs` is declared `type: 'json'`. The
-   *    drizzle path resolver (`@payloadcms/drizzle/queries/getTableColumnFromPath`)
-   *    has no `case 'json'` branch, so the value is left as a raw column and
-   *    the path segments are passed through to `parseParams.js`, which on
-   *    SQLite builds raw SQL using `convertPathToJSONTraversal` — generating
-   *    expressions like `input->>'collection_id'`.
-   *
-   * 2. When `parseParams.js` formats the right-hand side of `in`/`not_in`
-   *    (and even `equals` when `!isNaN(val)`), it inlines values via JS
-   *    template literals WITHOUT wrapping strings in quotes. The string
-   *    `'1'` from our WHERE becomes raw `1` in the SQL. Drizzle therefore
-   *    emits queries like `WHERE input->>'collection_id' IN (1)` even though
-   *    the caller passed `['1']` (an array of strings).
-   *
-   * On SQLite, `->>` preserves the JSON value's type and `IN (...)` does NOT
-   * coerce between TEXT and INTEGER, so a numeric-looking string id never
-   * matches once bug #2 strips its quotes. Storing the id as text (this
-   * migration) does not fix the SQL path — drizzle re-numbers it anyway — so
-   * we keep matching in memory.
-   *
-   * Why in-memory filtering is acceptable here
-   * ------------------------------------------
-   * Per-task job sets are small (typically <100 rows; the plugin actively
-   * cancels superseded jobs so they don't accumulate), so the JS filtering
-   * is effectively free. If/when the upstream drizzle bug is fixed, this can
-   * collapse back to a single SQL query.
+   * `excludeCompleted` is what bounds the read for the callers that pass it: under
+   * `jobs.deleteJobOnComplete: false` completed jobs are never removed, so an unfiltered scan grows
+   * with the whole translation history. Narrowing by collection on top of it measured no better —
+   * see issue #108.
    */
   async findByCollection(
     collectionSlug: CollectionSlug,
-    documentIds?: Array<string | number>
+    filter?: Array<string | number> | TaskFilter
   ): Promise<Task[]> {
-    const all = await this.findJobsInternal(undefined, { pagination: false });
+    const { documentIds, excludeCompleted } = toTaskFilter(filter);
+    const where = excludeCompleted ? { completedAt: { exists: false } } : undefined;
+    const all = await this.findJobsInternal(where, { pagination: false });
     const bySlug = all.filter((t) => t.input.collectionSlug === collectionSlug);
     if (!documentIds?.length) return bySlug;
-    // `documentIds` is the public `Array<string | number>` param, so normalize
-    // it here; `t.input.collectionId` is already `ID` (string) via normalizeJob.
     const wanted = new Set(documentIds.map(String));
     return bySlug.filter((t) => wanted.has(t.input.collectionId));
   }

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncTaskRunner.test.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncTaskRunner.test.ts
@@ -199,6 +199,18 @@ describe("SyncTaskRunner", () => {
       expect(filteredTasks.map((t) => t.input.collectionId).sort()).toEqual(["doc-1", "doc-3"]);
     });
 
+    it("drops finished tasks when asked to exclude them", async () => {
+      await runner.enqueue([createInput({ collectionId: "doc-1" })]);
+
+      const all = await runner.findByCollection("posts" as CollectionSlug);
+      const unfinished = await runner.findByCollection("posts" as CollectionSlug, {
+        excludeCompleted: true,
+      });
+
+      expect(all.map((t) => t.status)).toEqual(["completed"]);
+      expect(unfinished).toEqual([]);
+    });
+
     it("returns empty array when no tasks match", async () => {
       await runner.enqueue([createInput()]);
 

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncTaskRunner.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/sync-runner/SyncTaskRunner.ts
@@ -1,6 +1,7 @@
 import type { Payload, CollectionSlug } from "payload";
 
-import type { TaskRunner } from "../TaskRunner.interface";
+import type { TaskFilter, TaskRunner } from "../TaskRunner.interface";
+import { toTaskFilter } from "../toTaskFilter";
 import type { TaskHandler } from "../TaskRunnerProvider.interface";
 import type { Task, TaskInput, RunResult, ID } from "../types";
 import type { LazyMap } from "../../../shared/utils";
@@ -68,14 +69,19 @@ export class SyncTaskRunner implements TaskRunner {
 
   async findByCollection(
     collectionSlug: CollectionSlug,
-    documentIds?: Array<string | number>
+    filter?: Array<string | number> | TaskFilter
   ): Promise<Task[]> {
+    const { documentIds, excludeCompleted } = toTaskFilter(filter);
     const results: Task[] = [];
     const wanted = documentIds ? new Set(documentIds.map(String)) : undefined;
 
     for (const [, task] of this.tasks) {
       if (task.input.collectionSlug !== collectionSlug) continue;
       if (wanted && !wanted.has(task.input.collectionId)) continue;
+      // Keyed on `completedAt`, the same field the jobs runner pushes into its where clause. Keying
+      // on `status` instead would agree only by accident: `getJobStatus` happens to check
+      // `completedAt` before `error`, and reordering it would silently split the two runners.
+      if (excludeCompleted && task.completedAt) continue;
       results.push(task);
     }
 

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/toTaskFilter.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/toTaskFilter.ts
@@ -1,0 +1,14 @@
+import type { TaskFilter } from "./TaskRunner.interface";
+
+/**
+ * Normalize the two accepted shapes of {@link TaskRunner.findByCollection}'s second argument.
+ *
+ * Every implementation of {@link TaskRunner} owes this, so it ships alongside the contract rather
+ * than being re-derived: the array form is deprecated and will be removed, and a hand-written
+ * `Array.isArray` branch in someone else's runner would outlive it.
+ *
+ * @since 0.12.0
+ */
+export function toTaskFilter(filter?: Array<string | number> | TaskFilter): TaskFilter {
+  return Array.isArray(filter) ? { documentIds: filter } : (filter ?? {});
+}


### PR DESCRIPTION
> **Depends on #125** and is based on its branch, so the diff can be verified on all three adapters. GitHub retargets this to `main` once #125 merges and its branch is deleted — which is also when the `Closes #108` below starts working, since a closing reference only forms against the default branch.

## What was wrong

Placing one translation in the queue read **every** job in the table, unpaginated, then filtered in memory. `enqueue` does that once per document, so a bulk translate multiplied it by the batch size — and under `jobs.deleteJobOnComplete: false`, which a host wanting job history sets, nothing ever removed the completed jobs it was reading.

| history | today | fixed |
|---|---|---|
| 2000 jobs | 2000 rows / 58 ms | 0 rows / 1 ms |

**A second defect, found while fixing the first.** Superseding reaches `payload.delete`, and the search for jobs to supersede never looked at status — so re-translating a locale deleted the record of the previous run. Collateral rather than intent: the surrounding code describes superseding *pending* work, and cancelling a finished job is meaningless.

## The fix

Exclude finished jobs from the query. That is the whole change, and it closes both defects. `completedAt` is a real column, not a path inside the job's JSON, so it needs no adapter-specific handling.

**Not done: narrowing by collection**, which the issue proposed. It measured no better, and would have silently dropped every job written before the ID-agnostic migration — those store the collection in a different field, and a `where` sees only one of the two shapes.

`findByCollection`'s second parameter becomes a `TaskFilter`; the positional array stays as a deprecated overload so existing and third-party callers keep compiling.

## The trade, accepted deliberately

That deletion was also the table's only pruning. The steady state goes from one job per (document, locale) ever translated to one per translation **run**, and both status endpoints still read the table unpaginated on every poll — they cannot use the new filter, because finished jobs are their content.

So **#122 (retention) becomes a requirement rather than tidiness**, and **#123** covers the endpoints' own unbounded read. Both updated.

## Verification

```
unit           1320 passed
sqlite/mongo   73/73 both
postgres       70/73 — the three auto-translate cases of #124, pre-existing
check-types    clean · lint at the repo baseline
```

The integration spec went red against the unfixed code first, and caught a flaw in its own draft: SQLite reuses the rowid of a deleted row, so a replacement job arrived carrying the deleted one's id and an id-based assertion passed for the wrong reason. It counts rows instead. Three mutations each redden their own check.

Two review passes are recorded in `packages/payload-plugin-translator/docs/plans/2026-09-04-job-scan-bounds.task.md`, including one that caught a false claim in the rewritten code comment and one that found the two runners agreeing about "finished" only by accident.

Closes #108
