### PR TITLE
docs(translator): document host-side pruning of the job table

### DIFF
--- a/packages/payload-plugin-translator/README.md
+++ b/packages/payload-plugin-translator/README.md
@@ -618,6 +618,40 @@ Payload lets a wrapper field (group, array, blocks, tabs) be `localized`, which 
 
 See the `deleteJobOnComplete: false` note under [Runners](#createpayloadjobsrunneroptions-recommended).
 
+Keeping them means they accumulate: nothing in the plugin removes a completed translation job, and the
+status panels read a collection's jobs on every open. How long that history is worth keeping is your
+call, not the plugin's, so pruning is left to you — the same way `deleteJobOnComplete` is.
+
+_Applies only to `createPayloadJobsRunner`._ `createSyncRunner` translates inline and writes no jobs at
+all, so there is nothing to prune.
+
+```ts
+// Run from your own cron / scheduled task.
+// Must match the `taskName` you passed to createPayloadJobsRunner — "translate_document" by default.
+const TRANSLATOR_TASK = "translate_document";
+
+const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+await payload.delete({
+  collection: "payload-jobs",
+  where: {
+    and: [
+      { taskSlug: { equals: TRANSLATOR_TASK } },
+      { completedAt: { exists: true } },
+      { completedAt: { less_than: cutoff } },
+    ],
+  },
+});
+```
+
+Three things the clauses buy you, in order: only this plugin's jobs, only finished ones — so nothing
+queued or in flight is touched — and only those older than your cutoff, so a run someone may still want
+to look at survives. Keep a cutoff of at least a day for that last reason; deleting everything
+completed would erase a translation that finished minutes ago.
+
+All three filter on real columns rather than paths inside the job's JSON input, so this behaves the same
+on SQLite, Postgres and MongoDB.
+
 ## TypeScript
 
 The package ships its types. Besides the factories, the following are exported for typing your own code:

--- a/packages/payload-plugin-translator/docs/plans/2026-09-04-job-history-pruning.task.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-09-04-job-history-pruning.task.md
@@ -1,0 +1,92 @@
+# Task contract — document host-side pruning of the job table, export nothing (#122)
+
+Follows [#108](https://github.com/focusreactive/payload-plugins/issues/108), which removed the only
+thing that pruned the job table, and closes #122 as *won't build*.
+
+**Risk: LOW.** Documentation plus a two-line correction. No behaviour change, no new public surface.
+
+## Design decisions
+
+**D1 — retention stays out of the plugin.**
+The user's call. How long to keep translation history is the host's policy — the same class of decision
+as the `jobs.deleteJobOnComplete: false` that creates the situation — and Payload already gives the host
+cron to act on it. Rejected: a `retention` option with a schedule. It needs a default nobody can pick
+well, and getting it wrong deletes history a host explicitly asked to keep.
+
+**D2 — export no constant, no helper, no config object.**
+Considered in that order and all three rejected. The decisive fact is that the task name is
+*configuration*, not a library constant: `taskName` is an option on `createPayloadJobsRunner` and
+`"translate_document"` is only its default. A host who set their own name and imported ours would get a
+query that silently deletes nothing — the exact failure the export was supposed to prevent.
+
+Confirmed rather than assumed: `taskName` and `taskSlug` appear **nowhere** outside
+`server/modules/task-runner/payload-jobs-runner/`. The name is a detail of one runner implementation —
+`createSyncRunner` has no queue and no job table at all — so exporting it from `src/index.ts` would
+publish at plugin level something true only for one runner choice.
+
+A helper that builds the where clause was rejected for a second reason: it is the retention machinery
+D1 declined, under another name.
+
+**D3 — the README example names the coupling instead of hiding it.**
+It tells the reader to use the same value they passed as `taskName`, and states the default. Someone who
+customised it meets the requirement at the moment they copy the snippet.
+
+**New surface:** none. **Written contract owed:** none. **Escalate:** no.
+
+## Verified before writing the documentation
+
+The query was run against all three adapters, not reasoned about. Fixture per adapter: 3 jobs completed
+40 days ago, 2 completed a minute ago, 2 not completed. Cutoff at 30 days.
+
+| adapter | before | deleted | left |
+|---|---|---|---|
+| sqlite | 7 | **3** | 4 |
+| postgres | 7 | **3** | 4 |
+| mongo | 7 | **3** | 4 |
+
+`taskSlug` and `completedAt` are real columns and `exists` / `less_than` are ordinary operators, so no
+JSON-path traversal is involved — which is why the behaviour is identical everywhere.
+
+## Corrected during investigation
+
+**The polling worry was wrong.** The task brief said deleting a recently-completed job could pull a row
+out from under a reader. `useCollectionTranslationStatus.ts:44-49` and `useDocumentTranslation.ts:49`
+set `refetchInterval` to `false` unless something is `PENDING` or `RUNNING`, so polling stops once work
+finishes. A time offset is still right, but for an ordinary reason — someone may open the panel to read
+recent history — not to avoid a race.
+
+**Only one identifier matters.** `queueName` groups execution; ownership is carried by `taskSlug`. The
+first draft would have documented both and implied the queue was needed for the query.
+
+## Acceptance criteria
+
+1. **README documents the pruning query**, with the runner caveat (`createSyncRunner` writes no jobs)
+   and the `taskName` coupling. *Check: read the rendered section.*
+2. **The documented query is the one that was run**, not a retyped variant. *Check: compare the snippet
+   against the where clause in the table above.*
+3. **`@since` corrected** from `0.12.0` to `0.11.2` in `toTaskFilter.ts` and `TaskRunner.interface.ts` —
+   0.11.2 is what shipped. *Check: `grep -rn "@since 0.12" src` returns nothing.*
+4. **No new export.** *Check: `src/index.ts` is untouched by this diff.*
+5. **Checks clean:** check-types both packages, unit tests, lint at the repo baseline.
+6. **#122 closed** with the reasoning and a pointer to the documentation.
+
+## Human choices
+
+- **Do not build retention** (D1), and on the follow-up question **export nothing at all** (D2). The
+  user reframed it from "what is convenient to import" to "whose responsibility is this", which is what
+  settled it.
+
+## Risks
+
+- A host who never reads the README sees the table grow. Accepted: the same exposure as
+  `deleteJobOnComplete: false` itself, which is also theirs to set.
+- #123 stays open — the status endpoints still read a collection's history unpaginated. Host-side
+  pruning bounds what they read without the plugin choosing the policy.
+
+## Review log
+
+**2026-09-04 — verification.** All six criteria met. The pruning query was run against SQLite, Postgres
+and MongoDB before it was written down (table above), so criterion 2 compares the documented snippet to
+something that actually executed rather than to a plausible draft. `grep -rn "@since 0.12" src`
+returns nothing; `src/index.ts` is untouched, which is criterion 4 and also the whole of D2. Checks:
+1320 unit tests, check-types clean in both packages, lint at the 59-warning repo baseline.

--- a/packages/payload-plugin-translator/docs/plans/2026-09-04-job-scan-bounds.task.md
+++ b/packages/payload-plugin-translator/docs/plans/2026-09-04-job-scan-bounds.task.md
@@ -42,8 +42,9 @@ contract and has no life without it. Both runners implement it; `withQueuedNotif
 **New surface:** `TaskFilter`. Callers: `PayloadJobsTaskRunner.enqueue` and — through the union —
 every existing caller of `findByCollection`. It is a type, not an abstraction over behaviour.
 
-**`@since`:** `TaskFilter` carries `@since 0.12.0` — 0.11.1 plus the minor this ships as, per
-DEPRECATIONS.md's policy that deprecations ship as `feat`. It is not re-exported from `src/index.ts`,
+**`@since`:** `TaskFilter` carries `@since 0.11.2`. The user's call: this ships as a patch, so the
+three commits stay `fix` / `docs` / `refactor` rather than being retyped to `feat` for the sake of the
+new export or the new deprecation entry. It is not re-exported from `src/index.ts`,
 but `TaskRunnerProvider.create(): TaskRunner` is, so a third-party runner must satisfy this type.
 
 **Written contract owed:** yes — which fields reach the database and which are applied in memory, and

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/TaskRunner.interface.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/TaskRunner.interface.ts
@@ -44,7 +44,7 @@ export interface TaskRunner {
  * How a {@link TaskRunner.findByCollection} call is narrowed. Each field says whether it reaches the
  * database or is applied in memory over everything the database returned.
  *
- * @since 0.12.0
+ * @since 0.11.2
  */
 export type TaskFilter = {
   /** Keep only tasks for these documents. Applied in memory — see `PayloadJobsTaskRunner.findByCollection`. */

--- a/packages/payload-plugin-translator/src/server/modules/task-runner/toTaskFilter.ts
+++ b/packages/payload-plugin-translator/src/server/modules/task-runner/toTaskFilter.ts
@@ -7,7 +7,7 @@ import type { TaskFilter } from "./TaskRunner.interface";
  * than being re-derived: the array form is deprecated and will be removed, and a hand-written
  * `Array.isArray` branch in someone else's runner would outlive it.
  *
- * @since 0.12.0
+ * @since 0.11.2
  */
 export function toTaskFilter(filter?: Array<string | number> | TaskFilter): TaskFilter {
   return Array.isArray(filter) ? { documentIds: filter } : (filter ?? {});


### PR DESCRIPTION
Documentation, plus a two-line correction. No behaviour change, and no new public surface.

## Why

#108 removed the only thing that pruned the job table. Until then `enqueue` selected every job matching a document and target locale **regardless of status** and deleted them, so re-translating a locale erased the record of the previous run — which is why it was fixed. The pruning was collateral, and it went with it.

So completed translation jobs now accumulate, and the status panels read a collection's jobs on every open.

## What this does instead of building retention

How long translation history is worth keeping is the host's decision — the same class of choice as the `jobs.deleteJobOnComplete: false` that creates the situation — and Payload already gives them cron to act on it. Building it in would mean a config surface, a scheduler, and a default nobody can pick well: too aggressive and it deletes history someone explicitly asked to keep.

The README now documents the query, under the existing *Keeping completed-job status* section.

## No constant is exported, and that was the interesting part

Considered a constant, then a helper, then a config object. All three rejected, and the reason is the same one each time: **the task name is configuration, not a library constant.** `taskName` is an option on `createPayloadJobsRunner`; `"translate_document"` is only its default. A host who set their own name and imported ours would get a query that silently deletes nothing — precisely the failure the export was meant to prevent.

Checked rather than assumed: `taskName` and `taskSlug` appear **nowhere** outside `server/modules/task-runner/payload-jobs-runner/`. The name is a detail of one runner implementation — `createSyncRunner` has no queue and no job table at all — so exporting it from `src/index.ts` would publish, at plugin level, something true for only one runner choice.

The snippet names the coupling instead of hiding it, so anyone who customised the name meets the requirement while copying it.

## Verified before being written down

The query was run against all three adapters. Fixture per adapter: 3 jobs completed 40 days ago, 2 completed a minute ago, 2 unfinished. Cutoff at 30 days.

| adapter | before | deleted | left |
|---|---|---|---|
| sqlite | 7 | **3** | 4 |
| postgres | 7 | **3** | 4 |
| mongo | 7 | **3** | 4 |

It filters on real columns rather than paths inside the job's JSON input, which is why the behaviour is identical everywhere.

## One belief the investigation overturned

The plan assumed deleting a recently-completed job could pull a row out from under someone watching the panel. It cannot: `refetchInterval` returns `false` unless something is `PENDING` or `RUNNING`, so polling stops once work finishes. The documented cutoff still keeps a floor, but for an ordinary reason — someone may open the panel to read recent history — rather than to avoid a race.

## Also included

Two `@since` annotations corrected from `0.12.0` to `0.11.2`. The symbols shipped in 0.11.2; the earlier value was written when that change was expected to be a minor.

## Verification

```
unit tests     1320 passed
check-types    clean, both packages
lint           59 warnings, 0 errors — the repo baseline
```

Reasoning and rejected alternatives: `packages/payload-plugin-translator/docs/plans/2026-09-04-job-history-pruning.task.md`.

Closes #122
