### PR TITLE
fix(translator): translate without modifying the caller's source document

### DIFF
--- a/packages/payload-plugin-translator/src/core/translation-pipeline/stages/field-collector/FieldChunkCollector.ts
+++ b/packages/payload-plugin-translator/src/core/translation-pipeline/stages/field-collector/FieldChunkCollector.ts
@@ -129,8 +129,11 @@ export class FieldChunkCollector {
       walker
     );
 
+    // A detached copy, because write-back mutates an object-valued leaf (a rich-text tree) in
+    // place: seating the caller's own object here would translate their source document. Scalars
+    // are immutable, so they are seated as they are.
     for (const { dataRef, key, sourceValue } of selected) {
-      dataRef[key] = sourceValue;
+      dataRef[key] = isObject(sourceValue) ? structuredClone(sourceValue) : sourceValue;
     }
 
     return chunks;

--- a/packages/payload-plugin-translator/src/core/translation-pipeline/translateContent.test.ts
+++ b/packages/payload-plugin-translator/src/core/translation-pipeline/translateContent.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { Field } from "payload";
 
 import type { TranslationProvider } from "../domain/translation-providers";
+import { computeSourceFingerprint } from "../domain/content-projection/computeSourceFingerprint";
 import { translateContent } from "./translateContent";
 
 // Deterministic fake provider: prefixes each collected text chunk with "T:".
@@ -24,6 +25,38 @@ const run = (schema: Field[], sourceData: Record<string, unknown>) =>
     targetLng: "de",
     translationProvider: fakeProvider,
   });
+
+const richTextNode = (value: string) => ({
+  type: "text",
+  text: value,
+  format: 0,
+  detail: 0,
+  mode: "normal",
+  style: "",
+  version: 1,
+});
+
+const richTextValue = (values: string[]) => ({
+  root: {
+    type: "root",
+    children: [
+      {
+        type: "paragraph",
+        children: values.map(richTextNode),
+        format: "",
+        indent: 0,
+        version: 1,
+        direction: "ltr",
+      },
+    ],
+    format: "",
+    indent: 0,
+    version: 1,
+    direction: "ltr",
+  },
+});
+
+const richSchema: Field[] = [{ name: "body", type: "richText", localized: true }];
 
 describe("translateContent", () => {
   it("translates a localized leaf field", async () => {
@@ -112,5 +145,48 @@ describe("translateContent", () => {
       strategy: "skip_existing",
     });
     expect(result).toEqual({ title: "T:hello" });
+  });
+
+  describe("the caller's source document", () => {
+    it("is unchanged after a plain-text translation", async () => {
+      const sourceData = { title: "hello" };
+      const before = structuredClone(sourceData);
+
+      await run([{ name: "title", type: "text", localized: true }], sourceData);
+
+      expect(sourceData).toEqual(before);
+    });
+
+    it("is unchanged after a rich-text translation", async () => {
+      const sourceData = { body: richTextValue(["Hello ", "world"]) };
+      const before = structuredClone(sourceData);
+
+      const result = await run(richSchema, sourceData);
+
+      // Both halves: without the second, a pipeline that translated nothing would pass.
+      expect(sourceData).toEqual(before);
+      expect(result).not.toEqual(before);
+    });
+
+    it("leaves the source fingerprint identical either side of a translation", async () => {
+      const sourceData = { body: richTextValue(["Hello ", "world"]) };
+      const before = computeSourceFingerprint(sourceData, richSchema);
+
+      await run(richSchema, sourceData);
+
+      expect(computeSourceFingerprint(sourceData, richSchema)).toBe(before);
+    });
+
+    it("shares no object with the translated result", async () => {
+      const sourceData = { body: richTextValue(["Hello "]) };
+      const sourceNode = sourceData.body.root.children[0]?.children[0];
+
+      const result = await run(richSchema, sourceData);
+      const resultBody = (result as { body: { root: { children: { children: unknown[] }[] } } })
+        .body;
+
+      expect(resultBody.root.children[0]?.children[0]).not.toBe(sourceNode);
+      expect(resultBody.root).not.toBe(sourceData.body.root);
+    });
   });
 });

--- a/packages/payload-plugin-translator/src/server/features/translate-document/handler.test.ts
+++ b/packages/payload-plugin-translator/src/server/features/translate-document/handler.test.ts
@@ -417,11 +417,10 @@ describe("TranslateDocumentHandler", () => {
       expect(new Date(record.translatedAt).toISOString()).toBe(record.translatedAt);
     });
 
