### PR TITLE
test(translator): make nine fragment assertions fail when nothing is collected

### DIFF
--- a/packages/payload-plugin-translator/src/core/kernel/lexical/collectInlineFragments.test.ts
+++ b/packages/payload-plugin-translator/src/core/kernel/lexical/collectInlineFragments.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { collectInlineFragments } from "./collectInlineFragments";
+import type { SerializedLexicalNode } from "./types";
 
-const createNode = (type: string, props?: Record<string, any>, children?: any[]) =>
-  ({ type, ...props, ...(children && { children }) }) as any;
+const createNode = (
+  type: string,
+  props?: Record<string, unknown>,
+  children?: unknown[]
+): SerializedLexicalNode =>
+  ({ type, ...props, ...(children && { children }) }) as SerializedLexicalNode;
 
 const childrenOf = (node: unknown): unknown[] =>
   ((node as { children?: unknown[] }).children ?? []) as unknown[];
@@ -43,6 +48,7 @@ describe("collectInlineFragments", () => {
 
       const containers = collectInlineFragments(root);
 
+      expect(containers).toHaveLength(1);
       expect(containers.some((container) => container.node === link)).toBe(false);
     });
 
@@ -146,9 +152,10 @@ describe("collectInlineFragments", () => {
         ]),
       ]);
 
-      expect(collectInlineFragments(root).every((container) => container.skip !== undefined)).toBe(
-        true
-      );
+      const containers = collectInlineFragments(root);
+
+      expect(containers).toHaveLength(2);
+      expect(containers.every((container) => container.skip !== undefined)).toBe(true);
     });
   });
 
@@ -221,6 +228,7 @@ describe("collectInlineFragments", () => {
 
       const fragment = collectInlineFragments(root)[0]?.fragments[0];
 
+      expect(fragment).toBeDefined();
       expect(fragment?.top).toBe(fragment?.node);
     });
 
@@ -278,8 +286,10 @@ describe("collectInlineFragments", () => {
 
     it("gives a multi-leaf wrapper's fragment a copy of the wrapper as top, not the wrapper", () => {
       const { root, link } = linkWithTwoLeaves();
+      const fragment = collectInlineFragments(root)[0]?.fragments[1];
 
-      expect(collectInlineFragments(root)[0]?.fragments[1]?.top).not.toBe(link);
+      expect(fragment).toBeDefined();
+      expect(fragment?.top).not.toBe(link);
     });
 
     it("gives each leaf of a multi-leaf wrapper its own separate copy", () => {
@@ -378,6 +388,7 @@ describe("collectInlineFragments", () => {
 
       const fragments = collectInlineFragments(root)[0]?.fragments ?? [];
 
+      expect(fragments).toHaveLength(2);
       expect(fragments.some((piece) => piece.node === space || piece.top === space)).toBe(false);
     });
 
@@ -502,7 +513,10 @@ describe("collectInlineFragments", () => {
         ]),
       ]);
 
-      expect(collectInlineFragments(root)[0]?.skip).toBeUndefined();
+      const containers = collectInlineFragments(root);
+
+      expect(containers).toHaveLength(1);
+      expect(containers[0]?.skip).toBeUndefined();
     });
 
     it("mark-shaped: a comparison like 5 < 10 is not mark-shaped", () => {
@@ -515,7 +529,10 @@ describe("collectInlineFragments", () => {
         ]),
       ]);
 
-      expect(collectInlineFragments(root)[0]?.skip).toBeUndefined();
+      const containers = collectInlineFragments(root);
+
+      expect(containers).toHaveLength(1);
+      expect(containers[0]?.skip).toBeUndefined();
     });
 
     it("skips a container that is one plain text leaf", () => {
@@ -536,7 +553,10 @@ describe("collectInlineFragments", () => {
         ]),
       ]);
 
-      expect(collectInlineFragments(root)[0]?.skip).toBeUndefined();
+      const containers = collectInlineFragments(root);
+
+      expect(containers).toHaveLength(1);
+      expect(containers[0]?.skip).toBeUndefined();
     });
   });
 
@@ -579,9 +599,7 @@ describe("collectInlineFragments", () => {
 
       // Length assertion as above: without it a collector returning [] would pass this test.
       expect(containers[0]?.fragments).toHaveLength(3);
-      expect(containers[0]?.fragments[1]?.top).not.toBe(
-        (root as { children: { children: unknown[] }[] }).children[0]?.children[1]
-      );
+      expect(containers[0]?.fragments[1]?.top).not.toBe(childrenOf(childrenOf(root)[0])[1]);
       expect(root).toEqual(before);
     });
   });
@@ -613,7 +631,10 @@ describe("collectInlineFragments", () => {
         ]),
       ]);
 
-      expect(collectInlineFragments(root)[0]?.skip).toBeUndefined();
+      const containers = collectInlineFragments(root);
+
+      expect(containers).toHaveLength(1);
+      expect(containers[0]?.skip).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Follow-up on #137, found by auditing its own suite.

## How they were found

A throwing stub proves little — every check goes red because everything explodes. The harder question is what survives an implementation that returns **nothing, quietly**. `collectInlineFragments` was replaced with `() => []` and the suite re-run:

| | |
|---|---|
| checks in the file | 49 |
| **passed against a collector that collected nothing** | **11** |

## Why they passed

One mechanism, four spellings — the assertion reaches its value through an optional chain, or runs a predicate over an array that is empty:

```ts
const fragment = collectInlineFragments(root)[0]?.fragments[0];
expect(fragment?.top).toBe(fragment?.node);      // undefined === undefined → passes

expect(containers.every((c) => c.skip !== undefined)).toBe(true);   // [] → vacuously true
expect(containers.some((c) => c.node === link)).toBe(false);        // [] → false
expect(collectInlineFragments(root)[0]?.skip).toBeUndefined();      // undefined → passes
```

The most uncomfortable one was `gives a multi-leaf wrapper's fragment a copy of the wrapper as top, not the wrapper` — the distinction the module is built around — passing against a collector that returns an empty array.

## The fix

Each check now asserts the container or fragment exists before asserting anything about it. No production code changed.

Re-running the same audit afterwards: **11 survivors → 2**. Those two are `toEqual([])` for an empty root and for a node with no text children — checks whose entire content is the absence, which is their contract clause rather than an oversight. Strengthening them would mean asserting something they do not claim.

Also removes the three `any`s from the `createNode` helper. `oxlint` does not flag them; the project's own rule does.

## Verification

**1469 unit tests**, unchanged in count and all green. check-types clean. Lint **58 warnings, 0 errors** — identical to `main`.