-    it("fingerprints the PRISTINE source, before the pipeline can mutate it in place", async () => {
-      // Regression: the pipeline translates in place and shares object-valued source leaves (e.g.
-      // richText nodes) by reference with sourceData. If the handler fingerprints the source AFTER
-      // translateContent, the baseline captures the target translation and every fresh translation
-      // is instantly reported stale. The baseline must be the untranslated source.
+    it("fingerprints the source document, not whatever the pipeline hands back", async () => {
+      // The stub below mutates its `sourceData` argument on purpose. The real pipeline no longer
+      // does — it detaches object-valued leaves — so this stands as the handler-level guard that a
+      // regression there cannot silently poison the staleness baseline.
       const { translateContent } = await import("../../../core/translation-pipeline");
       const { computeSourceFingerprint } =
         await import("../../../core/domain/content-projection/computeSourceFingerprint");
@@ -435,7 +434,7 @@ describe("TranslateDocumentHandler", () => {
           )
       );
 
-      // Emulate the real pipeline: mutate the source argument, then return the translated shape.
+      // Deliberately hostile: writes into the argument it was given.
       (translateContent as unknown as ReturnType<typeof vi.fn>).mockImplementation(
         async ({ sourceData }: { sourceData: Record<string, unknown> }) => {
           sourceData.title = "TRANSLATED (pipeline mutation)";

--- a/packages/payload-plugin-translator/src/server/modules/provenance/Provenance.service.ts
+++ b/packages/payload-plugin-translator/src/server/modules/provenance/Provenance.service.ts
@@ -39,9 +39,12 @@ export class ProvenanceService {
   }
 
   /**
-   * Hash the PRISTINE source. The caller MUST pass source fetched **before** the translation pipeline
-   * runs — the pipeline mutates object-valued leaves (e.g. richText nodes) in place, so hashing after
-   * it would capture the target translation and make every fresh translation look instantly stale.
+   * Hash the source the translation was made from — the baseline staleness is later measured against.
+   *
+   * Ordering used to matter: the pipeline wrote into object-valued leaves it shared with the caller's
+   * source, so hashing afterwards captured the translation and reported every fresh translation as
+   * stale. It now detaches those leaves, so this may be called on either side of the pipeline.
+   *
    * Returns `null` on any failure (no schema, hashing error) so provenance is skipped, not the translation.
    */
   captureFingerprint(


### PR DESCRIPTION
## The defect

`FieldChunkCollector` seats the caller's own leaf value into the pipeline's working tree, and write-back then mutates it in place.

For a `text` field that is harmless: strings are immutable, and the write lands on the rebuilt container's key. For a `richText` field the value is a whole tree of objects, and the pipeline holds references straight into it — so translating a document rewrote the text nodes of the **source document the caller passed in**.

The outer tree was never the problem: `DataReconciler` already rebuilds every container level. The corruption is entirely inside a rich-text leaf, which the field walker treats as one value and hands over by reference.

## How it showed up

Through provenance. `captureFingerprint` had to run **before** the pipeline, or it hashed the translation instead of the source and reported every fresh translation as instantly stale.

Nothing enforced that. The ordering rested on two statements being in the right order in `translate-document/handler.ts`, and `PipelineContext.sourceData` being `readonly` forbids reassigning the reference, not writing `sourceData.body.root.children[0].text`.

The test that guarded it could not have caught a regression either: it emulated the mutation by overwriting a **top-level string key**, which the pipeline never does.

Reproduced on `main`, in the new test — two different hashes for the same source document, before and after one translation:

```
expected '3d3f7ab6…' to be 'fc12e17c…'
```

## The fix

```ts
dataRef[key] = isObject(sourceValue) ? structuredClone(sourceValue) : sourceValue;
```

Only the leaves the collector *selects* are copied — those are exactly the ones a write can reach, since the branch runs under `isTranslatableLeaf(field) && strategy.shouldTranslate(...)`. Scalars pass through untouched, and `structuredClone` is never handed an arbitrary document value.

Cloning at `DataReconciler`'s leaf instead was considered and rejected: it returns *every* leaf, translatable or not, so it would put values through `structuredClone` that nothing writes and that it may not be able to copy.

The prohibition on `structuredClone` recorded in `projectFieldLike.ts` does not apply here — it is about **field definitions**, which embed Lexical editor configs containing async functions. Document data arrives from `payload.findByID` at `depth: 0`.

## Consequences

- `ProvenanceService.captureFingerprint` no longer demands pristine input. Its docblock now states what is true and records why the ordering used to matter.
- The handler's statement order is left as it is — it is harmless either way now, and reordering working code buys nothing.
- The handler test keeps its hostile stub and says plainly that it guards against a regression rather than mirroring what the pipeline does.

## Verification

- **1363 unit tests**, 4 new. Each "source unchanged" assertion is paired with a "something was translated" assertion, so a pipeline that did nothing cannot pass.
- One of the four compares `computeSourceFingerprint` **before and after a real `translateContent` run** — the check that proves the ordering rule is retired, run rather than inferred.
- `check-types` clean. Lint **58 warnings, 0 errors** — measured on a clean checkout of `main` and again with the change: identical.
- `turbo run build` passes, including the `tsc` declaration build.
- Mutation-checked: removing the copy turns exactly the three new rich-text assertions red.

## Scope

Deliberately narrow. Write-back still mutates the nodes it now owns; replacing that with a rebuild is a larger change with a competing design already on record, and is not attempted here.